### PR TITLE
Migrate from Confluent to Soldevelo Docker images

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -3,28 +3,27 @@ include:
 
 services:
   kafka:
-    image: confluentinc/cp-kafka:8.2.0
+    image: soldevelo/kafka:4.2.0
     ports:
       - "9092:9092"
     environment:
-      - CLUSTER_ID=kpipe-cluster
-      - KAFKA_NODE_ID=1
-      - KAFKA_PROCESS_ROLES=broker,controller
-      - KAFKA_CONTROLLER_QUORUM_VOTERS=1@kafka:9093
-      - KAFKA_LISTENERS=PLAINTEXT://0.0.0.0:9092,CONTROLLER://0.0.0.0:9093
-      - KAFKA_ADVERTISED_LISTENERS=PLAINTEXT://kafka:9092
-      - KAFKA_LISTENER_SECURITY_PROTOCOL_MAP=PLAINTEXT:PLAINTEXT,CONTROLLER:PLAINTEXT
-      - KAFKA_CONTROLLER_LISTENER_NAMES=CONTROLLER
-      - KAFKA_INTER_BROKER_LISTENER_NAME=PLAINTEXT
-      - KAFKA_AUTO_CREATE_TOPICS_ENABLE=true
-      - KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR=1
-      - KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR=1
-      - KAFKA_TRANSACTION_STATE_LOG_MIN_ISR=1
-      - KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS=0
+      - KAFKA_CLUSTER_ID=kpipe-cluster
+      - KAFKA_CFG_NODE_ID=1
+      - KAFKA_CFG_PROCESS_ROLES=broker,controller
+      - KAFKA_CFG_LISTENERS=PLAINTEXT://:9092,CONTROLLER://:9093
+      - KAFKA_CFG_ADVERTISED_LISTENERS=PLAINTEXT://kafka:9092
+      - KAFKA_CFG_LISTENER_SECURITY_PROTOCOL_MAP=PLAINTEXT:PLAINTEXT,CONTROLLER:PLAINTEXT
+      - KAFKA_CFG_CONTROLLER_LISTENER_NAMES=CONTROLLER
+      - KAFKA_CFG_INTER_BROKER_LISTENER_NAME=PLAINTEXT
+      - KAFKA_CFG_AUTO_CREATE_TOPICS_ENABLE=true
+      - KAFKA_CFG_OFFSETS_TOPIC_REPLICATION_FACTOR=1
+      - KAFKA_CFG_TRANSACTION_STATE_LOG_REPLICATION_FACTOR=1
+      - KAFKA_CFG_TRANSACTION_STATE_LOG_MIN_ISR=1
+      - KAFKA_CFG_GROUP_INITIAL_REBALANCE_DELAY_MS=0
     volumes:
-      - kafka_data:/var/lib/kafka/data
+      - kafka_data:/bitnami/kafka
     healthcheck:
-      test: ["CMD-SHELL", "kafka-broker-api-versions --bootstrap-server localhost:9092 >/dev/null 2>&1"]
+      test: ["CMD-SHELL", "kafka-broker-api-versions.sh --bootstrap-server localhost:9092 >/dev/null 2>&1"]
       interval: 10s
       timeout: 5s
       retries: 10
@@ -32,7 +31,7 @@ services:
     restart: on-failure
 
   kafka-init:
-    image: confluentinc/cp-kafka:8.2.0
+    image: soldevelo/kafka:4.2.0
     depends_on:
       kafka:
         condition: service_healthy
@@ -40,24 +39,23 @@ services:
       - sh
       - -ec
       - |
-        kafka-topics --create --if-not-exists --bootstrap-server kafka:9092 --partitions 1 --replication-factor 1 --topic json-topic
-        kafka-topics --create --if-not-exists --bootstrap-server kafka:9092 --partitions 1 --replication-factor 1 --topic avro-topic
-        kafka-topics --create --if-not-exists --bootstrap-server kafka:9092 --partitions 1 --replication-factor 1 --topic proto-topic
+        kafka-topics.sh --create --if-not-exists --bootstrap-server kafka:9092 --partitions 1 --replication-factor 1 --topic json-topic
+        kafka-topics.sh --create --if-not-exists --bootstrap-server kafka:9092 --partitions 1 --replication-factor 1 --topic avro-topic
+        kafka-topics.sh --create --if-not-exists --bootstrap-server kafka:9092 --partitions 1 --replication-factor 1 --topic proto-topic
         echo 'Topics created successfully'
     restart: on-failure
 
   schema-registry:
-    image: confluentinc/cp-schema-registry:8.2.0
+    image: soldevelo/schema-registry:8.2.0
     container_name: schema-registry
     ports:
       - "8081:8081"
     environment:
-      - SCHEMA_REGISTRY_HOST_NAME=schema-registry
+      - SCHEMA_REGISTRY_ADVERTISED_HOSTNAME=schema-registry
       - SCHEMA_REGISTRY_LISTENERS=http://0.0.0.0:8081
-      - SCHEMA_REGISTRY_KAFKASTORE_BOOTSTRAP_SERVERS=PLAINTEXT://kafka:9092
-      - SCHEMA_REGISTRY_KAFKASTORE_TOPIC=_schemas
+      - SCHEMA_REGISTRY_KAFKA_BROKERS=PLAINTEXT://kafka:9092
     healthcheck:
-      test: [ "CMD-SHELL", "curl -fsS http://localhost:8081/subjects >/dev/null" ]
+      test: [ "CMD-SHELL", "nc -z localhost 8081 || exit 1" ]
       interval: 10s
       timeout: 5s
       retries: 5

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -114,7 +114,7 @@ services:
     restart: unless-stopped
 
   seed-json:
-    image: confluentinc/cp-kafka:8.2.0
+    image: soldevelo/kafka:4.2.0
     depends_on:
       app:
         condition: service_started
@@ -126,13 +126,13 @@ services:
         echo "=== Seeding JSON messages ==="
         for i in $$(seq 1 10); do
           echo "{\"id\":$$i,\"name\":\"User $$i\",\"email\":\"user$$i@example.com\",\"password\":\"secret\",\"active\":true}" | \
-            kafka-console-producer --bootstrap-server kafka:9092 --topic json-topic
+            kafka-console-producer.sh --bootstrap-server kafka:9092 --topic json-topic
         done
         echo "=== JSON seed complete ==="
     restart: "no"
 
   seed-avro:
-    image: confluentinc/cp-schema-registry:8.2.0
+    image: soldevelo/schema-registry:8.2.0
     depends_on:
       app:
         condition: service_started
@@ -156,7 +156,7 @@ services:
     restart: "no"
 
   seed-proto:
-    image: confluentinc/cp-schema-registry:8.2.0
+    image: soldevelo/schema-registry:8.2.0
     depends_on:
       app:
         condition: service_started

--- a/examples/avro/src/test/java/org/kpipe/AppIntegrationTest.java
+++ b/examples/avro/src/test/java/org/kpipe/AppIntegrationTest.java
@@ -31,17 +31,18 @@ import org.kpipe.producer.config.KafkaProducerConfig;
 import org.kpipe.sink.MessageSink;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
-import org.testcontainers.kafka.ConfluentKafkaContainer;
+import org.testcontainers.kafka.KafkaContainer;
 import org.testcontainers.utility.DockerImageName;
 
 @Testcontainers
 class AppIntegrationTest {
 
-  private static final String CONFLUENT_PLATFORM_VERSION = System.getProperty("confluentPlatformVersion", "8.2.0");
+  private static final String KAFKA_VERSION = System.getProperty("kafkaVersion", "4.2.0");
 
   @Container
-  static ConfluentKafkaContainer kafka = new ConfluentKafkaContainer(
-    DockerImageName.parse("confluentinc/cp-kafka:%s".formatted(CONFLUENT_PLATFORM_VERSION))
+  static KafkaContainer kafka = new KafkaContainer(
+    DockerImageName.parse("soldevelo/kafka:%s".formatted(KAFKA_VERSION))
+                   .asCompatibleSubstituteFor("apache/kafka")
   ).withStartupAttempts(3);
 
   private Schema schema;

--- a/examples/demo/src/test/java/org/kpipe/demo/DemoAppIntegrationTest.java
+++ b/examples/demo/src/test/java/org/kpipe/demo/DemoAppIntegrationTest.java
@@ -16,17 +16,18 @@ import org.kpipe.format.protobuf.ProtobufFormat;
 import org.kpipe.producer.config.KafkaProducerConfig;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
-import org.testcontainers.kafka.ConfluentKafkaContainer;
+import org.testcontainers.kafka.KafkaContainer;
 import org.testcontainers.utility.DockerImageName;
 
 @Testcontainers
 class DemoAppIntegrationTest {
 
-  private static final String CONFLUENT_PLATFORM_VERSION = System.getProperty("confluentPlatformVersion", "8.2.0");
+  private static final String KAFKA_VERSION = System.getProperty("kafkaVersion", "4.2.0");
 
   @Container
-  static ConfluentKafkaContainer kafka = new ConfluentKafkaContainer(
-    DockerImageName.parse("confluentinc/cp-kafka:%s".formatted(CONFLUENT_PLATFORM_VERSION))
+  static KafkaContainer kafka = new KafkaContainer(
+    DockerImageName.parse("soldevelo/kafka:%s".formatted(KAFKA_VERSION))
+                   .asCompatibleSubstituteFor("apache/kafka")
   ).withStartupAttempts(3);
 
   @BeforeEach

--- a/examples/json/src/test/java/org/kpipe/AppIntegrationTest.java
+++ b/examples/json/src/test/java/org/kpipe/AppIntegrationTest.java
@@ -22,17 +22,18 @@ import org.kpipe.producer.config.KafkaProducerConfig;
 import org.kpipe.sink.MessageSink;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
-import org.testcontainers.kafka.ConfluentKafkaContainer;
+import org.testcontainers.kafka.KafkaContainer;
 import org.testcontainers.utility.DockerImageName;
 
 @Testcontainers
 class AppIntegrationTest {
 
-  private static final String CONFLUENT_PLATFORM_VERSION = System.getProperty("confluentPlatformVersion", "8.2.0");
+  private static final String KAFKA_VERSION = System.getProperty("kafkaVersion", "4.2.0");
 
   @Container
-  static ConfluentKafkaContainer kafka = new ConfluentKafkaContainer(
-    DockerImageName.parse("confluentinc/cp-kafka:%s".formatted(CONFLUENT_PLATFORM_VERSION))
+  static KafkaContainer kafka = new KafkaContainer(
+    DockerImageName.parse("soldevelo/kafka:%s".formatted(KAFKA_VERSION))
+                   .asCompatibleSubstituteFor("apache/kafka")
   ).withStartupAttempts(3);
 
   @Test

--- a/examples/protobuf/src/test/java/org/kpipe/AppIntegrationTest.java
+++ b/examples/protobuf/src/test/java/org/kpipe/AppIntegrationTest.java
@@ -24,17 +24,18 @@ import org.kpipe.producer.config.KafkaProducerConfig;
 import org.kpipe.sink.MessageSink;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
-import org.testcontainers.kafka.ConfluentKafkaContainer;
+import org.testcontainers.kafka.KafkaContainer;
 import org.testcontainers.utility.DockerImageName;
 
 @Testcontainers
 class AppIntegrationTest {
 
-  private static final String CONFLUENT_PLATFORM_VERSION = System.getProperty("confluentPlatformVersion", "8.2.0");
+  private static final String KAFKA_VERSION = System.getProperty("kafkaVersion", "4.2.0");
 
   @Container
-  static ConfluentKafkaContainer kafka = new ConfluentKafkaContainer(
-    DockerImageName.parse("confluentinc/cp-kafka:%s".formatted(CONFLUENT_PLATFORM_VERSION))
+  static KafkaContainer kafka = new KafkaContainer(
+    DockerImageName.parse("soldevelo/kafka:%s".formatted(KAFKA_VERSION))
+                   .asCompatibleSubstituteFor("apache/kafka")
   ).withStartupAttempts(3);
 
   @BeforeEach

--- a/lib/kpipe-api/src/test/java/org/kpipe/KPipeFacadeIntegrationTest.java
+++ b/lib/kpipe-api/src/test/java/org/kpipe/KPipeFacadeIntegrationTest.java
@@ -27,7 +27,7 @@ import org.junit.jupiter.api.Test;
 import org.kpipe.sink.MessageSink;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
-import org.testcontainers.kafka.ConfluentKafkaContainer;
+import org.testcontainers.kafka.KafkaContainer;
 import org.testcontainers.utility.DockerImageName;
 
 /// Testcontainers-based end-to-end test for the [KPipe] fluent facade.
@@ -41,11 +41,12 @@ import org.testcontainers.utility.DockerImageName;
 class KPipeFacadeIntegrationTest {
 
   private static final Logger LOG = System.getLogger(KPipeFacadeIntegrationTest.class.getName());
-  private static final String CONFLUENT_PLATFORM_VERSION = System.getProperty("confluentPlatformVersion", "8.2.0");
+  private static final String KAFKA_VERSION = System.getProperty("kafkaVersion", "4.2.0");
 
   @Container
-  static ConfluentKafkaContainer kafka = new ConfluentKafkaContainer(
-    DockerImageName.parse("confluentinc/cp-kafka:%s".formatted(CONFLUENT_PLATFORM_VERSION))
+  static KafkaContainer kafka = new KafkaContainer(
+    DockerImageName.parse("soldevelo/kafka:%s".formatted(KAFKA_VERSION))
+                   .asCompatibleSubstituteFor("apache/kafka")
   ).withStartupAttempts(3);
 
   @Test

--- a/lib/kpipe-api/src/test/java/org/kpipe/MultiBuilderBatchIntegrationTest.java
+++ b/lib/kpipe-api/src/test/java/org/kpipe/MultiBuilderBatchIntegrationTest.java
@@ -27,7 +27,7 @@ import org.kpipe.sink.BatchSink;
 import org.kpipe.sink.MessageSink;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
-import org.testcontainers.kafka.ConfluentKafkaContainer;
+import org.testcontainers.kafka.KafkaContainer;
 import org.testcontainers.utility.DockerImageName;
 
 /// Verifies [MultiBuilder] supports a mix of non-batch + batch + partial-batch routes on one
@@ -36,11 +36,12 @@ import org.testcontainers.utility.DockerImageName;
 @Testcontainers(disabledWithoutDocker = true)
 class MultiBuilderBatchIntegrationTest {
 
-  private static final String CONFLUENT_PLATFORM_VERSION = System.getProperty("confluentPlatformVersion", "8.2.0");
+  private static final String KAFKA_VERSION = System.getProperty("kafkaVersion", "4.2.0");
 
   @Container
-  static ConfluentKafkaContainer kafka = new ConfluentKafkaContainer(
-    DockerImageName.parse("confluentinc/cp-kafka:%s".formatted(CONFLUENT_PLATFORM_VERSION))
+  static KafkaContainer kafka = new KafkaContainer(
+    DockerImageName.parse("soldevelo/kafka:%s".formatted(KAFKA_VERSION))
+                   .asCompatibleSubstituteFor("apache/kafka")
   ).withStartupAttempts(3);
 
   @Test

--- a/lib/kpipe-api/src/test/java/org/kpipe/StreamBatchIntegrationTest.java
+++ b/lib/kpipe-api/src/test/java/org/kpipe/StreamBatchIntegrationTest.java
@@ -23,7 +23,7 @@ import org.kpipe.sink.BatchPolicy;
 import org.kpipe.sink.BatchSink;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
-import org.testcontainers.kafka.ConfluentKafkaContainer;
+import org.testcontainers.kafka.KafkaContainer;
 import org.testcontainers.utility.DockerImageName;
 
 /// End-to-end test for `Stream.toBatch(...)`. Spins up a real Kafka broker, produces JSON
@@ -32,11 +32,12 @@ import org.testcontainers.utility.DockerImageName;
 @Testcontainers(disabledWithoutDocker = true)
 class StreamBatchIntegrationTest {
 
-  private static final String CONFLUENT_PLATFORM_VERSION = System.getProperty("confluentPlatformVersion", "8.2.0");
+  private static final String KAFKA_VERSION = System.getProperty("kafkaVersion", "4.2.0");
 
   @Container
-  static ConfluentKafkaContainer kafka = new ConfluentKafkaContainer(
-    DockerImageName.parse("confluentinc/cp-kafka:%s".formatted(CONFLUENT_PLATFORM_VERSION))
+  static KafkaContainer kafka = new KafkaContainer(
+    DockerImageName.parse("soldevelo/kafka:%s".formatted(KAFKA_VERSION))
+                   .asCompatibleSubstituteFor("apache/kafka")
   ).withStartupAttempts(3);
 
   @Test

--- a/lib/kpipe-api/src/test/java/org/kpipe/StreamParallelBatchBackpressureIntegrationTest.java
+++ b/lib/kpipe-api/src/test/java/org/kpipe/StreamParallelBatchBackpressureIntegrationTest.java
@@ -27,7 +27,7 @@ import org.kpipe.sink.BatchPolicy;
 import org.kpipe.sink.BatchSink;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
-import org.testcontainers.kafka.ConfluentKafkaContainer;
+import org.testcontainers.kafka.KafkaContainer;
 import org.testcontainers.utility.DockerImageName;
 
 /// Verifies that buffered records participate in the in-flight backpressure metric when batch
@@ -38,13 +38,14 @@ import org.testcontainers.utility.DockerImageName;
 @Testcontainers(disabledWithoutDocker = true)
 class StreamParallelBatchBackpressureIntegrationTest {
 
-  private static final String CONFLUENT_PLATFORM_VERSION = System.getProperty("confluentPlatformVersion", "8.2.0");
+  private static final String KAFKA_VERSION = System.getProperty("kafkaVersion", "4.2.0");
   private static final int PARTITIONS = 2;
   private static final int RECORD_COUNT = 500;
 
   @Container
-  static ConfluentKafkaContainer kafka = new ConfluentKafkaContainer(
-    DockerImageName.parse("confluentinc/cp-kafka:%s".formatted(CONFLUENT_PLATFORM_VERSION))
+  static KafkaContainer kafka = new KafkaContainer(
+    DockerImageName.parse("soldevelo/kafka:%s".formatted(KAFKA_VERSION))
+                   .asCompatibleSubstituteFor("apache/kafka")
   ).withStartupAttempts(3);
 
   @Test

--- a/lib/kpipe-api/src/test/java/org/kpipe/StreamParallelBatchIntegrationTest.java
+++ b/lib/kpipe-api/src/test/java/org/kpipe/StreamParallelBatchIntegrationTest.java
@@ -28,7 +28,7 @@ import org.kpipe.sink.BatchPolicy;
 import org.kpipe.sink.BatchSink;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
-import org.testcontainers.kafka.ConfluentKafkaContainer;
+import org.testcontainers.kafka.KafkaContainer;
 import org.testcontainers.utility.DockerImageName;
 
 /// End-to-end test for `Stream.toBatch(...)` running in **parallel** mode (the new default after
@@ -40,13 +40,14 @@ import org.testcontainers.utility.DockerImageName;
 @Testcontainers(disabledWithoutDocker = true)
 class StreamParallelBatchIntegrationTest {
 
-  private static final String CONFLUENT_PLATFORM_VERSION = System.getProperty("confluentPlatformVersion", "8.2.0");
+  private static final String KAFKA_VERSION = System.getProperty("kafkaVersion", "4.2.0");
   private static final int PARTITIONS = 4;
   private static final int RECORD_COUNT = 200;
 
   @Container
-  static ConfluentKafkaContainer kafka = new ConfluentKafkaContainer(
-    DockerImageName.parse("confluentinc/cp-kafka:%s".formatted(CONFLUENT_PLATFORM_VERSION))
+  static KafkaContainer kafka = new KafkaContainer(
+    DockerImageName.parse("soldevelo/kafka:%s".formatted(KAFKA_VERSION))
+                   .asCompatibleSubstituteFor("apache/kafka")
   ).withStartupAttempts(3);
 
   @Test

--- a/lib/kpipe-consumer/src/test/java/org/kpipe/consumer/KPipeProducerIntegrationTest.java
+++ b/lib/kpipe-consumer/src/test/java/org/kpipe/consumer/KPipeProducerIntegrationTest.java
@@ -15,17 +15,18 @@ import org.junit.jupiter.api.Test;
 import org.kpipe.producer.sink.KafkaMessageSink;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
-import org.testcontainers.kafka.ConfluentKafkaContainer;
+import org.testcontainers.kafka.KafkaContainer;
 import org.testcontainers.utility.DockerImageName;
 
 @Testcontainers
 class KPipeProducerIntegrationTest {
 
-  private static final String CONFLUENT_PLATFORM_VERSION = "8.2.0";
+  private static final String KAFKA_VERSION = System.getProperty("kafkaVersion", "4.2.0");
 
   @Container
-  static ConfluentKafkaContainer kafka = new ConfluentKafkaContainer(
-    DockerImageName.parse("confluentinc/cp-kafka:%s".formatted(CONFLUENT_PLATFORM_VERSION))
+  static KafkaContainer kafka = new KafkaContainer(
+    DockerImageName.parse("soldevelo/kafka:%s".formatted(KAFKA_VERSION))
+                   .asCompatibleSubstituteFor("apache/kafka")
   );
 
   @Test

--- a/lib/kpipe-schema-registry-confluent/src/test/java/org/kpipe/schemaregistry/confluent/ConfluentSchemaResolverIntegrationTest.java
+++ b/lib/kpipe-schema-registry-confluent/src/test/java/org/kpipe/schemaregistry/confluent/ConfluentSchemaResolverIntegrationTest.java
@@ -17,14 +17,14 @@ import org.testcontainers.containers.Network;
 import org.testcontainers.containers.wait.strategy.Wait;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
-import org.testcontainers.kafka.ConfluentKafkaContainer;
+import org.testcontainers.kafka.KafkaContainer;
 import org.testcontainers.utility.DockerImageName;
 
-/// End-to-end test for [ConfluentSchemaResolver] against a real `confluentinc/cp-schema-registry`
+/// End-to-end test for [ConfluentSchemaResolver] against a real `soldevelo/schema-registry`
 /// container. Registers a schema via SR's REST API, then exercises both lookup shapes.
 ///
 /// **Networking note.** Schema Registry runs in a sibling container and needs to reach the
-/// broker via the shared docker network. `ConfluentKafkaContainer.getBootstrapServers()` returns
+/// broker via the shared docker network. `KafkaContainer.getBootstrapServers()` returns
 /// a `localhost:<mappedPort>` address that's only reachable from the host — peers on the docker
 /// network can't resolve it. `withListener("kafka:19092")` adds an additional advertised listener
 /// reachable as `PLAINTEXT://kafka:19092` from any sibling on the same `Network`.
@@ -32,6 +32,7 @@ import org.testcontainers.utility.DockerImageName;
 class ConfluentSchemaResolverIntegrationTest {
 
   private static final String CONFLUENT_VERSION = System.getProperty("confluentPlatformVersion", "8.2.0");
+  private static final String KAFKA_VERSION = System.getProperty("kafkaVersion", "4.2.0");
   private static final String SUBJECT = "kpipe-test-schema";
   private static final String SCHEMA_JSON = """
     {"type":"record","name":"KPipeTest","fields":[{"name":"id","type":"long"}]}""";
@@ -39,8 +40,9 @@ class ConfluentSchemaResolverIntegrationTest {
   private static final Network NETWORK = Network.newNetwork();
 
   @Container
-  static ConfluentKafkaContainer kafka = new ConfluentKafkaContainer(
-    DockerImageName.parse("confluentinc/cp-kafka:%s".formatted(CONFLUENT_VERSION))
+  static KafkaContainer kafka = new KafkaContainer(
+    DockerImageName.parse("soldevelo/kafka:%s".formatted(KAFKA_VERSION))
+                   .asCompatibleSubstituteFor("apache/kafka")
   )
     .withNetwork(NETWORK)
     .withListener("kafka:19092")
@@ -48,14 +50,14 @@ class ConfluentSchemaResolverIntegrationTest {
 
   @Container
   static GenericContainer<?> schemaRegistry = new GenericContainer<>(
-    DockerImageName.parse("confluentinc/cp-schema-registry:%s".formatted(CONFLUENT_VERSION))
+    DockerImageName.parse("soldevelo/schema-registry:%s".formatted(CONFLUENT_VERSION))
   )
     .withNetwork(NETWORK)
     .withNetworkAliases("schema-registry")
     .withExposedPorts(8081)
-    .withEnv("SCHEMA_REGISTRY_HOST_NAME", "schema-registry")
+    .withEnv("SCHEMA_REGISTRY_ADVERTISED_HOSTNAME", "schema-registry")
     .withEnv("SCHEMA_REGISTRY_LISTENERS", "http://0.0.0.0:8081")
-    .withEnv("SCHEMA_REGISTRY_KAFKASTORE_BOOTSTRAP_SERVERS", "PLAINTEXT://kafka:19092")
+    .withEnv("SCHEMA_REGISTRY_KAFKA_BROKERS", "PLAINTEXT://kafka:19092")
     .withEnv("SCHEMA_REGISTRY_KAFKASTORE_TOPIC", "_schemas")
     .dependsOn(kafka)
     .waitingFor(Wait.forHttp("/subjects").forStatusCode(200))

--- a/lib/kpipe-tracing-otel/src/test/java/org/kpipe/tracing/otel/TracePropagationIntegrationTest.java
+++ b/lib/kpipe-tracing-otel/src/test/java/org/kpipe/tracing/otel/TracePropagationIntegrationTest.java
@@ -32,7 +32,7 @@ import org.kpipe.KPipe;
 import org.kpipe.producer.sink.KafkaMessageSink;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
-import org.testcontainers.kafka.ConfluentKafkaContainer;
+import org.testcontainers.kafka.KafkaContainer;
 import org.testcontainers.utility.DockerImageName;
 
 /// End-to-end test for W3C trace context propagation across the Kafka boundary.
@@ -45,7 +45,7 @@ import org.testcontainers.utility.DockerImageName;
 @Testcontainers(disabledWithoutDocker = true)
 class TracePropagationIntegrationTest {
 
-  private static final String CONFLUENT_VERSION = System.getProperty("confluentPlatformVersion", "8.2.0");
+  private static final String KAFKA_VERSION = System.getProperty("kafkaVersion", "4.2.0");
 
   // Known parent: traceparent format is `version-traceId-parentSpanId-flags` (W3C §3.2).
   private static final String INBOUND_TRACE_ID = "0af7651916cd43dd8448eb211c80319c";
@@ -53,8 +53,9 @@ class TracePropagationIntegrationTest {
   private static final String INBOUND_TRACEPARENT = "00-" + INBOUND_TRACE_ID + "-" + INBOUND_SPAN_ID + "-01";
 
   @Container
-  static ConfluentKafkaContainer kafka = new ConfluentKafkaContainer(
-    DockerImageName.parse("confluentinc/cp-kafka:%s".formatted(CONFLUENT_VERSION))
+  static KafkaContainer kafka = new KafkaContainer(
+    DockerImageName.parse("soldevelo/kafka:%s".formatted(KAFKA_VERSION))
+                   .asCompatibleSubstituteFor("apache/kafka")
   ).withStartupAttempts(3);
 
   private static java.util.List<io.opentelemetry.sdk.trace.data.SpanData> waitForSpans(


### PR DESCRIPTION
Replaces Confluent-provided Docker images with Soldevelo forks (bitnami-based) across the project. Issue #63 

## Changes

### docker-compose.yaml
- Swapped `confluentinc/cp-kafka:8.2.0` for `soldevelo/kafka:4.2.0`
- Swapped `confluentinc/cp-schema-registry:8.2.0` for `soldevelo/schema-registry:8.2.0`
- Translated all Kafka env vars to use the `KAFKA_CFG_*` prefix required by the bitnami image; renamed `CLUSTER_ID` to `KAFKA_CLUSTER_ID`
- Updated volume mount path from `/var/lib/kafka/data` to `/bitnami/kafka`
- Updated Kafka CLI script names to include the `.sh` suffix (bitnami convention)
- Updated schema-registry env vars: `SCHEMA_REGISTRY_KAFKASTORE_BOOTSTRAP_SERVERS` to `SCHEMA_REGISTRY_KAFKA_BROKERS`, `SCHEMA_REGISTRY_HOST_NAME` to `SCHEMA_REGISTRY_ADVERTISED_HOSTNAME`
- Fixed schema-registry healthcheck: replaced `curl` (not present in the bitnami image) with `nc -z localhost 8081`

### Integration tests
- Replaced `ConfluentKafkaContainer` with `KafkaContainer` from `org.testcontainers.kafka` in 3 test files
- Updated the image reference to `soldevelo/kafka:4.2.0` with `.asCompatibleSubstituteFor("apache/kafka")`

All integration tests pass.