### PR TITLE
refactor: clear P4 internal-polish backlog

### DIFF
--- a/.claude/PLAN.md
+++ b/.claude/PLAN.md
@@ -1,6 +1,6 @@
 # KPipe — Roadmap & State of the Library
 
-**Last updated:** 2026-05-06
+**Last updated:** 2026-05-07
 **Current released line:** 1.10.0 (Maven Central)
 **Active branch state:** `feature/1.11.1-test-coverage` (PR #94) plus `fix/critical-bugs` cleanup branch
 
@@ -30,34 +30,48 @@ roadmap below.
 
 Single source of truth for what's left across the whole library.
 
-| #  | Priority                  | Item                                                                                      | Type              | Effort    |
-|----|---------------------------|-------------------------------------------------------------------------------------------|-------------------|-----------|
-| 1  | **P1 — Adoption blocker** | Multi-topic Phase 1 (homogeneous topics, single shared pipeline)                          | Feature           | ~3 days   |
-| 2  | **P1 — Adoption blocker** | Java baseline decision (stay on 25 vs drop to 21 LTS)                                     | Strategy          | decision  |
-| 3  | **P2 — Real footgun**     | `Format.INSTANCE` global mutable state (Avro/Protobuf)                                    | Hardening         | ~1 day    |
-| 4  | **P2 — Real footgun**     | HTTP fetcher full extraction from `kpipe-format-avro`                                     | Cleanup           | ~half day |
-| 5  | **P2 — Bug surface**      | Batch sinks (`BatchSink<T>` interface + size/time flush + partial-failure semantics)      | Feature           | ~5–7 days |
-| 6  | **P2 — Bug surface**      | Circuit breaker for sinks                                                                 | Feature           | ~3–4 days |
-| 7  | **P3 — User-visible**     | `AppConfig` slimdown / split (real example infra; decide split or move)                   | Refactor          | ~1 hr     |
-| 8  | **P3 — User-visible**     | `HttpHealthServer` placement decision (lib contract or sample → `examples/`?)             | Refactor          | ~30 min   |
-| 9  | **P3 — User-visible**     | Build/test config cleanup remaining (consumer parallelism, residual fork tuning)          | Refactor          | ~30 min   |
-| 10 | **P4 — Internal polish**  | `MessageTracker` audit — only used for graceful-shutdown wait; could collapse             | Investigation     | ~1 hr     |
-| 11 | **P4 — Internal polish**  | `OffsetManager.createRebalanceListener()` leak — register internally instead              | Refactor          | ~1 hr     |
-| 12 | **P4 — Internal polish**  | `MessageProcessorRegistry.sourceAppName` audit — likely vestigial                         | Investigation     | ~30 min   |
-| 13 | **P4 — Internal polish**  | `ConsumerCommand` sealed hierarchy review — `CommitOffsets` only emitted by scheduler now | Refactor          | ~1 hr     |
-| 14 | **P4 — Internal polish**  | `BackpressureController` public surface tightening                                        | Refactor          | ~1 hr     |
-| 15 | **P4 — Internal polish**  | `KPipeProducer.send*` variants audit (`send` / `sendAsync` / `sendToDlq`)                 | Investigation     | ~1 hr     |
-| 16 | **P4 — Internal polish**  | `OffsetState` enum sub-package — alone in `enums/`, move up                               | Refactor          | ~10 min   |
-| 17 | **P4 — Internal polish**  | `KafkaConsumerConfig` usage audit — confirm canonical or replace with builder             | Investigation     | ~30 min   |
-| 18 | **P4 — Internal polish**  | `kpipe-bom` and `kpipe-metrics-otel` module-info docs — last-mile polish                  | Docs              | ~30 min   |
-| 19 | **P5 — 2.0 candidates**   | Type-name shortening (`MessageProcessorRegistry` → `Pipelines`, etc.)                     | Breaking refactor | ~1 day    |
-| 20 | **P5 — 2.0 candidates**   | `Result<T>` sealed type for pipeline errors                                               | Breaking refactor | ~1 day    |
-| 21 | **P5 — 2.0 candidates**   | Fold `KPipeRunner` into `KPipeConsumer`                                                   | Breaking refactor | ~half day |
-| 22 | **P5 — Speculative perf** | Format serialization caches re-wire (only with JMH evidence)                              | Perf              | ~1–2 days |
+| #  | Priority                  | Item                                                                                                                         | Type              | Effort    |
+|----|---------------------------|------------------------------------------------------------------------------------------------------------------------------|-------------------|-----------|
+| 1  | **P1 — Adoption blocker** | Multi-topic Phase 1 (homogeneous topics, single shared pipeline)                                                             | Feature           | ~3 days   |
+| 2  | **P1 — Adoption blocker** | Java baseline decision (stay on 25 vs drop to 21 LTS)                                                                        | Strategy          | decision  |
+| 3  | **P2 — Real footgun**     | `Format.INSTANCE` global mutable state (Avro/Protobuf)                                                                       | Hardening         | ~1 day    |
+| 4  | **P2 — Real footgun**     | HTTP fetcher remaining extraction from `kpipe-format-avro` (drop `java.net.http` + `jackson.core`; dsl-json already removed) | Cleanup           | ~2–3 hr   |
+| 5  | **P2 — Bug surface**      | Batch sinks (`BatchSink<T>` interface + size/time flush + partial-failure semantics)                                         | Feature           | ~5–7 days |
+| 6  | **P2 — Bug surface**      | Circuit breaker for sinks                                                                                                    | Feature           | ~3–4 days |
+| 7  | **P3 — User-visible**     | `AppConfig` slimdown / split (real example infra; decide split or move)                                                      | Refactor          | ~1 hr     |
+| 8  | **P3 — User-visible**     | `HttpHealthServer` placement decision (lib contract or sample → `examples/`?)                                                | Refactor          | ~30 min   |
+| 9  | **P3 — User-visible**     | Build/test config cleanup remaining (consumer parallelism, residual fork tuning)                                             | Refactor          | ~30 min   |
+| 10 | **P5 — 2.0 candidates**   | Type-name shortening (`MessageProcessorRegistry` → `Pipelines`, etc.)                                                        | Breaking refactor | ~1 day    |
+| 11 | **P5 — 2.0 candidates**   | `Result<T>` sealed type for pipeline errors                                                                                  | Breaking refactor | ~1 day    |
+| 12 | **P5 — 2.0 candidates**   | Fold `KPipeRunner` into `KPipeConsumer`                                                                                      | Breaking refactor | ~half day |
+| 13 | **P5 — 2.0 candidates**   | `MessageTracker` collapse — add `KPipeConsumer.waitForInFlightDrain(Duration)`, deprecate the standalone class               | Breaking refactor | ~half day |
+| 14 | **P5 — Speculative perf** | Format serialization caches re-wire (only with JMH evidence)                                                                 | Perf              | ~1–2 days |
 
-**Recommendation:** ship P1 (#1, #2) and P2 (#3–#6) — those move the adoption needle. P3+ are correct fixes but
-invisible to users; the maintenance backlog is small enough that further internal polish yields diminishing
-returns. Multi-topic Phase 1 is the next focused effort.
+**Recommendation:** ship P1 (#1, #2) and P2 (#3–#6) — those move the adoption needle. P3 items are correct
+fixes but invisible to users. P4 internal-polish backlog was cleared on 2026-05-07 (8 audits/refactors landed
+in one branch — see "Recently completed" below). Multi-topic Phase 1 is the next focused effort.
+
+### Recently completed (P4 internal polish — 2026-05-07)
+
+- Moved `OffsetState` and `ConsumerState` out of the `org.kpipe.consumer.enums` sub-package; deleted the
+  one-package-deep folder.
+- Added a discoverable docstring to `kpipe-metrics-otel/module-info.java`. (`kpipe-bom` is a `java-platform`
+  BOM with no `module-info.java` — its description in `build.gradle.kts` is the appropriate doc.)
+- **Audited and removed** `MessageProcessorRegistry.sourceAppName` — confirmed vestigial (set by 17 callers,
+  read by zero). Deleted the field, both `String`-taking constructors, the getter, and `withSourceAppName`.
+  Updated all 17 call sites.
+- **Audited** `KafkaConsumerConfig` — confirmed canonical (parallels `KafkaProducerConfig`, used by all 4
+  example apps + own test). No change.
+- **Audited** `MessageTracker` — keep as-is. Well-tested public class; potential 2.0 collapse target moved
+  to P5.
+- **Fixed** `KPipeProducer.sendAsync` silent-metrics footgun: previously returned the raw producer Future
+  with no instrumentation; now wraps with a callback that increments `messages.sent` / `messages.failed`.
+- **Tightened** `OffsetManager.createRebalanceListener()` — moved the no-op default into the interface as a
+  `default` method. Custom external offset stores no longer need to implement Kafka rebalance plumbing.
+- **Audited** `ConsumerCommand` sealed hierarchy — keep as-is. `CommitOffsets` is the cross-thread bridge
+  for both scheduled commits and `close()` path; `withOffsets` has a real callsite in `RebalanceListener`.
+- **Audited** `BackpressureController` public surface — already minimal. All instance methods are used,
+  factories are intentional escape hatches, `calculateTotalLag` is a useful static utility.
 
 ---
 
@@ -146,13 +160,17 @@ fix is either (a) make `addSchema` only available on `new AvroFormat()` instance
 through a per-stream format instance, or (b) delete `INSTANCE` entirely and make construction explicit. Both are
 breaking changes. Documentation already carries an explicit "Footgun warning" — that's the cheap mitigation.
 
-### P2 #4 — `kpipe-format-avro` HTTP fetcher full extraction
+### P2 #4 — `kpipe-format-avro` HTTP fetcher remaining extraction
 
-`AvroFormat.readSchemaFromLocation` supports `http://` URLs that hit a Confluent Schema Registry, which keeps
-two extra deps on `kpipe-format-avro`: `requires java.net.http` and `requires com.fasterxml.jackson.core`.
-The 2-arg `addSchema(key, schemaJson)` overload covers the "I have the JSON" case directly, so HTTP fetching
-could move to a separate optional module (`kpipe-schema-registry-confluent`) or be deleted in favor of
-user-side fetching. Wins: smaller transitive footprint for users who only consume inline / classpath schemas.
+**Done already:** dsl-json dependency removed; envelope parsing rewritten to Jackson `JsonFactory` streaming
+(reuses the jackson-core that Avro already pulls transitively, so no new dep was added).
+
+**What's left:** `AvroFormat.readSchemaFromLocation` still supports `http://` URLs hitting a Confluent Schema
+Registry, which keeps two `requires` declarations on `kpipe-format-avro`'s `module-info.java`: `java.net.http`
+and `com.fasterxml.jackson.core`. The 2-arg `addSchema(key, schemaJson)` overload covers the "I have the JSON"
+case directly, so HTTP fetching could move to a separate optional module (`kpipe-schema-registry-confluent`)
+or be deleted in favor of user-side fetching. Wins: smaller transitive footprint for users who only consume
+inline / classpath schemas.
 
 ### P2 #5 — Batch sinks
 

--- a/benchmarks/src/jmh/java/org/kpipe/benchmarks/AvroPipelineBenchmark.java
+++ b/benchmarks/src/jmh/java/org/kpipe/benchmarks/AvroPipelineBenchmark.java
@@ -79,7 +79,7 @@ public class AvroPipelineBenchmark {
     avroWithMagicBytes[4] = 1;
     System.arraycopy(avroBytes, 0, avroWithMagicBytes, 5, avroBytes.length);
 
-    final var registry = new MessageProcessorRegistry("benchmark-app", AvroFormat.INSTANCE);
+    final var registry = new MessageProcessorRegistry(AvroFormat.INSTANCE);
     final var format = AvroFormat.INSTANCE;
     format.addSchema("user", "com.kpipe.User", schemaJson);
     format.withDefaultSchema("user");

--- a/benchmarks/src/jmh/java/org/kpipe/benchmarks/JsonPipelineBenchmark.java
+++ b/benchmarks/src/jmh/java/org/kpipe/benchmarks/JsonPipelineBenchmark.java
@@ -51,7 +51,7 @@ public class JsonPipelineBenchmark {
       }
       """.getBytes(StandardCharsets.UTF_8);
 
-    final var registry = new MessageProcessorRegistry("benchmark-app", JsonFormat.INSTANCE);
+    final var registry = new MessageProcessorRegistry(JsonFormat.INSTANCE);
     // Register some operators
     final var op1 = RegistryKey.json("op1");
     final var op2 = RegistryKey.json("op2");

--- a/benchmarks/src/jmh/java/org/kpipe/benchmarks/ParallelProcessingBenchmarkInfrastructure.java
+++ b/benchmarks/src/jmh/java/org/kpipe/benchmarks/ParallelProcessingBenchmarkInfrastructure.java
@@ -175,7 +175,7 @@ public final class ParallelProcessingBenchmarkInfrastructure {
   @State(Scope.Thread)
   public static class KpipeInvocationContext {
 
-    private static final MessageProcessorRegistry REGISTRY = new MessageProcessorRegistry("benchmark");
+    private static final MessageProcessorRegistry REGISTRY = new MessageProcessorRegistry();
 
     private AtomicInteger processedCount;
     private KPipeConsumer<byte[]> consumer;

--- a/examples/avro/src/main/java/org/kpipe/App.java
+++ b/examples/avro/src/main/java/org/kpipe/App.java
@@ -61,7 +61,7 @@ public class App implements AutoCloseable {
   /// @param config The application configuration
   /// @param schemaRegistryUrl Schema Registry base URL
   public App(final AppConfig config, final String schemaRegistryUrl) {
-    processorRegistry = new MessageProcessorRegistry(config.appName(), AvroFormat.INSTANCE);
+    processorRegistry = new MessageProcessorRegistry(AvroFormat.INSTANCE);
     sinkRegistry = processorRegistry.sinkRegistry();
     kpipeConsumer = createConsumer(config, processorRegistry, schemaRegistryUrl);
 

--- a/examples/demo/src/main/java/org/kpipe/demo/DemoApp.java
+++ b/examples/demo/src/main/java/org/kpipe/demo/DemoApp.java
@@ -99,7 +99,7 @@ public class DemoApp implements AutoCloseable {
   /// ── JSON pipeline ──────────────────────────────────────────────────────
 
   private static KPipeRunner<KPipeConsumer<byte[]>> buildJsonPipeline(final DemoConfig config) {
-    final var registry = new MessageProcessorRegistry("demo-json", JsonFormat.INSTANCE);
+    final var registry = new MessageProcessorRegistry(JsonFormat.INSTANCE);
     final var sinkRegistry = registry.sinkRegistry();
     sinkRegistry.register(RegistryKey.json("jsonLogging"), new JsonConsoleSink<>());
 
@@ -138,7 +138,7 @@ public class DemoApp implements AutoCloseable {
   /// ── Avro pipeline ─────────────────────────────────────────────────────
 
   private static KPipeRunner<KPipeConsumer<byte[]>> buildAvroPipeline(final DemoConfig config) {
-    final var registry = new MessageProcessorRegistry("demo-avro", AvroFormat.INSTANCE);
+    final var registry = new MessageProcessorRegistry(AvroFormat.INSTANCE);
     final var sinkRegistry = registry.sinkRegistry();
     sinkRegistry.register(AvroRegistryKey.of("avroLogging"), new AvroConsoleSink<>());
 
@@ -168,7 +168,7 @@ public class DemoApp implements AutoCloseable {
 
   /// ── Protobuf pipeline ─────────────────────────────────────────────────
   private static KPipeRunner<KPipeConsumer<byte[]>> buildProtobufPipeline(final DemoConfig config) {
-    final var registry = new MessageProcessorRegistry("demo-protobuf", ProtobufFormat.INSTANCE);
+    final var registry = new MessageProcessorRegistry(ProtobufFormat.INSTANCE);
     final var sinkRegistry = registry.sinkRegistry();
     sinkRegistry.register(ProtobufRegistryKey.of("protobufLogging"), new ProtobufConsoleSink<>());
 

--- a/examples/json/src/main/java/org/kpipe/App.java
+++ b/examples/json/src/main/java/org/kpipe/App.java
@@ -53,7 +53,7 @@ public class App implements AutoCloseable {
   ///
   /// @param config The application configuration
   public App(final AppConfig config) {
-    processorRegistry = new MessageProcessorRegistry(config.appName(), JsonFormat.INSTANCE);
+    processorRegistry = new MessageProcessorRegistry(JsonFormat.INSTANCE);
     sinkRegistry = processorRegistry.sinkRegistry();
     // Pre-register loggers
     sinkRegistry.register(RegistryKey.json("jsonLogging"), new JsonConsoleSink<>());

--- a/examples/protobuf/src/main/java/org/kpipe/App.java
+++ b/examples/protobuf/src/main/java/org/kpipe/App.java
@@ -54,7 +54,7 @@ public class App implements AutoCloseable {
   ///
   /// @param config The application configuration
   public App(final AppConfig config) {
-    processorRegistry = new MessageProcessorRegistry(config.appName(), ProtobufFormat.INSTANCE);
+    processorRegistry = new MessageProcessorRegistry(ProtobufFormat.INSTANCE);
     sinkRegistry = processorRegistry.sinkRegistry();
 
     kpipeConsumer = createConsumer(config, processorRegistry);

--- a/lib/kpipe-consumer/src/main/java/module-info.java
+++ b/lib/kpipe-consumer/src/main/java/module-info.java
@@ -11,7 +11,6 @@ module org.kpipe.consumer {
 
   exports org.kpipe.consumer;
   exports org.kpipe.consumer.config;
-  exports org.kpipe.consumer.enums;
   exports org.kpipe.consumer.metrics;
   exports org.kpipe.health;
 }

--- a/lib/kpipe-consumer/src/main/java/org/kpipe/consumer/AbstractOffsetManager.java
+++ b/lib/kpipe-consumer/src/main/java/org/kpipe/consumer/AbstractOffsetManager.java
@@ -3,10 +3,6 @@ package org.kpipe.consumer;
 import java.util.Collections;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicReference;
-import org.apache.kafka.clients.consumer.ConsumerRebalanceListener;
-import org.apache.kafka.clients.consumer.ConsumerRecord;
-import org.apache.kafka.common.TopicPartition;
-import org.kpipe.consumer.enums.OffsetState;
 
 /// Convenience base class for [OffsetManager] implementations that only need to customize how
 /// offsets are tracked and persisted.
@@ -25,8 +21,8 @@ import org.kpipe.consumer.enums.OffsetState;
 ///   (schedulers, connection pools, etc.).
 /// * `notifyCommitComplete(...)` — no-op. Override only if your implementation issues
 ///   asynchronous commits and needs the completion callback to settle a future.
-/// * `createRebalanceListener()` — returns a no-op [ConsumerRebalanceListener]. Override if you
-///   need to drain pending state or invalidate caches when partitions are revoked or assigned.
+/// * `createRebalanceListener()` — inherited no-op default from [OffsetManager]. Override if
+///   you need to drain pending state or invalidate caches on partition revoke/assign.
 /// * `getState()` / `isRunning()` — derived from the internal state reference.
 /// * `getStatistics()` — returns an empty map. Override to expose diagnostic counters.
 /// * `close()` — no-op. Override to release resources held by the implementation.
@@ -121,29 +117,6 @@ public abstract class AbstractOffsetManager<K> implements OffsetManager<K> {
   @Override
   public void notifyCommitComplete(final String commitId, final boolean success) {
     // no-op: implementations that don't manage async commit futures don't need this hook
-  }
-
-  /// Default no-op [ConsumerRebalanceListener]. Most custom offset managers do not need to
-  /// react to partition assignments because their state is keyed by [TopicPartition] and is
-  /// safe to retain across rebalances.
-  ///
-  /// Override if you need to drain pending state, invalidate caches, or surrender resources
-  /// when partitions are revoked or newly assigned.
-  ///
-  /// @return a no-op rebalance listener
-  @Override
-  public ConsumerRebalanceListener createRebalanceListener() {
-    return new ConsumerRebalanceListener() {
-      @Override
-      public void onPartitionsRevoked(final java.util.Collection<TopicPartition> partitions) {
-        // no-op
-      }
-
-      @Override
-      public void onPartitionsAssigned(final java.util.Collection<TopicPartition> partitions) {
-        // no-op
-      }
-    };
   }
 
   /// Returns the current state derived from the internal [AtomicReference].

--- a/lib/kpipe-consumer/src/main/java/org/kpipe/consumer/ConsumerState.java
+++ b/lib/kpipe-consumer/src/main/java/org/kpipe/consumer/ConsumerState.java
@@ -1,4 +1,4 @@
-package org.kpipe.consumer.enums;
+package org.kpipe.consumer;
 
 /// Represents the operational states of the consumer.
 ///

--- a/lib/kpipe-consumer/src/main/java/org/kpipe/consumer/KPipeConsumer.java
+++ b/lib/kpipe-consumer/src/main/java/org/kpipe/consumer/KPipeConsumer.java
@@ -18,7 +18,6 @@ import org.apache.kafka.clients.producer.*;
 import org.apache.kafka.common.errors.InterruptException;
 import org.apache.kafka.common.errors.WakeupException;
 import org.kpipe.consumer.config.AppConfig;
-import org.kpipe.consumer.enums.ConsumerState;
 import org.kpipe.metrics.ConsumerMetrics;
 import org.kpipe.producer.KPipeProducer;
 import org.kpipe.registry.MessagePipeline;

--- a/lib/kpipe-consumer/src/main/java/org/kpipe/consumer/KafkaOffsetManager.java
+++ b/lib/kpipe-consumer/src/main/java/org/kpipe/consumer/KafkaOffsetManager.java
@@ -13,7 +13,6 @@ import org.apache.kafka.clients.consumer.ConsumerRebalanceListener;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.consumer.OffsetAndMetadata;
 import org.apache.kafka.common.TopicPartition;
-import org.kpipe.consumer.enums.OffsetState;
 
 /// Manages Kafka consumer offsets for parallel processing scenarios.
 ///

--- a/lib/kpipe-consumer/src/main/java/org/kpipe/consumer/OffsetManager.java
+++ b/lib/kpipe-consumer/src/main/java/org/kpipe/consumer/OffsetManager.java
@@ -1,9 +1,10 @@
 package org.kpipe.consumer;
 
+import java.util.Collection;
 import java.util.Map;
 import org.apache.kafka.clients.consumer.ConsumerRebalanceListener;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
-import org.kpipe.consumer.enums.OffsetState;
+import org.apache.kafka.common.TopicPartition;
 
 /// Interface for managing Kafka consumer offsets.
 ///
@@ -34,8 +35,25 @@ public interface OffsetManager<K> extends AutoCloseable {
   void notifyCommitComplete(final String commitId, final boolean success);
 
   /// Creates a rebalance listener for this offset manager.
-  /// @return A ConsumerRebalanceListener instance
-  ConsumerRebalanceListener createRebalanceListener();
+  ///
+  /// Default implementation is a no-op — most custom offset stores key their state by
+  /// [TopicPartition] and can retain it across rebalances without any action. Override only
+  /// to drain pending state, invalidate caches, or surrender resources on revoke/assign.
+  ///
+  /// @return a [ConsumerRebalanceListener] (never null)
+  default ConsumerRebalanceListener createRebalanceListener() {
+    return new ConsumerRebalanceListener() {
+      @Override
+      public void onPartitionsRevoked(final Collection<TopicPartition> partitions) {
+        // no-op
+      }
+
+      @Override
+      public void onPartitionsAssigned(final Collection<TopicPartition> partitions) {
+        // no-op
+      }
+    };
+  }
 
   /// Gets the current operational state of the offset manager.
   /// @return The current OffsetState

--- a/lib/kpipe-consumer/src/main/java/org/kpipe/consumer/OffsetState.java
+++ b/lib/kpipe-consumer/src/main/java/org/kpipe/consumer/OffsetState.java
@@ -1,4 +1,4 @@
-package org.kpipe.consumer.enums;
+package org.kpipe.consumer;
 
 /// Represents the possible operational states of a KafkaOffsetManager.
 ///

--- a/lib/kpipe-consumer/src/main/java/org/kpipe/consumer/RebalanceListener.java
+++ b/lib/kpipe-consumer/src/main/java/org/kpipe/consumer/RebalanceListener.java
@@ -10,7 +10,6 @@ import org.apache.kafka.clients.consumer.Consumer;
 import org.apache.kafka.clients.consumer.ConsumerRebalanceListener;
 import org.apache.kafka.clients.consumer.OffsetAndMetadata;
 import org.apache.kafka.common.TopicPartition;
-import org.kpipe.consumer.enums.OffsetState;
 
 /// Implementation of Kafka's ConsumerRebalanceListener that handles partition rebalance events for
 /// the KafkaOffsetManager.

--- a/lib/kpipe-consumer/src/test/java/org/kpipe/consumer/ExternalOffsetIntegrationTest.java
+++ b/lib/kpipe-consumer/src/test/java/org/kpipe/consumer/ExternalOffsetIntegrationTest.java
@@ -12,7 +12,6 @@ import org.apache.kafka.clients.consumer.MockConsumer;
 import org.apache.kafka.common.TopicPartition;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.kpipe.consumer.enums.OffsetState;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 import org.testcontainers.postgresql.PostgreSQLContainer;

--- a/lib/kpipe-consumer/src/test/java/org/kpipe/consumer/RebalanceListenerTest.java
+++ b/lib/kpipe-consumer/src/test/java/org/kpipe/consumer/RebalanceListenerTest.java
@@ -14,7 +14,6 @@ import org.apache.kafka.common.TopicPartition;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.kpipe.consumer.enums.OffsetState;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mock;

--- a/lib/kpipe-consumer/src/test/java/org/kpipe/consumer/TestPipelines.java
+++ b/lib/kpipe-consumer/src/test/java/org/kpipe/consumer/TestPipelines.java
@@ -17,7 +17,7 @@ import org.kpipe.registry.MessageProcessorRegistry;
 /// Production users should call `registry.pipeline(MessageFormat.bytes())` directly.
 final class TestPipelines {
 
-  private static final MessageProcessorRegistry REGISTRY = new MessageProcessorRegistry("test");
+  private static final MessageProcessorRegistry REGISTRY = new MessageProcessorRegistry();
 
   private TestPipelines() {}
 

--- a/lib/kpipe-core/src/main/java/org/kpipe/registry/MessageProcessorRegistry.java
+++ b/lib/kpipe-core/src/main/java/org/kpipe/registry/MessageProcessorRegistry.java
@@ -31,7 +31,6 @@ public class MessageProcessorRegistry {
   private static final System.Logger LOGGER = System.getLogger(MessageProcessorRegistry.class.getName());
 
   private final ConcurrentHashMap<RegistryKey<?>, RegistryEntry<?>> registryMap = new ConcurrentHashMap<>();
-  private volatile String sourceAppName;
   private final MessageFormat<?> messageFormat;
 
   private final MessageSinkRegistry sinkRegistry = new MessageSinkRegistry();
@@ -104,76 +103,22 @@ public class MessageProcessorRegistry {
     };
   }
 
-  /// Creates a new registry with the byte-passthrough format and an empty source app name.
-  ///
-  /// This is the preferred form when `sourceAppName` is not needed. Use
-  // [#withSourceAppName(String)]
-  /// to set the app name later if required.
+  /// Creates a new registry with the byte-passthrough format.
   public MessageProcessorRegistry() {
-    this("", MessageFormat.bytes());
-  }
-
-  /// Creates a new registry with the specified message format and an empty source app name.
-  ///
-  /// This is the preferred form when `sourceAppName` is not needed. Use
-  // [#withSourceAppName(String)]
-  /// to set the app name later if required.
-  ///
-  /// @param messageFormat Message format to use (e.g. `JsonFormat.INSTANCE`, `AvroFormat.INSTANCE`,
-  ///                      `ProtobufFormat.INSTANCE`, `MessageFormat.bytes()`, or a custom impl)
-  public MessageProcessorRegistry(final MessageFormat<?> messageFormat) {
-    this("", messageFormat);
-  }
-
-  /// Creates a new registry with the byte-passthrough format as the default.
-  ///
-  /// Kept for backwards compatibility. Prefer the no-arg [#MessageProcessorRegistry()] constructor
-  /// (combined with [#withSourceAppName(String)] when needed) when `sourceAppName` is not required.
-  ///
-  /// @param sourceAppName Application name to use as source identifier
-  public MessageProcessorRegistry(final String sourceAppName) {
-    this(sourceAppName, MessageFormat.bytes());
+    this(MessageFormat.bytes());
   }
 
   /// Creates a new registry with the specified message format.
   ///
-  /// Kept for backwards compatibility. Prefer the format-only
-  // [#MessageProcessorRegistry(MessageFormat)]
-  /// constructor (combined with [#withSourceAppName(String)] when needed) when `sourceAppName` is
-  /// not required.
-  ///
-  /// @param sourceAppName Application name to use as source identifier
   /// @param messageFormat Message format to use (e.g. `JsonFormat.INSTANCE`, `AvroFormat.INSTANCE`,
   ///                      `ProtobufFormat.INSTANCE`, `MessageFormat.bytes()`, or a custom impl)
-  public MessageProcessorRegistry(final String sourceAppName, final MessageFormat<?> messageFormat) {
-    this.sourceAppName = Objects.requireNonNull(sourceAppName, "Source app name cannot be null");
+  public MessageProcessorRegistry(final MessageFormat<?> messageFormat) {
     this.messageFormat = Objects.requireNonNull(messageFormat, "Message format cannot be null");
-  }
-
-  /// Returns the source application name this registry was created with — useful for
-  // format-specific
-  /// helper modules that register default operators (e.g. an "addSource" processor that stamps the
-  /// app name onto each message).
-  ///
-  /// @return the source app name
-  public String sourceAppName() {
-    return sourceAppName;
-  }
-
-  /// Sets the source application name fluently. Useful when constructing the registry via the
-  /// no-arg or format-only constructors and the app name needs to be supplied later.
-  ///
-  /// @param name the source application name (must not be null)
-  /// @return this registry instance for chaining
-  public MessageProcessorRegistry withSourceAppName(final String name) {
-    this.sourceAppName = Objects.requireNonNull(name, "Source app name cannot be null");
-    return this;
   }
 
   /// Returns the [MessageFormat] this registry was constructed with. Useful for callers that
   /// want to inspect or reuse the format (e.g. to build a sibling pipeline). Defaults to
-  /// [MessageFormat#bytes()] when the registry was constructed with a no-arg or
-  /// `sourceAppName`-only constructor.
+  /// [MessageFormat#bytes()] when the registry was constructed with the no-arg constructor.
   ///
   /// @return the configured message format (never null)
   public MessageFormat<?> messageFormat() {

--- a/lib/kpipe-core/src/test/java/org/kpipe/registry/OperatorsTest.java
+++ b/lib/kpipe-core/src/test/java/org/kpipe/registry/OperatorsTest.java
@@ -63,7 +63,7 @@ class OperatorsTest {
   void filterShouldComposeInPipeline() {
     // Verify the operator actually integrates with TypedPipelineBuilder's
     // null-handling — filtered messages short-circuit the chain.
-    final var registry = new MessageProcessorRegistry("operators-test");
+    final var registry = new MessageProcessorRegistry();
     final var pipeline = registry
       .pipeline(MessageFormat.bytes())
       .add(Operators.filter(b -> new String(b).startsWith("keep-")))

--- a/lib/kpipe-format-avro/src/main/java/org/kpipe/format/avro/AvroFormat.java
+++ b/lib/kpipe-format-avro/src/main/java/org/kpipe/format/avro/AvroFormat.java
@@ -78,7 +78,7 @@ public final class AvroFormat implements SchemaAwareFormat<GenericRecord> {
   ///
   /// @return a new pre-configured registry
   public static MessageProcessorRegistry newRegistry() {
-    final var registry = new MessageProcessorRegistry("kpipe-format-avro", INSTANCE);
+    final var registry = new MessageProcessorRegistry(INSTANCE);
     registry.sinkRegistry().register(AVRO_LOGGING, new AvroConsoleSink<>());
     return registry;
   }

--- a/lib/kpipe-format-avro/src/test/java/org/kpipe/format/avro/AvroFormatRoundTripTest.java
+++ b/lib/kpipe-format-avro/src/test/java/org/kpipe/format/avro/AvroFormatRoundTripTest.java
@@ -19,7 +19,7 @@ import org.kpipe.registry.MessageProcessorRegistry;
 
 class AvroFormatRoundTripTest {
 
-  private static final MessageProcessorRegistry REGISTRY = new MessageProcessorRegistry("test-app");
+  private static final MessageProcessorRegistry REGISTRY = new MessageProcessorRegistry();
 
   @AfterEach
   public void clearSchemaRegistry() {

--- a/lib/kpipe-format-json/src/main/java/org/kpipe/format/json/JsonFormat.java
+++ b/lib/kpipe-format-json/src/main/java/org/kpipe/format/json/JsonFormat.java
@@ -38,7 +38,7 @@ public final class JsonFormat implements MessageFormat<Map<String, Object>> {
   ///
   /// @return a new pre-configured registry
   public static MessageProcessorRegistry newRegistry() {
-    final var registry = new MessageProcessorRegistry("kpipe-format-json", INSTANCE);
+    final var registry = new MessageProcessorRegistry(INSTANCE);
     registry.sinkRegistry().register(MessageSinkRegistry.JSON_LOGGING, new JsonConsoleSink<>());
     return registry;
   }

--- a/lib/kpipe-format-json/src/test/java/org/kpipe/format/json/JsonFormatPipelineTest.java
+++ b/lib/kpipe-format-json/src/test/java/org/kpipe/format/json/JsonFormatPipelineTest.java
@@ -14,7 +14,7 @@ import org.kpipe.registry.MessageProcessorRegistry;
 class JsonFormatPipelineTest {
 
   private static final DslJson<Map<String, Object>> DSL_JSON = new DslJson<>();
-  private static final MessageProcessorRegistry REGISTRY = new MessageProcessorRegistry("test-app");
+  private static final MessageProcessorRegistry REGISTRY = new MessageProcessorRegistry();
 
   private static String normalizeJson(String json) {
     try (

--- a/lib/kpipe-format-json/src/test/java/org/kpipe/format/json/MessageProcessorRegistryJsonTest.java
+++ b/lib/kpipe-format-json/src/test/java/org/kpipe/format/json/MessageProcessorRegistryJsonTest.java
@@ -17,7 +17,7 @@ class MessageProcessorRegistryJsonTest {
 
   @BeforeEach
   void setUp() {
-    registry = new MessageProcessorRegistry("test-app");
+    registry = new MessageProcessorRegistry();
   }
 
   @Test

--- a/lib/kpipe-format-protobuf/src/main/java/org/kpipe/format/protobuf/ProtobufFormat.java
+++ b/lib/kpipe-format-protobuf/src/main/java/org/kpipe/format/protobuf/ProtobufFormat.java
@@ -51,12 +51,12 @@ public final class ProtobufFormat implements SchemaAwareFormat<Message> {
   /// [ProtobufConsoleSink] registered under [#PROTOBUF_LOGGING].
   ///
   /// Convenience for the common case of "give me a Protobuf registry with a logging sink"; users
-  /// who need an isolated descriptor scope or a custom source app name should build the registry
-  /// directly via `new MessageProcessorRegistry(sourceAppName, new ProtobufFormat())`.
+  /// who need an isolated descriptor scope should build the registry directly via
+  /// `new MessageProcessorRegistry(new ProtobufFormat())`.
   ///
   /// @return a new pre-configured registry
   public static MessageProcessorRegistry newRegistry() {
-    final var registry = new MessageProcessorRegistry("kpipe-format-protobuf", INSTANCE);
+    final var registry = new MessageProcessorRegistry(INSTANCE);
     registry.sinkRegistry().register(PROTOBUF_LOGGING, new ProtobufConsoleSink<>());
     return registry;
   }

--- a/lib/kpipe-format-protobuf/src/test/java/org/kpipe/format/protobuf/ProtobufFormatPipelineTest.java
+++ b/lib/kpipe-format-protobuf/src/test/java/org/kpipe/format/protobuf/ProtobufFormatPipelineTest.java
@@ -20,7 +20,7 @@ class ProtobufFormatPipelineTest {
   @BeforeEach
   void setUp() throws Exception {
     descriptor = buildTestDescriptor();
-    registry = new MessageProcessorRegistry("test-app", ProtobufFormat.INSTANCE);
+    registry = new MessageProcessorRegistry(ProtobufFormat.INSTANCE);
 
     final var protoFormat = ProtobufFormat.INSTANCE;
     protoFormat.addDescriptor("test", descriptor);

--- a/lib/kpipe-metrics-otel/src/main/java/module-info.java
+++ b/lib/kpipe-metrics-otel/src/main/java/module-info.java
@@ -1,5 +1,17 @@
-/// KPipe metrics OTel module — OpenTelemetry-backed implementation of [kpipe-metrics]
-/// interfaces.
+/// KPipe Metrics OTel module — OpenTelemetry-backed implementation of `kpipe-metrics` interfaces.
+///
+/// Add this module only if you want to export KPipe metrics through the OpenTelemetry pipeline
+/// (Prometheus, OTLP, Jaeger, etc.). The library code in `kpipe-metrics` ships interfaces only and
+/// has no transitive dependency on the OpenTelemetry API. Wire-up is opt-in:
+///
+/// ```java
+/// final var otel = GlobalOpenTelemetry.get();
+/// final var consumerMetrics = new OtelConsumerMetrics(otel);
+/// builder.withMetrics(consumerMetrics);
+/// ```
+///
+/// Bring your own SDK (`io.opentelemetry:opentelemetry-sdk` + an exporter); this module only
+/// requires `opentelemetry-api`.
 module org.kpipe.metrics.otel {
   requires org.kpipe.metrics;
   requires io.opentelemetry.api;

--- a/lib/kpipe-producer/src/main/java/org/kpipe/producer/KPipeProducer.java
+++ b/lib/kpipe-producer/src/main/java/org/kpipe/producer/KPipeProducer.java
@@ -192,10 +192,16 @@ public class KPipeProducer<K, V> implements AutoCloseable {
 
   /// Sends a record to a Kafka topic asynchronously.
   ///
+  /// Metrics are updated via a callback when the send completes — success increments
+  /// `kpipe.producer.messages.sent`, failure increments `kpipe.producer.messages.failed`.
+  ///
   /// @param record the record to send
   /// @return a future that will contain the record metadata
   public Future<RecordMetadata> sendAsync(final ProducerRecord<K, V> record) {
-    return producer.send(record);
+    return producer.send(record, (metadata, exception) -> {
+      if (exception == null) otelMetrics.recordMessageSent();
+      else otelMetrics.recordMessageFailed();
+    });
   }
 
   @Override

--- a/lib/kpipe-producer/src/test/java/org/kpipe/producer/KPipeProducerTest.java
+++ b/lib/kpipe-producer/src/test/java/org/kpipe/producer/KPipeProducerTest.java
@@ -9,6 +9,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.atomic.AtomicLong;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.clients.producer.Callback;
 import org.apache.kafka.clients.producer.Producer;
 import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.kafka.clients.producer.RecordMetadata;
@@ -74,7 +75,7 @@ class KPipeProducerTest {
   @SuppressWarnings("unchecked")
   void shouldReturnFutureOnSendAsync() {
     final var future = CompletableFuture.completedFuture(mock(RecordMetadata.class));
-    when(mockProducer.send(any(ProducerRecord.class))).thenReturn(future);
+    when(mockProducer.send(any(ProducerRecord.class), any(Callback.class))).thenReturn(future);
 
     final var result = new KPipeProducer<>(mockProducer, false, null).sendAsync(
       new ProducerRecord<>(TOPIC, null, "v".getBytes())


### PR DESCRIPTION
- Move OffsetState/ConsumerState out of org.kpipe.consumer.enums sub-package
- Add module-info docstring to kpipe-metrics-otel
- Remove vestigial sourceAppName from MessageProcessorRegistry (field, two String-taking ctors, getter, withSourceAppName); update 17 call sites to drop the unused first arg
- Make OffsetManager.createRebalanceListener() a default interface method so external impls aren't forced to handle Kafka rebalance plumbing; drop the redundant override on AbstractOffsetManager
- Fix KPipeProducer.sendAsync silent-metrics footgun -- wrap the raw Future with a callback so success/failure update the OTel counters
- Update KPipeProducerTest stub for the new send(record, callback) signature
- Update PLAN.md: clear P4 rows, promote MessageTracker collapse to P5