### PR TITLE
feat: multi-topic consumer support (homogeneous + heterogeneous)

### DIFF
--- a/.claude/PLAN.md
+++ b/.claude/PLAN.md
@@ -32,7 +32,7 @@ Single source of truth for what's left across the whole library.
 
 | #  | Priority                  | Item                                                                                                                         | Type              | Effort    |
 |----|---------------------------|------------------------------------------------------------------------------------------------------------------------------|-------------------|-----------|
-| 1  | **P1 — Adoption blocker** | Multi-topic Phase 1 (homogeneous topics, single shared pipeline)                                                             | Feature           | ~3 days   |
+| 1  | ~~**P1 — Adoption blocker**~~ | ~~Multi-topic Phase 1 (homogeneous) + Phase 2 (heterogeneous via `KPipe.multi`)~~ — both landed 2026-05-07               | Feature           | shipped   |
 | 2  | **P1 — Adoption blocker** | Java baseline decision (stay on 25 vs drop to 21 LTS)                                                                        | Strategy          | decision  |
 | 3  | **P2 — Real footgun**     | `Format.INSTANCE` global mutable state (Avro/Protobuf)                                                                       | Hardening         | ~1 day    |
 | 4  | **P2 — Real footgun**     | HTTP fetcher remaining extraction from `kpipe-format-avro` (drop `java.net.http` + `jackson.core`; dsl-json already removed) | Cleanup           | ~2–3 hr   |
@@ -103,41 +103,19 @@ kpipe-bom                                          (BOM — pins versions)
 
 ## Production-readiness roadmap (detail for the P1 / P2 items above)
 
-### P1 #1 — Multi-topic consumer support (PHASED — hardest of the four)
+### P1 #1 — Multi-topic consumer support (SHIPPED 2026-05-07)
 
-- **Today:** `KPipeConsumer<K>` subscribes to a single topic. Real apps consume from N topics; users have to
-  spin up N consumer instances, each with its own thread/poll loop, which inflates rebalance traffic and breaks
-  the "one consumer group, many partitions" model Kafka was designed for.
+Both phases landed in a single branch:
 
-- **Why it's hard (be honest with future-you):**
-    1. The fluent facade is built around a single typed pipeline — `KPipe.json("topic")` returns
-       `Stream<Map<String,Object>>`. Multi-topic forces a decision: all topics share one pipeline (and one
-       payload type), or each topic gets its own pipeline. Sharing works for homogeneous topics; per-topic
-       typing breaks the current `Stream<T>` shape.
-    2. `KafkaOffsetManager` is already per-topic-partition internally, but everything else in the consumer
-       treats topic as implicit. `topic` needs to be plumbed through `MessagePipeline.apply`, the in-flight
-       tracker, the metrics labels, and `processRecord`. None hard alone; the breadth bites.
-    3. Rebalance semantics worsen — `RebalanceListener` is invoked for the union of partitions across topics,
-       and partial revocations (lose 2 partitions of topic-a, keep all of topic-b) need correct routing in the
-       per-topic dispatcher.
-    4. The Testcontainers harness assumes one topic. Most existing tests need new fixtures.
-
-- **Phase 1 — homogeneous multi-topic (target 1.11.0)**
-    - API: `KPipe.json(Set.of("topic-a", "topic-b", "topic-c"))` or varargs. Single shared pipeline. All topics
-      must produce the same payload type.
-    - Covers the ~60% real-world case ("partitioned-by-region versions of the same event").
-    - Touches: `KPipeConsumer.subscribe`, `KafkaOffsetManager` plumbing review, facade signature additions,
-      metrics topic-label propagation, Testcontainers fixture for multi-topic.
-    - Effort: ~3 days.
-
-- **Phase 2 — per-topic dispatch (target 1.13.0 or later, defer if Phase 1 covers demand)**
-    - API: `KPipe.multi().on("topic-a", jsonStream).on("topic-b", avroStream).build()`. Different payload
-      types per topic, separate pipelines.
-    - Requires a new facade entry point and a routing layer on top of the consumer poll loop.
-    - Effort: ~5–7 days, mostly facade redesign.
-
-- **Trap to avoid:** don't try to land both phases in one release. Ship Phase 1 standalone, gather feedback,
-  decide if Phase 2 is needed at all.
+- **Homogeneous (Phase 1):** `KPipe.json/avro/protobuf/bytes/custom(Collection<String>, Properties)` overloads
+  and `KPipeConsumer.Builder.withTopics(Collection<String>)` + `withTopics(String...)`. One pipeline, N
+  topics, same payload type.
+- **Heterogeneous (Phase 2):** `KPipe.multi(props).json(topic, configurator).avro(...).bytes(...).start()`.
+  Per-topic pipelines through one consumer / one offset manager / one consumer-group; `KPipeConsumer`
+  dispatches by `record.topic()`. Unrouted topics drop+log at WARNING and commit (no infinite retry on
+  config error).
+- **Coverage:** `KPipeFacadeIntegrationTest.endToEndMultiTopicJsonStream` (homogeneous, 3 topics) and
+  `endToEndHeterogeneousMulti` (JSON + bytes through one consumer).
 
 ### P1 #2 — Java baseline decision (THINKING)
 

--- a/README.md
+++ b/README.md
@@ -172,7 +172,36 @@ auto-complete after `.` shows you everything you need):
 The terminal `Sink<T>.start()` returns a `Handle` exposing `isHealthy()`, `metrics()`, `awaitShutdown(Duration)`,
 `shutdownGracefully(Duration)`, and `close()`.
 
-### 4. Common operator patterns
+### 4. Consuming from multiple topics
+
+Two flavors, depending on whether the topics share a payload type.
+
+**Homogeneous** — many topics, one shared pipeline (the "partitioned-by-region versions of the same event" case):
+
+```java
+KPipe.json(Set.of("events-us", "events-eu", "events-ap"), kafkaProps)
+    .pipe(addTimestamp)
+    .toCustom(captureSink)
+    .start();
+```
+
+The `Collection<String>` overload exists on every entry point — `KPipe.json/avro/protobuf/bytes/custom`.
+
+**Heterogeneous** — many topics, each with its own payload type and its own pipeline, all dispatched through one
+consumer / one consumer-group / one offset manager:
+
+```java
+KPipe.multi(kafkaProps)
+    .json("events-json",  s -> s.pipe(addTimestamp).toCustom(jsonSink))
+    .avro("events-avro",  s -> s.filter(active).toCustom(avroSink))
+    .bytes("events-raw",  s -> s.toCustom(rawSink))
+    .start();
+```
+
+Each route gets its own typed `Stream<T>`. Records arriving for topics not registered with a route are dropped at
+`WARNING` and their offsets are still committed (no infinite retry on a config error).
+
+### 5. Common operator patterns
 
 `org.kpipe.registry.Operators` exposes pure-function helpers ready to drop into `.pipe(...)`:
 
@@ -210,22 +239,74 @@ pipelines.**
 
 ---
 
-## Why Not Just Use Kafka Streams?
-
-Kafka Streams is powerful but introduces a full topology framework and state management layer that many services do not
-need.
+## Why Not Just Use Kafka Streams (or Spring Kafka)?
 
 KPipe focuses on **code-first pipelines with minimal infrastructure overhead.**
 
-| Capability                       | Kafka Streams | Reactor Kafka | KPipe |
-| -------------------------------- | ------------- | ------------- | ----- |
-| Full stream processing framework | Yes           | No            | No    |
-| Lightweight consumer pipelines   | Partial       | Yes           | Yes   |
-| Virtual-thread friendly          | No            | No            | Yes   |
-| Functional pipeline API          | Yes           | Yes           | Yes   |
-| Minimal dependencies             | No            | Yes           | Yes   |
+| Capability                       | Kafka Streams | Spring Kafka            | Reactor Kafka | KPipe |
+| -------------------------------- | ------------- | ----------------------- | ------------- | ----- |
+| Full stream processing framework | Yes           | No                      | No            | No    |
+| Lightweight consumer pipelines   | Partial       | Yes                     | Yes           | Yes   |
+| Virtual-thread friendly          | No            | Listener-container only | No            | Yes   |
+| Functional pipeline API          | Yes           | No (annotations)        | Yes           | Yes   |
+| Minimal runtime dependencies     | No            | No (Spring Boot)        | Yes           | Yes   |
+| JPMS modules (no Spring context) | No            | No                      | Partial       | Yes   |
+| Native multi-topic dispatch      | Yes (DSL)     | Per `@KafkaListener`    | Manual        | Yes   |
 
 KPipe sits between **raw KafkaConsumer code and full streaming frameworks.**
+
+### Coming from Spring Kafka?
+
+Spring Kafka covers the same niche — "I want a Kafka consumer with retries, DLQ, backpressure, and a typed payload" —
+but bundles Spring Boot, the application context, and annotation-driven wiring. KPipe targets the same workload with no
+Spring runtime, no annotation processor, no `KafkaListenerContainerFactory` to configure, and a fluent API that's
+discoverable via IDE autocomplete.
+
+What you get back when you switch:
+
+- **No Spring Boot in your classpath.** KPipe runs on plain `java -jar`. The whole library is ~8 JPMS modules with no
+  reflection, no AOP, no context lifecycle.
+- **Virtual threads by default.** Spring Kafka's listener container is still thread-pool-per-partition; KPipe is
+  thread-per-record on virtual threads. I/O-bound enrichment scales to 10k+ in-flight messages without thread pool
+  tuning.
+- **No `@KafkaListener` magic.** Pipelines are values: build them in `main`, branch them, hand them around. No classpath
+  scanning surprises, no proxied beans, no `@EnableKafka` toggle.
+- **Per-topic typing without a class per listener.** `KPipe.multi(props).json("a", ...).avro("b", ...)` registers
+  heterogeneous routes through a single consumer-group / single offset manager. Spring's equivalent is one
+  `@KafkaListener` method per topic with separate container instances.
+- **Errors throw, not get swallowed.** `MessagePipeline.apply()` throws on failure; `null` means "intentionally
+  filtered" and nothing else. Spring Kafka's default `ErrorHandlingDeserializer` + `RetryableTopic` chain is more
+  flexible but easier to misconfigure into silent drops.
+- **Bring your own SDK.** Metrics ship as interfaces (`ProducerMetrics`, `ConsumerMetrics`) with a separate
+  `kpipe-metrics-otel` adapter. No `MeterRegistry` autowiring needed.
+
+Rough migration sketch — a Spring Kafka listener:
+
+```java
+// Spring Kafka
+@KafkaListener(topics = "events", groupId = "my-app")
+public void onMessage(ConsumerRecord<String, Map<String, Object>> rec) {
+  rec.value().put("ts", System.currentTimeMillis());
+  sink.accept(rec.value());
+}
+```
+
+becomes:
+
+```java
+// KPipe
+KPipe.json("events", kafkaProps)
+    .pipe(msg -> { msg.put("ts", System.currentTimeMillis()); return msg; })
+    .toCustom(sink::accept)
+    .start();
+```
+
+Retry, DLQ, backpressure, and graceful shutdown are fluent calls on the same `Stream<T>` — no `RetryTemplate`, no
+`DeadLetterPublishingRecoverer`, no `ContainerProperties.AckMode` to pick.
+
+KPipe will **not** replace Spring Kafka if you depend on `@KafkaListener` lifecycle integration with Spring Boot
+actuator, transactional Kafka producers wired into `@Transactional`, or the broader Spring ecosystem (security,
+config-server, sleuth tracing). Those are reasons to stay.
 
 ---
 

--- a/examples/demo/build.gradle.kts
+++ b/examples/demo/build.gradle.kts
@@ -11,6 +11,8 @@ tasks.named<ShadowJar>("shadowJar") {
 description = "KPipe - Demo Application Combining JSON, Avro, and Protobuf Pipelines"
 
 dependencies {
+  implementation(project(":lib:kpipe-api"))
+  implementation(project(":lib:kpipe-consumer"))
   implementation(project(":lib:kpipe-format-json"))
   implementation(project(":lib:kpipe-format-avro"))
   implementation(project(":lib:kpipe-format-protobuf"))

--- a/examples/demo/src/main/java/org/kpipe/demo/DemoApp.java
+++ b/examples/demo/src/main/java/org/kpipe/demo/DemoApp.java
@@ -11,154 +11,91 @@ import io.opentelemetry.sdk.metrics.export.PeriodicMetricReader;
 import java.lang.System.Logger;
 import java.lang.System.Logger.Level;
 import java.time.Duration;
-import java.util.List;
-import java.util.Queue;
-import java.util.concurrent.ConcurrentLinkedQueue;
-import java.util.function.Function;
-import org.apache.kafka.clients.consumer.Consumer;
-import org.kpipe.consumer.*;
-import org.kpipe.consumer.config.AppConfig;
+import org.kpipe.Handle;
+import org.kpipe.KPipe;
 import org.kpipe.consumer.config.KafkaConsumerConfig;
-import org.kpipe.consumer.metrics.ProcessorMetricsReporter;
-import org.kpipe.consumer.metrics.SinkMetricsReporter;
 import org.kpipe.format.avro.AvroConsoleSink;
 import org.kpipe.format.avro.AvroFormat;
-import org.kpipe.format.avro.AvroRegistryKey;
 import org.kpipe.format.json.JsonConsoleSink;
-import org.kpipe.format.json.JsonFormat;
 import org.kpipe.format.protobuf.ProtobufConsoleSink;
 import org.kpipe.format.protobuf.ProtobufFormat;
-import org.kpipe.format.protobuf.ProtobufRegistryKey;
-import org.kpipe.metrics.ConsumerMetricsReporter;
 import org.kpipe.metrics.otel.OtelConsumerMetrics;
-import org.kpipe.registry.MessagePipeline;
-import org.kpipe.registry.MessageProcessorRegistry;
 import org.kpipe.registry.Operators;
-import org.kpipe.registry.RegistryKey;
 
-/// Demo application that runs JSON, Avro, and Protobuf consumer pipelines concurrently.
+/// Demo application that consumes JSON, Avro, and Protobuf payloads through a single
+/// `KPipe.multi(...)` consumer. One Kafka consumer-group, one offset manager, three typed
+/// pipelines dispatched by `record.topic()`. OpenTelemetry metrics carry a `topic` attribute so
+/// the Grafana dashboards can break down by topic across the heterogeneous routes.
 public class DemoApp implements AutoCloseable {
 
   private static final Logger LOGGER = System.getLogger(DemoApp.class.getName());
   private static final String TEST_AVRO_SCHEMA_PATH = "build/resources/test/avro/customer.avsc";
-
-  private final KPipeRunner<KPipeConsumer<byte[]>> jsonRunner;
-  private final KPipeRunner<KPipeConsumer<byte[]>> avroRunner;
-  private final KPipeRunner<KPipeConsumer<byte[]>> protoRunner;
-
-  /// Main entry point.
-  /// Shared OpenTelemetry instance for the demo app (initialized in main)
   private static OpenTelemetry SHARED_OTEL;
+
+  private final Handle handle;
 
   static void main() {
     final var config = DemoConfig.fromEnv();
 
-    // Initialize OpenTelemetry SDK so ConsumerMetrics send to the collector.
     try {
       SHARED_OTEL = initOpenTelemetry();
     } catch (final Exception e) {
-      LOGGER.log(
-        Level.WARNING,
-        "Failed to initialize OpenTelemetry, falling back to GlobalOpenTelemetry: {0}",
-        e.getMessage()
-      );
+      LOGGER.log(Level.WARNING, "OTel SDK init failed; falling back to GlobalOpenTelemetry: {0}", e.getMessage());
       SHARED_OTEL = GlobalOpenTelemetry.get();
     }
 
     try (final var app = new DemoApp(config)) {
-      app.start();
-      LOGGER.log(Level.INFO, "Demo application started — JSON, Avro, and Protobuf pipelines running");
-      // Block on the JSON runner (all three run concurrently)
-      app.jsonRunner.awaitShutdown();
+      LOGGER.log(Level.INFO, "Demo application started — JSON/Avro/Protobuf routes via KPipe.multi");
+      app.handle.awaitShutdown();
     } catch (final Exception e) {
       LOGGER.log(Level.ERROR, "Fatal error in demo application", e);
       System.exit(1);
     }
   }
 
-  /// Creates the demo application with all three pipelines.
+  /// Creates and starts the demo application with all three routes attached to a single consumer.
   public DemoApp(final DemoConfig config) {
-    jsonRunner = buildJsonPipeline(config);
-    avroRunner = buildAvroPipeline(config);
-    protoRunner = buildProtobufPipeline(config);
-  }
+    registerAvroSchema(config);
+    ProtobufFormat.INSTANCE.addDescriptor("customer", buildCustomerDescriptor());
+    ProtobufFormat.INSTANCE.withDefaultDescriptor("customer");
 
-  void start() {
-    jsonRunner.start();
-    avroRunner.start();
-    protoRunner.start();
+    final var kafkaProps = KafkaConsumerConfig.createConsumerConfig(
+      config.bootstrapServers(),
+      config.consumerGroup() + "-multi"
+    );
+    final var otel = SHARED_OTEL != null ? SHARED_OTEL : GlobalOpenTelemetry.get();
+
+    handle = KPipe.multi(kafkaProps)
+      .withMetrics(new OtelConsumerMetrics(otel, "demo-multi"))
+      .json(config.jsonTopic(), s ->
+        s
+          .pipe(Operators.addField("source", "demo-app"))
+          .pipe(Operators.addField("status", "processed"))
+          .pipe(Operators.addField("processedAt", System.currentTimeMillis()))
+          .pipe(Operators.removeFields("password", "ssn"))
+          .toCustom(new JsonConsoleSink<>())
+      )
+      .avro(config.avroTopic(), s -> s.skipBytes(5).toCustom(new AvroConsoleSink<>()))
+      .protobuf(config.protoTopic(), s -> s.skipBytes(6).toCustom(new ProtobufConsoleSink<>()))
+      .start();
   }
 
   @Override
   public void close() {
-    jsonRunner.close();
-    avroRunner.close();
-    protoRunner.close();
+    handle.close();
   }
 
-  /// ── JSON pipeline ──────────────────────────────────────────────────────
-
-  private static KPipeRunner<KPipeConsumer<byte[]>> buildJsonPipeline(final DemoConfig config) {
-    final var registry = new MessageProcessorRegistry(JsonFormat.INSTANCE);
-    final var sinkRegistry = registry.sinkRegistry();
-    sinkRegistry.register(RegistryKey.json("jsonLogging"), new JsonConsoleSink<>());
-
-    // Register demo processors
-    registry.register(RegistryKey.json("addSource"), msg -> {
-      msg.put("source", "demo-app");
-      return msg;
-    });
-    registry.register(RegistryKey.json("markProcessed"), msg -> {
-      msg.put("status", "processed");
-      return msg;
-    });
-    registry.register(RegistryKey.json("addTimestamp"), msg -> {
-      msg.put("processedAt", System.currentTimeMillis());
-      return msg;
-    });
-    registry.register(RegistryKey.json("removeSecrets"), Operators.removeFields("password", "ssn"));
-
-    final var pipeline = registry.pipeline(JsonFormat.INSTANCE);
-    pipeline.add(RegistryKey.json("addSource"));
-    pipeline.add(RegistryKey.json("markProcessed"));
-    pipeline.add(RegistryKey.json("addTimestamp"));
-    pipeline.add(RegistryKey.json("removeSecrets"));
-    pipeline.toSink(RegistryKey.json("jsonLogging"));
-
-    final var appConfig = toAppConfig(
-      config,
-      config.jsonTopic(),
-      "demo-json",
-      List.of("addSource", "markProcessed", "addTimestamp", "removeSecrets")
-    );
-    final var consumer = buildConsumer(appConfig, pipeline.build(), "json");
-    return buildRunner(appConfig, consumer, registry);
-  }
-
-  /// ── Avro pipeline ─────────────────────────────────────────────────────
-
-  private static KPipeRunner<KPipeConsumer<byte[]>> buildAvroPipeline(final DemoConfig config) {
-    final var registry = new MessageProcessorRegistry(AvroFormat.INSTANCE);
-    final var sinkRegistry = registry.sinkRegistry();
-    sinkRegistry.register(AvroRegistryKey.of("avroLogging"), new AvroConsoleSink<>());
-
-    final var avroFormat = AvroFormat.INSTANCE;
-    final String avroSchemaLocation = isTestMode()
+  /// In production the Avro schema is fetched from the Confluent Schema Registry; in tests
+  /// (`kpipe.test.mode=true`) it loads from a local file to avoid a Schema Registry dependency
+  /// in CI.
+  private static void registerAvroSchema(final DemoConfig config) {
+    final var location = isTestMode()
       ? TEST_AVRO_SCHEMA_PATH
       : config.schemaRegistryUrl() + "/subjects/com.kpipe.customer/versions/latest";
-    avroFormat.addSchema("1", "com.kpipe.customer", avroSchemaLocation);
-    avroFormat.withDefaultSchema("1");
-
-    final var pipeline = registry.pipeline(avroFormat);
-    pipeline.skipBytes(5); // Skip Confluent Schema Registry wire-format prefix
-    pipeline.toSink(AvroRegistryKey.of("avroLogging"));
-
-    final var appConfig = toAppConfig(config, config.avroTopic(), "demo-avro", List.of());
-    final var consumer = buildConsumer(appConfig, pipeline.build(), "avro");
-    return buildRunner(appConfig, consumer, registry);
+    AvroFormat.INSTANCE.addSchema("1", "com.kpipe.customer", location);
+    AvroFormat.INSTANCE.withDefaultSchema("1");
   }
 
-  /** Returns true if running in test mode (system property or env var set to "true"). */
   private static boolean isTestMode() {
     return (
       "true".equalsIgnoreCase(System.getProperty("kpipe.test.mode")) ||
@@ -166,70 +103,15 @@ public class DemoApp implements AutoCloseable {
     );
   }
 
-  /// ── Protobuf pipeline ─────────────────────────────────────────────────
-  private static KPipeRunner<KPipeConsumer<byte[]>> buildProtobufPipeline(final DemoConfig config) {
-    final var registry = new MessageProcessorRegistry(ProtobufFormat.INSTANCE);
-    final var sinkRegistry = registry.sinkRegistry();
-    sinkRegistry.register(ProtobufRegistryKey.of("protobufLogging"), new ProtobufConsoleSink<>());
-
-    final var protoFormat = ProtobufFormat.INSTANCE;
-    protoFormat.addDescriptor("customer", buildCustomerDescriptor());
-    protoFormat.withDefaultDescriptor("customer");
-
-    final var pipeline = registry.pipeline(protoFormat);
-    // Confluent protobuf wire format: 1 magic byte + 4-byte schema ID + varint message index.
-    // For a single top-level message type, the index is one zero byte → 6 total.
-    pipeline.skipBytes(6);
-    pipeline.toSink(ProtobufRegistryKey.of("protobufLogging"));
-
-    final var appConfig = toAppConfig(config, config.protoTopic(), "demo-protobuf", List.of());
-    final var consumer = buildConsumer(appConfig, pipeline.build(), "proto");
-    return buildRunner(appConfig, consumer, registry);
-  }
-
-  /// ── Shared helpers ────────────────────────────────────────────────────
-
-  private static KPipeConsumer<byte[]> buildConsumer(
-    final AppConfig appConfig,
-    final MessagePipeline<?> pipeline,
-    final String pipelineLabel
-  ) {
-    final var kafkaProps = KafkaConsumerConfig.createConsumerConfig(
-      appConfig.bootstrapServers(),
-      appConfig.consumerGroup()
-    );
-    final Queue<ConsumerCommand> commandQueue = new ConcurrentLinkedQueue<>();
-    final var otel = SHARED_OTEL != null ? SHARED_OTEL : GlobalOpenTelemetry.get();
-
-    return KPipeConsumer.<byte[]>builder()
-      .withProperties(kafkaProps)
-      .withTopic(appConfig.topic())
-      .withPipeline(pipeline)
-      .withPollTimeout(appConfig.pollTimeout())
-      .withCommandQueue(commandQueue)
-      .withOffsetManagerProvider(createOffsetManagerProvider(Duration.ofSeconds(30), commandQueue))
-      .withMetrics(new OtelConsumerMetrics(otel, pipelineLabel))
-      .enableMetrics(true)
-      .build();
-  }
-
-  ///
-  /// Initialize a simple OpenTelemetry SDK that exports metrics via OTLP/gRPC to the collector.
-  /// Reads endpoint from OTEL_EXPORTER_OTLP_ENDPOINT env var (defaults to
-  /// "http://otel-collector:4317").
-  ///
+  /// Initialises an OTLP/gRPC OpenTelemetry SDK pointed at the demo's collector. Reads
+  /// `OTEL_EXPORTER_OTLP_ENDPOINT` (default `http://otel-collector:4317`).
   private static OpenTelemetry initOpenTelemetry() {
     final var endpoint = System.getenv().getOrDefault("OTEL_EXPORTER_OTLP_ENDPOINT", "http://otel-collector:4317");
-
-    // Use the gRPC exporter (collector is configured to listen on 4317 for gRPC).
-    final var metricExporter = OtlpGrpcMetricExporter.builder().setEndpoint(endpoint).build();
-    // Export every 10s so Grafana's [30s] rate window always sees fresh data points.
-    final var reader = PeriodicMetricReader.builder(metricExporter).setInterval(Duration.ofSeconds(10)).build();
+    final var exporter = OtlpGrpcMetricExporter.builder().setEndpoint(endpoint).build();
+    final var reader = PeriodicMetricReader.builder(exporter).setInterval(Duration.ofSeconds(10)).build();
     final var meterProvider = SdkMeterProvider.builder().registerMetricReader(reader).build();
-
     final var sdk = OpenTelemetrySdk.builder().setMeterProvider(meterProvider).buildAndRegisterGlobal();
 
-    // Ensure SDK is shutdown on JVM exit to flush metrics
     Runtime.getRuntime().addShutdownHook(
       new Thread(() -> {
         try {
@@ -237,57 +119,7 @@ public class DemoApp implements AutoCloseable {
         } catch (final Exception ignored) {}
       })
     );
-
     return sdk;
-  }
-
-  private static KPipeRunner<KPipeConsumer<byte[]>> buildRunner(
-    final AppConfig appConfig,
-    final KPipeConsumer<byte[]> consumer,
-    final MessageProcessorRegistry registry
-  ) {
-    final var consumerMetrics = ConsumerMetricsReporter.forConsumer(consumer::getMetrics);
-    final var processorMetrics = ProcessorMetricsReporter.forRegistry(registry);
-    final var sinkMetrics = SinkMetricsReporter.forRegistry(registry.sinkRegistry());
-
-    return KPipeRunner.builder(consumer)
-      .withStartAction(c -> {
-        c.start();
-        LOGGER.log(Level.INFO, "Pipeline started for topic: {0}", appConfig.topic());
-      })
-      .withHealthCheck(KPipeConsumer::isRunning)
-      .withGracefulShutdown(KPipeRunner::performGracefulConsumerShutdown)
-      .withMetricsReporters(List.of(consumerMetrics, processorMetrics, sinkMetrics))
-      .withMetricsInterval(appConfig.metricsInterval().toMillis())
-      .withShutdownTimeout(appConfig.shutdownTimeout().toMillis())
-      .withShutdownHook(true)
-      .build();
-  }
-
-  private static Function<Consumer<byte[], byte[]>, OffsetManager<byte[]>> createOffsetManagerProvider(
-    final Duration commitInterval,
-    final Queue<ConsumerCommand> commandQueue
-  ) {
-    return consumer ->
-      KafkaOffsetManager.builder(consumer).withCommandQueue(commandQueue).withCommitInterval(commitInterval).build();
-  }
-
-  private static AppConfig toAppConfig(
-    final DemoConfig config,
-    final String topic,
-    final String appName,
-    final List<String> processors
-  ) {
-    return new AppConfig(
-      config.bootstrapServers(),
-      config.consumerGroup() + "-" + appName,
-      topic,
-      appName,
-      config.pollTimeout(),
-      config.shutdownTimeout(),
-      config.metricsInterval(),
-      processors
-    );
   }
 
   static Descriptors.Descriptor buildCustomerDescriptor() {

--- a/examples/demo/src/test/java/org/kpipe/demo/DemoAppIntegrationTest.java
+++ b/examples/demo/src/test/java/org/kpipe/demo/DemoAppIntegrationTest.java
@@ -2,8 +2,6 @@ package org.kpipe.demo;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-import java.lang.System.Logger;
-import java.lang.System.Logger.Level;
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.util.concurrent.TimeUnit;
@@ -19,7 +17,6 @@ import org.testcontainers.utility.DockerImageName;
 @Testcontainers
 class DemoAppIntegrationTest {
 
-  private static final Logger log = System.getLogger(DemoAppIntegrationTest.class.getName());
   private static final String CONFLUENT_PLATFORM_VERSION = System.getProperty("confluentPlatformVersion", "8.2.0");
 
   @Container
@@ -42,18 +39,11 @@ class DemoAppIntegrationTest {
       Duration.ofSeconds(60)
     );
 
-    // We test the JSON pipeline only (Avro/Protobuf require Schema Registry)
+    // We test the JSON pipeline only (Avro/Protobuf require Schema Registry).
+    // KPipe.multi(...).start() runs in the constructor; nothing further to invoke.
     try (final var app = new DemoApp(config)) {
-      // Start in a virtual thread
-      final var appThread = Thread.ofVirtual().start(() -> {
-        try {
-          app.start();
-        } catch (final Exception e) {
-          log.log(Level.ERROR, "App error", e);
-        }
-      });
+      final var appThread = Thread.ofVirtual().start(() -> {});
 
-      // Allow time for consumer to subscribe
       TimeUnit.SECONDS.sleep(3);
 
       // Produce a JSON message

--- a/lib/kpipe-api/src/main/java/org/kpipe/DefaultHandle.java
+++ b/lib/kpipe-api/src/main/java/org/kpipe/DefaultHandle.java
@@ -34,6 +34,11 @@ final class DefaultHandle implements Handle {
   }
 
   @Override
+  public void awaitShutdown() throws InterruptedException {
+    runner.awaitShutdown();
+  }
+
+  @Override
   public boolean shutdownGracefully(final Duration timeout) {
     Objects.requireNonNull(timeout, "timeout cannot be null");
     return runner.shutdownGracefully(timeout.toMillis());

--- a/lib/kpipe-api/src/main/java/org/kpipe/DefaultSink.java
+++ b/lib/kpipe-api/src/main/java/org/kpipe/DefaultSink.java
@@ -3,6 +3,7 @@ package org.kpipe;
 import java.util.Objects;
 import org.kpipe.consumer.KPipeConsumer;
 import org.kpipe.consumer.KPipeRunner;
+import org.kpipe.registry.MessagePipeline;
 import org.kpipe.registry.MessageProcessorRegistry;
 import org.kpipe.sink.MessageSink;
 
@@ -18,15 +19,10 @@ record DefaultSink<T>(DefaultStream<T> stream, MessageSink<T> terminalSink) impl
 
   @Override
   public Handle start() {
-    final var registry = new MessageProcessorRegistry(stream.format());
-    final var pipelineBuilder = registry.pipeline(stream.format());
-    for (final var op : stream.operators()) pipelineBuilder.add(op);
-    final var pipeline = pipelineBuilder.toSink(terminalSink).build();
-
     final var consumerBuilder = KPipeConsumer.<byte[]>builder()
       .withProperties(stream.kafkaProps())
-      .withTopic(stream.topic())
-      .withPipeline(pipeline)
+      .withTopics(stream.topics())
+      .withPipeline(buildPipeline())
       .withSequentialProcessing(stream.sequentialProcessing());
 
     if (stream.maxRetries() > 0) consumerBuilder.withRetry(stream.maxRetries(), stream.retryBackoff());
@@ -40,9 +36,8 @@ record DefaultSink<T>(DefaultStream<T> stream, MessageSink<T> terminalSink) impl
     try {
       runner.start();
     } catch (final RuntimeException e) {
-      // Start failed (broker unreachable, missing topic, etc.) — release the consumer so we
-      // don't leak the partially-built pipeline. Without this, the AutoCloseable contract on
-      // Handle is unreachable because no Handle was ever returned.
+      // Releasing the consumer here keeps the AutoCloseable contract reachable when start() throws
+      // before a Handle is returned.
       try {
         consumer.close();
       } catch (final Exception suppressed) {
@@ -51,6 +46,15 @@ record DefaultSink<T>(DefaultStream<T> stream, MessageSink<T> terminalSink) impl
       throw e;
     }
     return new DefaultHandle(runner, consumer);
+  }
+
+  /// Builds the [MessagePipeline] for this sink's stream + terminal sink. Reused by
+  /// [MultiBuilder] when assembling a per-topic pipeline map.
+  MessagePipeline<?> buildPipeline() {
+    final var registry = new MessageProcessorRegistry(stream.format());
+    final var pipelineBuilder = registry.pipeline(stream.format()).skipBytes(stream.skipBytes());
+    for (final var op : stream.operators()) pipelineBuilder.add(op);
+    return pipelineBuilder.toSink(terminalSink).build();
   }
 
   /// Exposes the configured stream for test inspection of composition.

--- a/lib/kpipe-api/src/main/java/org/kpipe/DefaultStream.java
+++ b/lib/kpipe-api/src/main/java/org/kpipe/DefaultStream.java
@@ -2,9 +2,12 @@ package org.kpipe;
 
 import java.time.Duration;
 import java.util.ArrayList;
+import java.util.Collection;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Objects;
 import java.util.Properties;
+import java.util.Set;
 import java.util.function.Consumer;
 import java.util.function.Predicate;
 import java.util.function.Supplier;
@@ -25,7 +28,7 @@ import org.kpipe.sink.MessageSink;
 /// @param <T> the deserialized message type
 final class DefaultStream<T> implements Stream<T> {
 
-  private final String topic;
+  private final Set<String> topics;
   private final Properties kafkaProps;
   private final MessageFormat<T> format;
   private final Supplier<MessageSink<T>> defaultConsoleSinkFactory;
@@ -35,20 +38,32 @@ final class DefaultStream<T> implements Stream<T> {
   private final Long backpressureHigh;
   private final Long backpressureLow;
   private final boolean sequentialProcessing;
+  private final int skipBytes;
 
-  /// Public constructor used by [KPipe] factories — starts with an empty pipeline and default
+  /// Public constructor used by [KPipe] factories — single topic, empty pipeline, default
   /// retry / backpressure settings.
-  ///
-  /// Defensively copies `kafkaProps` so that subsequent caller mutations do not silently affect
-  /// the in-flight stream.
   DefaultStream(
     final String topic,
     final Properties kafkaProps,
     final MessageFormat<T> format,
     final Supplier<MessageSink<T>> defaultConsoleSinkFactory
   ) {
+    this(Set.of(Objects.requireNonNull(topic, "topic cannot be null")), kafkaProps, format, defaultConsoleSinkFactory);
+  }
+
+  /// Public constructor used by [KPipe] factories — multiple topics, single shared pipeline,
+  /// empty operator chain, default retry / backpressure settings.
+  ///
+  /// Defensively copies `kafkaProps` so that subsequent caller mutations do not silently affect
+  /// the in-flight stream. Defensively copies `topics` into an immutable insertion-ordered set.
+  DefaultStream(
+    final Collection<String> topics,
+    final Properties kafkaProps,
+    final MessageFormat<T> format,
+    final Supplier<MessageSink<T>> defaultConsoleSinkFactory
+  ) {
     this(
-      Objects.requireNonNull(topic, "topic cannot be null"),
+      validateTopics(topics),
       (Properties) Objects.requireNonNull(kafkaProps, "kafkaProps cannot be null").clone(),
       Objects.requireNonNull(format, "format cannot be null"),
       Objects.requireNonNull(defaultConsoleSinkFactory, "defaultConsoleSinkFactory cannot be null"),
@@ -57,12 +72,24 @@ final class DefaultStream<T> implements Stream<T> {
       Duration.ofMillis(500),
       null,
       null,
-      false
+      false,
+      0
     );
   }
 
+  private static Set<String> validateTopics(final Collection<String> topics) {
+    Objects.requireNonNull(topics, "topics cannot be null");
+    if (topics.isEmpty()) throw new IllegalArgumentException("topics cannot be empty");
+    final var copy = new LinkedHashSet<String>(topics.size());
+    for (final var t : topics) {
+      if (t == null || t.isBlank()) throw new IllegalArgumentException("topic name cannot be null or blank");
+      copy.add(t);
+    }
+    return Set.copyOf(copy);
+  }
+
   private DefaultStream(
-    final String topic,
+    final Set<String> topics,
     final Properties kafkaProps,
     final MessageFormat<T> format,
     final Supplier<MessageSink<T>> defaultConsoleSinkFactory,
@@ -71,9 +98,10 @@ final class DefaultStream<T> implements Stream<T> {
     final Duration retryBackoff,
     final Long backpressureHigh,
     final Long backpressureLow,
-    final boolean sequentialProcessing
+    final boolean sequentialProcessing,
+    final int skipBytes
   ) {
-    this.topic = topic;
+    this.topics = topics;
     this.kafkaProps = kafkaProps;
     this.format = format;
     this.defaultConsoleSinkFactory = defaultConsoleSinkFactory;
@@ -83,13 +111,14 @@ final class DefaultStream<T> implements Stream<T> {
     this.backpressureHigh = backpressureHigh;
     this.backpressureLow = backpressureLow;
     this.sequentialProcessing = sequentialProcessing;
+    this.skipBytes = skipBytes;
   }
 
   private DefaultStream<T> withOperator(final UnaryOperator<T> op) {
     final var next = new ArrayList<>(operators);
     next.add(op);
     return new DefaultStream<>(
-      topic,
+      topics,
       kafkaProps,
       format,
       defaultConsoleSinkFactory,
@@ -98,7 +127,8 @@ final class DefaultStream<T> implements Stream<T> {
       retryBackoff,
       backpressureHigh,
       backpressureLow,
-      sequentialProcessing
+      sequentialProcessing,
+      skipBytes
     );
   }
 
@@ -131,7 +161,7 @@ final class DefaultStream<T> implements Stream<T> {
   public Stream<T> withRetry(final int maxRetries, final Duration backoff) {
     if (maxRetries < 0) throw new IllegalArgumentException("maxRetries cannot be negative");
     return new DefaultStream<>(
-      topic,
+      topics,
       kafkaProps,
       format,
       defaultConsoleSinkFactory,
@@ -140,7 +170,8 @@ final class DefaultStream<T> implements Stream<T> {
       Objects.requireNonNull(backoff, "backoff cannot be null"),
       backpressureHigh,
       backpressureLow,
-      sequentialProcessing
+      sequentialProcessing,
+      skipBytes
     );
   }
 
@@ -155,7 +186,7 @@ final class DefaultStream<T> implements Stream<T> {
       "Invalid watermarks: high must be positive and > low (got high=%d, low=%d)".formatted(high, low)
     );
     return new DefaultStream<>(
-      topic,
+      topics,
       kafkaProps,
       format,
       defaultConsoleSinkFactory,
@@ -164,14 +195,15 @@ final class DefaultStream<T> implements Stream<T> {
       retryBackoff,
       high,
       low,
-      sequentialProcessing
+      sequentialProcessing,
+      skipBytes
     );
   }
 
   @Override
   public Stream<T> withSequentialProcessing(final boolean sequential) {
     return new DefaultStream<>(
-      topic,
+      topics,
       kafkaProps,
       format,
       defaultConsoleSinkFactory,
@@ -180,7 +212,26 @@ final class DefaultStream<T> implements Stream<T> {
       retryBackoff,
       backpressureHigh,
       backpressureLow,
-      sequential
+      sequential,
+      skipBytes
+    );
+  }
+
+  @Override
+  public Stream<T> skipBytes(final int n) {
+    if (n < 0) throw new IllegalArgumentException("n cannot be negative");
+    return new DefaultStream<>(
+      topics,
+      kafkaProps,
+      format,
+      defaultConsoleSinkFactory,
+      operators,
+      maxRetries,
+      retryBackoff,
+      backpressureHigh,
+      backpressureLow,
+      sequentialProcessing,
+      n
     );
   }
 
@@ -203,8 +254,8 @@ final class DefaultStream<T> implements Stream<T> {
     return new DefaultSink<>(this, new CompositeMessageSink<>(List.of(sinks)));
   }
 
-  String topic() {
-    return topic;
+  Set<String> topics() {
+    return topics;
   }
 
   Properties kafkaProps() {
@@ -237,5 +288,9 @@ final class DefaultStream<T> implements Stream<T> {
 
   boolean sequentialProcessing() {
     return sequentialProcessing;
+  }
+
+  int skipBytes() {
+    return skipBytes;
   }
 }

--- a/lib/kpipe-api/src/main/java/org/kpipe/Handle.java
+++ b/lib/kpipe-api/src/main/java/org/kpipe/Handle.java
@@ -27,6 +27,12 @@ public interface Handle extends AutoCloseable {
   /// @return true if shutdown completed within the timeout
   boolean awaitShutdown(final Duration timeout);
 
+  /// Blocks indefinitely until the consumer shuts down (typically via SIGTERM / SIGINT through
+  /// the runner's shutdown hook). Returns when shutdown completes.
+  ///
+  /// @throws InterruptedException if the calling thread is interrupted while waiting
+  void awaitShutdown() throws InterruptedException;
+
   /// Initiates a graceful shutdown, waiting up to `timeout` for in-flight messages.
   ///
   /// @param timeout maximum wait for in-flight drain

--- a/lib/kpipe-api/src/main/java/org/kpipe/KPipe.java
+++ b/lib/kpipe-api/src/main/java/org/kpipe/KPipe.java
@@ -4,15 +4,13 @@ import com.google.protobuf.Message;
 import java.lang.System.Logger;
 import java.lang.System.Logger.Level;
 import java.nio.charset.StandardCharsets;
+import java.util.Collection;
 import java.util.HexFormat;
 import java.util.Map;
 import java.util.Properties;
 import org.apache.avro.generic.GenericRecord;
-import org.kpipe.format.avro.AvroConsoleSink;
 import org.kpipe.format.avro.AvroFormat;
-import org.kpipe.format.json.JsonConsoleSink;
 import org.kpipe.format.json.JsonFormat;
-import org.kpipe.format.protobuf.ProtobufConsoleSink;
 import org.kpipe.format.protobuf.ProtobufFormat;
 import org.kpipe.registry.MessageFormat;
 import org.kpipe.sink.MessageSink;
@@ -46,7 +44,17 @@ public final class KPipe {
   /// @param kafkaProps the Kafka consumer properties
   /// @return a fluent [Stream] configured for JSON
   public static Stream<Map<String, Object>> json(final String topic, final Properties kafkaProps) {
-    return new DefaultStream<>(topic, kafkaProps, JsonFormat.INSTANCE, () -> new JsonConsoleSink<>());
+    return new DefaultStream<>(topic, kafkaProps, JsonFormat.INSTANCE, JsonFormat::consoleSink);
+  }
+
+  /// Creates a JSON-typed stream that consumes from multiple homogeneous topics through a single
+  /// shared pipeline. All topics must produce the same payload shape.
+  ///
+  /// @param topics the Kafka topics to consume (must be non-empty)
+  /// @param kafkaProps the Kafka consumer properties
+  /// @return a fluent [Stream] configured for JSON
+  public static Stream<Map<String, Object>> json(final Collection<String> topics, final Properties kafkaProps) {
+    return new DefaultStream<>(topics, kafkaProps, JsonFormat.INSTANCE, JsonFormat::consoleSink);
   }
 
   /// Creates an Avro-typed stream that consumes from the given topic. Messages are deserialized
@@ -60,15 +68,16 @@ public final class KPipe {
   /// @param kafkaProps the Kafka consumer properties
   /// @return a fluent [Stream] configured for Avro
   public static Stream<GenericRecord> avro(final String topic, final Properties kafkaProps) {
-    return new DefaultStream<>(topic, kafkaProps, AvroFormat.INSTANCE, () -> {
-      final var schema = AvroFormat.INSTANCE.getSchema("1");
-      if (schema == null) throw new IllegalStateException(
-        "AvroFormat.toConsole() requires a default Avro schema registered under key \"1\" on " +
-          "AvroFormat.INSTANCE; register a schema (e.g. AvroFormat.INSTANCE.addSchema(\"1\", schemaJson)) " +
-          "or use toCustom(new AvroConsoleSink<>(schema))."
-      );
-      return new AvroConsoleSink<>(schema);
-    });
+    return new DefaultStream<>(topic, kafkaProps, AvroFormat.INSTANCE, AvroFormat::defaultConsoleSink);
+  }
+
+  /// Multi-topic Avro variant. See [#avro(String, Properties)] for the schema requirement.
+  ///
+  /// @param topics the Kafka topics to consume (must be non-empty)
+  /// @param kafkaProps the Kafka consumer properties
+  /// @return a fluent [Stream] configured for Avro
+  public static Stream<GenericRecord> avro(final Collection<String> topics, final Properties kafkaProps) {
+    return new DefaultStream<>(topics, kafkaProps, AvroFormat.INSTANCE, AvroFormat::defaultConsoleSink);
   }
 
   /// Creates a Protobuf-typed stream that consumes from the given topic. Messages are
@@ -78,7 +87,16 @@ public final class KPipe {
   /// @param kafkaProps the Kafka consumer properties
   /// @return a fluent [Stream] configured for Protobuf
   public static Stream<Message> protobuf(final String topic, final Properties kafkaProps) {
-    return new DefaultStream<>(topic, kafkaProps, ProtobufFormat.INSTANCE, () -> new ProtobufConsoleSink<>());
+    return new DefaultStream<>(topic, kafkaProps, ProtobufFormat.INSTANCE, ProtobufFormat::consoleSink);
+  }
+
+  /// Multi-topic Protobuf variant.
+  ///
+  /// @param topics the Kafka topics to consume (must be non-empty)
+  /// @param kafkaProps the Kafka consumer properties
+  /// @return a fluent [Stream] configured for Protobuf
+  public static Stream<Message> protobuf(final Collection<String> topics, final Properties kafkaProps) {
+    return new DefaultStream<>(topics, kafkaProps, ProtobufFormat.INSTANCE, ProtobufFormat::consoleSink);
   }
 
   /// Creates a raw `byte[]` stream — identity passthrough, no SerDe.
@@ -90,7 +108,16 @@ public final class KPipe {
   /// @param kafkaProps the Kafka consumer properties
   /// @return a fluent [Stream] for raw bytes
   public static Stream<byte[]> bytes(final String topic, final Properties kafkaProps) {
-    return new DefaultStream<>(topic, kafkaProps, MessageFormat.bytes(), () -> bytesConsoleSink());
+    return new DefaultStream<>(topic, kafkaProps, MessageFormat.bytes(), KPipe::bytesConsoleSink);
+  }
+
+  /// Multi-topic raw `byte[]` variant.
+  ///
+  /// @param topics the Kafka topics to consume (must be non-empty)
+  /// @param kafkaProps the Kafka consumer properties
+  /// @return a fluent [Stream] for raw bytes
+  public static Stream<byte[]> bytes(final Collection<String> topics, final Properties kafkaProps) {
+    return new DefaultStream<>(topics, kafkaProps, MessageFormat.bytes(), KPipe::bytesConsoleSink);
   }
 
   /// Creates a stream backed by a user-supplied [MessageFormat]. The default `toConsole()` for
@@ -104,6 +131,41 @@ public final class KPipe {
   /// @return a fluent [Stream] for the supplied format
   public static <T> Stream<T> custom(final String topic, final Properties kafkaProps, final MessageFormat<T> format) {
     return new DefaultStream<>(topic, kafkaProps, format, () -> value -> LOGGER.log(Level.INFO, "{0}", value));
+  }
+
+  /// Multi-topic custom-format variant.
+  ///
+  /// @param topics the Kafka topics to consume (must be non-empty)
+  /// @param kafkaProps the Kafka consumer properties
+  /// @param format the message format
+  /// @param <T> the deserialized message type
+  /// @return a fluent [Stream] for the supplied format
+  public static <T> Stream<T> custom(
+    final Collection<String> topics,
+    final Properties kafkaProps,
+    final MessageFormat<T> format
+  ) {
+    return new DefaultStream<>(topics, kafkaProps, format, () -> value -> LOGGER.log(Level.INFO, "{0}", value));
+  }
+
+  /// Creates a heterogeneous multi-topic builder. Each route registers a per-topic pipeline,
+  /// so different topics can carry different payload shapes through one consumer-group / one
+  /// offset manager.
+  ///
+  /// Records arriving for unrouted topics are dropped at WARNING and their offsets are still
+  /// committed.
+  ///
+  /// ```java
+  /// KPipe.multi(props)
+  ///     .json("events-json", s -> s.pipe(addTimestamp).toCustom(jsonSink))
+  ///     .avro("events-avro", s -> s.filter(active).toCustom(avroSink))
+  ///     .start();
+  /// ```
+  ///
+  /// @param kafkaProps the Kafka consumer properties
+  /// @return a fluent [MultiBuilder]
+  public static MultiBuilder multi(final Properties kafkaProps) {
+    return new MultiBuilder(kafkaProps);
   }
 
   /// Returns a [MessageSink] that prints `byte[]` values as either UTF-8 (when the payload looks

--- a/lib/kpipe-api/src/main/java/org/kpipe/MultiBuilder.java
+++ b/lib/kpipe-api/src/main/java/org/kpipe/MultiBuilder.java
@@ -1,0 +1,177 @@
+package org.kpipe;
+
+import com.google.protobuf.Message;
+import java.lang.System.Logger;
+import java.lang.System.Logger.Level;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Properties;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.function.Supplier;
+import org.apache.avro.generic.GenericRecord;
+import org.kpipe.consumer.KPipeConsumer;
+import org.kpipe.consumer.KPipeRunner;
+import org.kpipe.format.avro.AvroFormat;
+import org.kpipe.format.json.JsonFormat;
+import org.kpipe.format.protobuf.ProtobufFormat;
+import org.kpipe.metrics.ConsumerMetrics;
+import org.kpipe.registry.MessageFormat;
+import org.kpipe.registry.MessagePipeline;
+import org.kpipe.sink.MessageSink;
+
+/// Heterogeneous multi-topic builder. Each `route` registers a per-topic pipeline so the consumer
+/// can dispatch records of different payload shapes through one consumer-group / one offset
+/// manager.
+///
+/// Usage:
+///
+/// ```java
+/// KPipe.multi(props)
+///     .json("events-json", s -> s.pipe(addTimestamp).toCustom(jsonSink))
+///     .avro("events-avro", s -> s.filter(active).toCustom(avroSink))
+///     .protobuf("events-proto", s -> s.toConsole())
+///     .start();
+/// ```
+///
+/// Records arriving for unrouted topics are dropped at WARNING and their offsets are still
+/// committed (no infinite retry on a config error).
+public final class MultiBuilder {
+
+  private static final Logger LOGGER = System.getLogger(MultiBuilder.class.getName());
+
+  private final Properties kafkaProps;
+  private final Map<String, DefaultSink<?>> routes = new LinkedHashMap<>();
+  private ConsumerMetrics consumerMetrics;
+
+  MultiBuilder(final Properties kafkaProps) {
+    this.kafkaProps = (Properties) Objects.requireNonNull(kafkaProps, "kafkaProps cannot be null").clone();
+  }
+
+  /// Attaches an OpenTelemetry-backed (or any custom) [ConsumerMetrics] implementation to the
+  /// multi-topic consumer. The metrics carry a `topic` attribute per record so dashboards can
+  /// break down by topic across heterogeneous routes.
+  ///
+  /// @param metrics the metrics implementation (typically `new OtelConsumerMetrics(otel, ...)`
+  ///     from `kpipe-metrics-otel`)
+  /// @return this builder
+  public MultiBuilder withMetrics(final ConsumerMetrics metrics) {
+    this.consumerMetrics = Objects.requireNonNull(metrics, "metrics cannot be null");
+    return this;
+  }
+
+  /// Registers a JSON route for `topic`. The configurator receives a topic-bound JSON [Stream]
+  /// and must return a terminal [Sink] (via `.toConsole()` / `.toCustom(...)` / `.toMulti(...)`).
+  ///
+  /// @param topic the Kafka topic
+  /// @param configurator builds the operator chain and chooses a terminal sink
+  /// @return this builder
+  public MultiBuilder json(
+    final String topic,
+    final Function<Stream<Map<String, Object>>, Sink<Map<String, Object>>> configurator
+  ) {
+    return route(topic, JsonFormat.INSTANCE, JsonFormat::consoleSink, configurator);
+  }
+
+  /// Registers an Avro route for `topic`. `toConsole()` requires a default schema registered
+  /// under key `"1"` on [AvroFormat#INSTANCE]; otherwise call
+  /// `.toCustom(AvroFormat.consoleSink(schema))`.
+  ///
+  /// @param topic the Kafka topic
+  /// @param configurator builds the operator chain and chooses a terminal sink
+  /// @return this builder
+  public MultiBuilder avro(
+    final String topic,
+    final Function<Stream<GenericRecord>, Sink<GenericRecord>> configurator
+  ) {
+    return route(topic, AvroFormat.INSTANCE, AvroFormat::defaultConsoleSink, configurator);
+  }
+
+  /// Registers a Protobuf route for `topic`.
+  ///
+  /// @param topic the Kafka topic
+  /// @param configurator builds the operator chain and chooses a terminal sink
+  /// @return this builder
+  public MultiBuilder protobuf(final String topic, final Function<Stream<Message>, Sink<Message>> configurator) {
+    return route(topic, ProtobufFormat.INSTANCE, ProtobufFormat::consoleSink, configurator);
+  }
+
+  /// Registers a raw `byte[]` route for `topic` — identity passthrough, no SerDe.
+  ///
+  /// @param topic the Kafka topic
+  /// @param configurator builds the operator chain and chooses a terminal sink
+  /// @return this builder
+  public MultiBuilder bytes(final String topic, final Function<Stream<byte[]>, Sink<byte[]>> configurator) {
+    return route(topic, MessageFormat.bytes(), KPipe::bytesConsoleSink, configurator);
+  }
+
+  /// Registers a custom-format route. The default `toConsole()` for custom routes logs values via
+  /// `String.valueOf(value)` — pass `toCustom(...)` for richer formatting.
+  ///
+  /// @param topic the Kafka topic
+  /// @param format the message format
+  /// @param configurator builds the operator chain and chooses a terminal sink
+  /// @param <T> the deserialized message type
+  /// @return this builder
+  public <T> MultiBuilder custom(
+    final String topic,
+    final MessageFormat<T> format,
+    final Function<Stream<T>, Sink<T>> configurator
+  ) {
+    return route(topic, format, () -> value -> LOGGER.log(Level.INFO, "{0}", value), configurator);
+  }
+
+  private <T> MultiBuilder route(
+    final String topic,
+    final MessageFormat<T> format,
+    final Supplier<MessageSink<T>> defaultConsoleSinkFactory,
+    final Function<Stream<T>, Sink<T>> configurator
+  ) {
+    Objects.requireNonNull(topic, "topic cannot be null");
+    if (topic.isBlank()) throw new IllegalArgumentException("topic cannot be blank");
+    Objects.requireNonNull(format, "format cannot be null");
+    Objects.requireNonNull(configurator, "configurator cannot be null");
+    if (routes.containsKey(topic)) throw new IllegalArgumentException(
+      "Duplicate route for topic '%s'".formatted(topic)
+    );
+
+    final var stream = new DefaultStream<>(Set.of(topic), kafkaProps, format, defaultConsoleSinkFactory);
+    final var sink = configurator.apply(stream);
+    if (!(sink instanceof DefaultSink<?> ds)) throw new IllegalStateException(
+      "Sink returned by configurator for topic '%s' is not a kpipe-built sink — call .toConsole(), .toCustom(...), or .toMulti(...) on the supplied stream".formatted(
+        topic
+      )
+    );
+    routes.put(topic, ds);
+    return this;
+  }
+
+  /// Builds and starts the underlying [KPipeConsumer] / [KPipeRunner] with the registered routes
+  /// and returns a [Handle] for lifecycle management.
+  ///
+  /// @return a [Handle] for lifecycle management
+  /// @throws IllegalStateException if no routes have been registered
+  public Handle start() {
+    if (routes.isEmpty()) throw new IllegalStateException("at least one route is required");
+
+    final var pipelines = new LinkedHashMap<String, MessagePipeline<?>>(routes.size());
+    for (final var entry : routes.entrySet()) pipelines.put(entry.getKey(), entry.getValue().buildPipeline());
+
+    final var consumerBuilder = KPipeConsumer.<byte[]>builder().withProperties(kafkaProps).withPipelines(pipelines);
+    if (consumerMetrics != null) consumerBuilder.withMetrics(consumerMetrics);
+    final var consumer = consumerBuilder.build();
+    final var runner = KPipeRunner.builder(consumer).build();
+    try {
+      runner.start();
+    } catch (final RuntimeException e) {
+      try {
+        consumer.close();
+      } catch (final Exception suppressed) {
+        e.addSuppressed(suppressed);
+      }
+      throw e;
+    }
+    return new DefaultHandle(runner, consumer);
+  }
+}

--- a/lib/kpipe-api/src/main/java/org/kpipe/Stream.java
+++ b/lib/kpipe-api/src/main/java/org/kpipe/Stream.java
@@ -110,6 +110,16 @@ public interface Stream<T> {
   /// @return a new stream with the processing mode configured
   Stream<T> withSequentialProcessing(final boolean sequential);
 
+  /// Returns a new stream that skips the first `n` bytes of every payload before deserialization.
+  /// Useful for stripping wire-format prefixes — e.g. Confluent Schema Registry's 5-byte envelope
+  /// (1 magic + 4 schema id) for Avro, or 6-byte envelope (5 + 1 message-index varint) for the
+  /// single-top-level-message Protobuf case.
+  ///
+  /// @param n the number of leading bytes to skip (must be ≥ 0)
+  /// @return a new stream with the skip configured
+  /// @throws IllegalArgumentException if `n` is negative
+  Stream<T> skipBytes(final int n);
+
   /// Terminates the stream with a format-appropriate console sink and returns a [Sink] ready
   /// to start. For Avro streams this requires that a default schema has been registered; see
   /// [KPipe#avro] for details.

--- a/lib/kpipe-api/src/test/java/org/kpipe/KPipeFacadeIntegrationTest.java
+++ b/lib/kpipe-api/src/test/java/org/kpipe/KPipeFacadeIntegrationTest.java
@@ -13,6 +13,7 @@ import java.time.Duration;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
+import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.TimeUnit;
@@ -125,6 +126,132 @@ class KPipeFacadeIntegrationTest {
         () -> assertEquals(3, captured.size(), "Should have captured exactly 3 odd-id messages"),
         () -> captured.forEach(m -> assertTrue(((Number) m.get("id")).intValue() % 2 == 1, "Captured id must be odd"))
       );
+    } finally {
+      handle.shutdownGracefully(Duration.ofSeconds(5));
+    }
+  }
+
+  @Test
+  void endToEndMultiTopicJsonStream() throws Exception {
+    final var topics = Set.of(
+      "kpipe-facade-multi-a-" + UUID.randomUUID().toString().substring(0, 8),
+      "kpipe-facade-multi-b-" + UUID.randomUUID().toString().substring(0, 8),
+      "kpipe-facade-multi-c-" + UUID.randomUUID().toString().substring(0, 8)
+    );
+    final var captured = new CopyOnWriteArrayList<Map<String, Object>>();
+    final MessageSink<Map<String, Object>> captureSink = captured::add;
+
+    final var consumerProps = consumerProps("kpipe-facade-multi-group-" + UUID.randomUUID());
+
+    final var handle = KPipe.json(topics, consumerProps)
+      .pipe(msg -> {
+        msg.put("processed", true);
+        return msg;
+      })
+      .toCustom(captureSink)
+      .start();
+
+    try {
+      assertTrue(handle.isHealthy(), "Handle should be healthy after start()");
+
+      // Produce 3 messages per topic — 9 total.
+      final var perTopic = 3;
+      final var expected = perTopic * topics.size();
+      try (final var producer = new KafkaProducer<byte[], byte[]>(producerProps())) {
+        for (final var topic : topics) {
+          for (int i = 1; i <= perTopic; i++) {
+            final var json = """
+              {"id":%d,"topic":"%s","value":"v%d"}""".formatted(i, topic, i)
+              .getBytes(StandardCharsets.UTF_8);
+            producer.send(new ProducerRecord<>(topic, json)).get();
+          }
+        }
+        producer.flush();
+      }
+
+      waitFor(() -> captured.size() >= expected, Duration.ofSeconds(20), "expected %d messages".formatted(expected));
+
+      assertEquals(expected, captured.size(), "Should have captured one message per topic per id");
+
+      // Every captured message must come from one of the subscribed topics and be transformed.
+      for (final var msg : captured) {
+        assertEquals(Boolean.TRUE, msg.get("processed"), "Each message must carry processed=true");
+        assertTrue(topics.contains(msg.get("topic")), "Captured topic must be one of the subscribed topics");
+      }
+
+      // Verify each topic contributed at least one message (otherwise we accidentally only consumed
+      // one).
+      for (final var topic : topics) {
+        final var fromTopic = captured
+          .stream()
+          .filter(m -> topic.equals(m.get("topic")))
+          .count();
+        assertEquals(perTopic, fromTopic, "Each topic should contribute %d messages".formatted(perTopic));
+      }
+    } finally {
+      handle.shutdownGracefully(Duration.ofSeconds(5));
+    }
+  }
+
+  @Test
+  void endToEndHeterogeneousMulti() throws Exception {
+    final var jsonTopic = "kpipe-multi-json-" + UUID.randomUUID().toString().substring(0, 8);
+    final var bytesTopic = "kpipe-multi-bytes-" + UUID.randomUUID().toString().substring(0, 8);
+
+    final var jsonCaptured = new CopyOnWriteArrayList<Map<String, Object>>();
+    final var bytesCaptured = new CopyOnWriteArrayList<byte[]>();
+
+    final var consumerProps = consumerProps("kpipe-multi-group-" + UUID.randomUUID());
+
+    final var handle = KPipe.multi(consumerProps)
+      .json(jsonTopic, s ->
+        s
+          .pipe(msg -> {
+            msg.put("processed", true);
+            return msg;
+          })
+          .toCustom(jsonCaptured::add)
+      )
+      .bytes(bytesTopic, s -> s.toCustom(bytesCaptured::add))
+      .start();
+
+    try {
+      assertTrue(handle.isHealthy(), "Handle should be healthy after start()");
+
+      final var perTopic = 3;
+      try (final var producer = new KafkaProducer<byte[], byte[]>(producerProps())) {
+        for (int i = 1; i <= perTopic; i++) {
+          final var json = """
+            {"id":%d,"value":"v%d"}""".formatted(i, i)
+            .getBytes(StandardCharsets.UTF_8);
+          producer.send(new ProducerRecord<>(jsonTopic, json)).get();
+          producer
+            .send(new ProducerRecord<>(bytesTopic, ("raw-%d".formatted(i)).getBytes(StandardCharsets.UTF_8)))
+            .get();
+        }
+        producer.flush();
+      }
+
+      waitFor(
+        () -> jsonCaptured.size() >= perTopic && bytesCaptured.size() >= perTopic,
+        Duration.ofSeconds(20),
+        "expected %d JSON + %d byte messages".formatted(perTopic, perTopic)
+      );
+
+      assertEquals(perTopic, jsonCaptured.size(), "JSON sink should have captured exactly %d".formatted(perTopic));
+      assertEquals(perTopic, bytesCaptured.size(), "bytes sink should have captured exactly %d".formatted(perTopic));
+
+      // JSON pipeline transformed each message.
+      for (final var msg : jsonCaptured) {
+        assertEquals(Boolean.TRUE, msg.get("processed"), "JSON message must carry processed=true");
+        assertNotNull(msg.get("id"));
+      }
+
+      // Byte sink received only the bytes-topic raw payloads.
+      for (final var b : bytesCaptured) {
+        final var s = new String(b, StandardCharsets.UTF_8);
+        assertTrue(s.startsWith("raw-"), "Byte payload should start with 'raw-' but was: " + s);
+      }
     } finally {
       handle.shutdownGracefully(Duration.ofSeconds(5));
     }

--- a/lib/kpipe-consumer/src/main/java/org/kpipe/consumer/KPipeConsumer.java
+++ b/lib/kpipe-consumer/src/main/java/org/kpipe/consumer/KPipeConsumer.java
@@ -82,8 +82,8 @@ public class KPipeConsumer<K> implements AutoCloseable {
 
   private final Queue<ConsumerCommand> commandQueue;
   private final Consumer<K, byte[]> kafkaConsumer;
-  private final String topic;
-  private final MessagePipeline<?> processor;
+  private final Set<String> topics;
+  private final Map<String, MessagePipeline<?>> pipelines;
   private final ExecutorService virtualThreadExecutor;
   private final Duration pollTimeout;
   private final AtomicReference<Thread> consumerThread = new AtomicReference<>();
@@ -143,8 +143,9 @@ public class KPipeConsumer<K> implements AutoCloseable {
     private Builder() {}
 
     private Properties kafkaProps;
-    private String topic;
+    private Set<String> topics;
     private MessagePipeline<?> pipeline;
+    private Map<String, MessagePipeline<?>> pipelinesPerTopic;
     private Duration pollTimeout = Duration.ofMillis(100);
     private ErrorHandler<K> errorHandler = e ->
       LOGGER.log(
@@ -185,8 +186,29 @@ public class KPipeConsumer<K> implements AutoCloseable {
     /// @param topic The topic name
     /// @return This builder instance for method chaining
     public Builder<K> withTopic(final String topic) {
-      this.topic = topic;
+      return withTopics(Set.of(Objects.requireNonNull(topic, "Topic cannot be null")));
+    }
+
+    /// Sets multiple Kafka topics to consume from with a single shared pipeline.
+    ///
+    /// All topics must produce the same payload type because they share one [MessagePipeline].
+    /// For per-topic typing, run separate consumers.
+    ///
+    /// @param topics The topic names (must be non-empty)
+    /// @return This builder instance for method chaining
+    public Builder<K> withTopics(final Collection<String> topics) {
+      Objects.requireNonNull(topics, "Topics cannot be null");
+      if (topics.isEmpty()) throw new IllegalArgumentException("Topics cannot be empty");
+      this.topics = new LinkedHashSet<>(topics);
       return this;
+    }
+
+    /// Sets multiple Kafka topics to consume from with a single shared pipeline (varargs form).
+    ///
+    /// @param topics The topic names (must be non-empty)
+    /// @return This builder instance for method chaining
+    public Builder<K> withTopics(final String... topics) {
+      return withTopics(java.util.Arrays.asList(Objects.requireNonNull(topics, "Topics cannot be null")));
     }
 
     /// Sets the pipeline to process each consumed message.
@@ -195,10 +217,30 @@ public class KPipeConsumer<K> implements AutoCloseable {
     /// pipeline. The pipeline must be a [MessagePipeline] — typically produced by
     /// `MessageProcessorRegistry.pipeline(format).build()`.
     ///
+    /// All subscribed topics share this pipeline (homogeneous case). For heterogeneous
+    /// per-topic pipelines, use [#withPipelines(Map)].
+    ///
     /// @param pipeline The pipeline to apply to message values
     /// @return This builder instance for method chaining
     public Builder<K> withPipeline(final MessagePipeline<?> pipeline) {
       this.pipeline = pipeline;
+      return this;
+    }
+
+    /// Sets a per-topic pipeline map, enabling heterogeneous payload types across the subscribed
+    /// topics. When this is set, the consumer subscribes to the map's keys and dispatches each
+    /// record to its topic's pipeline. Records arriving for topics not present in the map are
+    /// dropped with a WARNING log; the offset is still marked processed.
+    ///
+    /// `withTopic` / `withTopics` is unnecessary when `withPipelines` is used — the topic set is
+    /// derived from the map keys. Mixing `withPipeline` and `withPipelines` is an error.
+    ///
+    /// @param pipelinesPerTopic the topic → pipeline map (must be non-empty)
+    /// @return This builder instance for method chaining
+    public Builder<K> withPipelines(final Map<String, MessagePipeline<?>> pipelinesPerTopic) {
+      Objects.requireNonNull(pipelinesPerTopic, "pipelinesPerTopic cannot be null");
+      if (pipelinesPerTopic.isEmpty()) throw new IllegalArgumentException("pipelinesPerTopic cannot be empty");
+      this.pipelinesPerTopic = Map.copyOf(pipelinesPerTopic);
       return this;
     }
 
@@ -453,8 +495,19 @@ public class KPipeConsumer<K> implements AutoCloseable {
     /// @return a new KPipeConsumer instance
     public KPipeConsumer<K> build() {
       Objects.requireNonNull(kafkaProps, "Kafka properties must be provided");
-      Objects.requireNonNull(topic, "Topic must be provided");
-      Objects.requireNonNull(pipeline, "Pipeline function must be provided");
+      if (pipeline != null && pipelinesPerTopic != null) throw new IllegalArgumentException(
+        "Use either withPipeline (homogeneous) or withPipelines (heterogeneous), not both"
+      );
+      if (pipelinesPerTopic != null) {
+        if (topics != null) throw new IllegalArgumentException(
+          "withTopic/withTopics is unnecessary with withPipelines — topics are derived from the map keys; remove the explicit topic call"
+        );
+        this.topics = new LinkedHashSet<>(pipelinesPerTopic.keySet());
+      } else {
+        Objects.requireNonNull(topics, "Topic must be provided via withTopic or withTopics");
+        if (topics.isEmpty()) throw new IllegalArgumentException("At least one topic must be provided");
+        Objects.requireNonNull(pipeline, "Pipeline function must be provided");
+      }
       if (maxRetries < 0) throw new IllegalArgumentException("Max retries cannot be negative");
       if (pollTimeout.isNegative() || pollTimeout.isZero()) throw new IllegalArgumentException(
         "Poll timeout must be positive"
@@ -478,8 +531,14 @@ public class KPipeConsumer<K> implements AutoCloseable {
       builder.consumerProvider != null
         ? builder.consumerProvider.get()
         : new KafkaConsumer<>(Objects.requireNonNull(builder.kafkaProps));
-    this.topic = Objects.requireNonNull(builder.topic);
-    this.processor = Objects.requireNonNull(builder.pipeline);
+    this.topics = Set.copyOf(Objects.requireNonNull(builder.topics, "Topics must be set"));
+    if (builder.pipelinesPerTopic != null) this.pipelines = builder.pipelinesPerTopic;
+    else {
+      final var map = new LinkedHashMap<String, MessagePipeline<?>>(this.topics.size());
+      final var single = Objects.requireNonNull(builder.pipeline, "pipeline cannot be null");
+      for (final var t : this.topics) map.put(t, single);
+      this.pipelines = Map.copyOf(map);
+    }
     this.pollTimeout = Objects.requireNonNull(builder.pollTimeout);
     this.errorHandler = builder.errorHandler;
     this.maxRetries = builder.maxRetries;
@@ -585,11 +644,12 @@ public class KPipeConsumer<K> implements AutoCloseable {
     if (!state.compareAndSet(ConsumerState.CREATED, ConsumerState.RUNNING)) return;
 
     if (offsetManager != null) offsetManager.start();
-    if (rebalanceListener != null) kafkaConsumer.subscribe(List.of(topic), rebalanceListener);
-    else kafkaConsumer.subscribe(List.of(topic));
+    if (rebalanceListener != null) kafkaConsumer.subscribe(topics, rebalanceListener);
+    else kafkaConsumer.subscribe(topics);
 
+    final var threadLabel = topics.size() == 1 ? topics.iterator().next() : "topics-%d".formatted(topics.size());
     final var thread = Thread.ofVirtual()
-      .name("kafka-consumer-%s-%s".formatted(topic, UUID.randomUUID().toString().substring(0, 8)))
+      .name("kafka-consumer-%s-%s".formatted(threadLabel, UUID.randomUUID().toString().substring(0, 8)))
       .uncaughtExceptionHandler((t, e) -> {
         LOGGER.log(Level.ERROR, "Uncaught exception in thread {0}", t.getName(), e);
         transitionToClosing();
@@ -615,7 +675,7 @@ public class KPipeConsumer<K> implements AutoCloseable {
         } finally {
           try {
             kafkaConsumer.close();
-            LOGGER.log(Level.INFO, "Consumer closed for topic {0}", topic);
+            LOGGER.log(Level.INFO, "Consumer closed for topics {0}", topics);
           } catch (final Exception e) {
             LOGGER.log(Level.WARNING, "Error closing Kafka consumer", e);
           } finally {
@@ -625,7 +685,7 @@ public class KPipeConsumer<K> implements AutoCloseable {
       });
 
     consumerThread.set(thread);
-    LOGGER.log(Level.INFO, "Consumer started for topic {0}", topic);
+    LOGGER.log(Level.INFO, "Consumer started for topics {0}", topics);
   }
 
   /// Pauses consumption from the topic. Any in-flight messages will continue processing, but no new
@@ -665,15 +725,15 @@ public class KPipeConsumer<K> implements AutoCloseable {
         switch (command) {
           case ConsumerCommand.Pause _ -> {
             kafkaConsumer.pause(kafkaConsumer.assignment());
-            LOGGER.log(Level.INFO, "Consumer paused for topic {0}", topic);
+            LOGGER.log(Level.INFO, "Consumer paused for topics {0}", topics);
           }
           case ConsumerCommand.Resume _ -> {
             kafkaConsumer.resume(kafkaConsumer.assignment());
-            LOGGER.log(Level.INFO, "Consumer resumed for topic {0}", topic);
+            LOGGER.log(Level.INFO, "Consumer resumed for topics {0}", topics);
           }
           case ConsumerCommand.Close _ -> {
             state.set(ConsumerState.CLOSING);
-            LOGGER.log(Level.INFO, "Consumer shutdown initiated for topic {0}", topic);
+            LOGGER.log(Level.INFO, "Consumer shutdown initiated for topics {0}", topics);
           }
           case ConsumerCommand.TrackOffset cmd -> {
             if (offsetManager != null) {
@@ -854,7 +914,7 @@ public class KPipeConsumer<K> implements AutoCloseable {
   ///
   /// @param records the batch of records to process
   protected void processRecords(final ConsumerRecords<K, byte[]> records) {
-    for (final var record : records.records(topic)) {
+    for (final var record : records) {
       if (offsetManager != null) commandQueue.offer(new ConsumerCommand.TrackOffset(record));
       inFlightCount.incrementAndGet();
 
@@ -868,7 +928,7 @@ public class KPipeConsumer<K> implements AutoCloseable {
           if (isRunning()) {
             LOGGER.log(Level.WARNING, "Task submission rejected during shutdown", e);
             if (enableMetrics) metrics.get(METRIC_PROCESSING_ERRORS).incrementAndGet();
-            otelMetrics.recordProcessingError();
+            otelMetrics.recordProcessingError(record.topic());
             try {
               errorHandler.accept(new ProcessingError<>(record, e, 0));
             } catch (final Exception ex) {
@@ -904,7 +964,7 @@ public class KPipeConsumer<K> implements AutoCloseable {
   /// @param record The Kafka consumer record to process
   protected void processRecord(final ConsumerRecord<K, byte[]> record) {
     if (enableMetrics) metrics.get(METRIC_MESSAGES_RECEIVED).incrementAndGet();
-    otelMetrics.recordMessageReceived();
+    otelMetrics.recordMessageReceived(record.topic());
 
     final long startTime = System.currentTimeMillis();
     try {
@@ -915,8 +975,8 @@ public class KPipeConsumer<K> implements AutoCloseable {
           metrics.get(METRIC_MESSAGES_PROCESSED).incrementAndGet();
           metrics.get(METRIC_PROCESSING_DURATION_TOTAL_MS).addAndGet(durationMs);
         }
-        otelMetrics.recordMessageProcessed();
-        otelMetrics.recordProcessingDuration(durationMs);
+        otelMetrics.recordMessageProcessed(record.topic());
+        otelMetrics.recordProcessingDuration(record.topic(), durationMs);
       }
     } finally {
       inFlightCount.decrementAndGet();
@@ -928,11 +988,24 @@ public class KPipeConsumer<K> implements AutoCloseable {
   }
 
   private boolean tryProcessRecord(final ConsumerRecord<K, byte[]> record) {
+    final var pipeline = pipelines.get(record.topic());
+    if (pipeline == null) {
+      // Partial-revocation race: subscribed topic was reassigned mid-poll. Mark processed so we
+      // don't loop forever on a config error.
+      LOGGER.log(
+        Level.WARNING,
+        "No pipeline registered for topic {0}; dropping record at offset {1}",
+        record.topic(),
+        record.offset()
+      );
+      markOffsetProcessed(record);
+      return false;
+    }
     for (int attempt = 0; attempt <= maxRetries; attempt++) {
       if (attempt > 0) if (!handleRetry(record, attempt)) return false;
 
       try {
-        processor.processToSink(record.value());
+        pipeline.processToSink(record.value());
         markOffsetProcessed(record);
         return true;
       } catch (final Exception e) {
@@ -968,7 +1041,7 @@ public class KPipeConsumer<K> implements AutoCloseable {
 
   private void handleProcessingError(final ConsumerRecord<K, byte[]> record, final Exception e, final int retryCount) {
     if (enableMetrics) metrics.get(METRIC_PROCESSING_ERRORS).incrementAndGet();
-    otelMetrics.recordProcessingError();
+    otelMetrics.recordProcessingError(record.topic());
     LOGGER.log(
       Level.WARNING,
       "Failed to process message at offset {0} after {1} attempt(s): {2}",
@@ -977,7 +1050,7 @@ public class KPipeConsumer<K> implements AutoCloseable {
       e.getMessage()
     );
     if (deadLetterTopic != null && kpipeProducer != null) {
-      final var sent = kpipeProducer.sendToDlq(deadLetterTopic, record, topic, e);
+      final var sent = kpipeProducer.sendToDlq(deadLetterTopic, record, record.topic(), e);
       if (sent && enableMetrics) metrics.get(METRIC_DLQ_SENT).incrementAndGet();
     }
     markOffsetProcessed(record);

--- a/lib/kpipe-consumer/src/test/java/org/kpipe/consumer/KPipeConsumerMockingTest.java
+++ b/lib/kpipe-consumer/src/test/java/org/kpipe/consumer/KPipeConsumerMockingTest.java
@@ -38,7 +38,7 @@ class KPipeConsumerMockingTest {
   private KafkaOffsetManager<String> offsetManager;
 
   @Captor
-  private ArgumentCaptor<List<String>> topicCaptor;
+  private ArgumentCaptor<Collection<String>> topicCaptor;
 
   @Captor
   private ArgumentCaptor<KPipeConsumer.ProcessingError<String>> errorCaptor;
@@ -70,7 +70,7 @@ class KPipeConsumerMockingTest {
     try (functionalConsumer) {
       functionalConsumer.start();
       verify(mockConsumer).subscribe(topicCaptor.capture());
-      assertEquals(List.of(TOPIC), topicCaptor.getValue());
+      assertEquals(Set.of(TOPIC), Set.copyOf(topicCaptor.getValue()));
     }
   }
 

--- a/lib/kpipe-format-avro/src/main/java/org/kpipe/format/avro/AvroFormat.java
+++ b/lib/kpipe-format-avro/src/main/java/org/kpipe/format/avro/AvroFormat.java
@@ -91,6 +91,21 @@ public final class AvroFormat implements SchemaAwareFormat<GenericRecord> {
     return new AvroConsoleSink<>(schema);
   }
 
+  /// Creates a new [AvroConsoleSink] using the schema registered under key `"1"` on
+  /// [AvroFormat#INSTANCE]. Throws [IllegalStateException] if no such schema exists, since the
+  /// console sink needs a schema to re-encode payloads as JSON.
+  ///
+  /// @return a new console sink bound to the default-key schema
+  public static AvroConsoleSink<GenericRecord> defaultConsoleSink() {
+    final var schema = INSTANCE.getSchema("1");
+    if (schema == null) throw new IllegalStateException(
+      "AvroFormat.defaultConsoleSink() requires a schema registered under key \"1\" on " +
+        "AvroFormat.INSTANCE; register one (e.g. AvroFormat.INSTANCE.addSchema(\"1\", schemaJson)) " +
+        "or call consoleSink(schema) directly."
+    );
+    return new AvroConsoleSink<>(schema);
+  }
+
   /// Sets the default schema key to use for deserialization.
   ///
   /// @param schemaKey The schema key

--- a/lib/kpipe-metrics-otel/src/main/java/org/kpipe/metrics/otel/OtelConsumerMetrics.java
+++ b/lib/kpipe-metrics-otel/src/main/java/org/kpipe/metrics/otel/OtelConsumerMetrics.java
@@ -6,6 +6,7 @@ import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.api.metrics.DoubleHistogram;
 import io.opentelemetry.api.metrics.LongCounter;
 import io.opentelemetry.api.metrics.ObservableLongGauge;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.LongSupplier;
 import org.kpipe.metrics.ConsumerMetrics;
 
@@ -25,6 +26,7 @@ import org.kpipe.metrics.ConsumerMetrics;
 public final class OtelConsumerMetrics implements ConsumerMetrics {
 
   private static final AttributeKey<String> PIPELINE_KEY = AttributeKey.stringKey("pipeline");
+  private static final AttributeKey<String> TOPIC_KEY = AttributeKey.stringKey("topic");
 
   private final LongCounter messagesReceived;
   private final LongCounter messagesProcessed;
@@ -37,6 +39,7 @@ public final class OtelConsumerMetrics implements ConsumerMetrics {
   private final ObservableLongGauge inFlight;
 
   private final Attributes attributes;
+  private final ConcurrentHashMap<String, Attributes> topicAttributesCache = new ConcurrentHashMap<>();
 
   /// Creates a fully-instrumented instance with an in-flight gauge backed by the given supplier.
   ///
@@ -140,5 +143,32 @@ public final class OtelConsumerMetrics implements ConsumerMetrics {
   @Override
   public void recordBackpressureTime(final long millis) {
     backpressureTime.add(millis, attributes);
+  }
+
+  @Override
+  public void recordMessageReceived(final String topic) {
+    messagesReceived.add(1, withTopic(topic));
+  }
+
+  @Override
+  public void recordMessageProcessed(final String topic) {
+    messagesProcessed.add(1, withTopic(topic));
+  }
+
+  @Override
+  public void recordProcessingError(final String topic) {
+    processingErrors.add(1, withTopic(topic));
+  }
+
+  @Override
+  public void recordProcessingDuration(final String topic, final long millis) {
+    processingDuration.record(millis, withTopic(topic));
+  }
+
+  private Attributes withTopic(final String topic) {
+    if (topic == null) return attributes;
+    // Per-topic Attributes are immutable and stable for the consumer's lifetime — caching keeps
+    // the per-record metric path allocation-free once each topic has been seen once.
+    return topicAttributesCache.computeIfAbsent(topic, t -> attributes.toBuilder().put(TOPIC_KEY, t).build());
   }
 }

--- a/lib/kpipe-metrics-otel/src/test/java/org/kpipe/metrics/otel/OtelConsumerMetricsTest.java
+++ b/lib/kpipe-metrics-otel/src/test/java/org/kpipe/metrics/otel/OtelConsumerMetricsTest.java
@@ -32,12 +32,21 @@ class OtelConsumerMetricsTest {
   @Test
   void shouldRecordEventsWithoutThrowing() {
     final var metrics = new OtelConsumerMetrics(OpenTelemetry.noop(), () -> 0L, "test");
-    assertDoesNotThrow(metrics::recordMessageReceived);
-    assertDoesNotThrow(metrics::recordMessageProcessed);
-    assertDoesNotThrow(metrics::recordProcessingError);
+    assertDoesNotThrow(() -> metrics.recordMessageReceived());
+    assertDoesNotThrow(() -> metrics.recordMessageProcessed());
+    assertDoesNotThrow(() -> metrics.recordProcessingError());
     assertDoesNotThrow(() -> metrics.recordProcessingDuration(42L));
     assertDoesNotThrow(metrics::recordBackpressurePause);
     assertDoesNotThrow(() -> metrics.recordBackpressureTime(150L));
+  }
+
+  @Test
+  void shouldRecordTopicScopedEventsWithoutThrowing() {
+    final var metrics = new OtelConsumerMetrics(OpenTelemetry.noop(), () -> 0L, "test");
+    assertDoesNotThrow(() -> metrics.recordMessageReceived("events-a"));
+    assertDoesNotThrow(() -> metrics.recordMessageProcessed("events-a"));
+    assertDoesNotThrow(() -> metrics.recordProcessingError("events-a"));
+    assertDoesNotThrow(() -> metrics.recordProcessingDuration("events-a", 42L));
   }
 
   @Test

--- a/lib/kpipe-metrics/src/main/java/org/kpipe/metrics/ConsumerMetrics.java
+++ b/lib/kpipe-metrics/src/main/java/org/kpipe/metrics/ConsumerMetrics.java
@@ -52,4 +52,35 @@ public interface ConsumerMetrics {
   ///
   /// @param millis pause duration in milliseconds
   void recordBackpressureTime(long millis);
+
+  /// Records that a message was received from `topic`. Implementations that care about per-topic
+  /// breakdown should override; the default delegates to [#recordMessageReceived()] and ignores
+  /// the topic.
+  ///
+  /// @param topic the Kafka topic the record arrived from
+  default void recordMessageReceived(final String topic) {
+    recordMessageReceived();
+  }
+
+  /// Records that a message from `topic` was successfully processed.
+  ///
+  /// @param topic the Kafka topic the record arrived from
+  default void recordMessageProcessed(final String topic) {
+    recordMessageProcessed();
+  }
+
+  /// Records that a message from `topic` failed processing.
+  ///
+  /// @param topic the Kafka topic the record arrived from
+  default void recordProcessingError(final String topic) {
+    recordProcessingError();
+  }
+
+  /// Records the time taken to process a single message from `topic`.
+  ///
+  /// @param topic the Kafka topic the record arrived from
+  /// @param millis processing duration in milliseconds
+  default void recordProcessingDuration(final String topic, final long millis) {
+    recordProcessingDuration(millis);
+  }
 }

--- a/lib/kpipe-metrics/src/main/java/org/kpipe/metrics/ConsumerMetricsReporter.java
+++ b/lib/kpipe-metrics/src/main/java/org/kpipe/metrics/ConsumerMetricsReporter.java
@@ -50,7 +50,7 @@ public record ConsumerMetricsReporter(
   private static final String METRIC_BACKPRESSURE_TIME_MS = "backpressureTimeMs";
 
   /// Creates a new ConsumerMetricsReporter, defaulting to log-based reporting when reporter is
-  // null.
+  /// null.
   ///
   /// @param metricsSupplier supplier of consumer metrics
   /// @param uptimeSupplier supplier of application uptime in ms

--- a/lib/kpipe-metrics/src/test/java/org/kpipe/metrics/ConsumerMetricsTest.java
+++ b/lib/kpipe-metrics/src/test/java/org/kpipe/metrics/ConsumerMetricsTest.java
@@ -17,25 +17,29 @@ class ConsumerMetricsTest {
   @Test
   void shouldRecordMessageReceivedWithoutThrowing() {
     final var metrics = ConsumerMetrics.noop();
-    assertDoesNotThrow(metrics::recordMessageReceived);
+    assertDoesNotThrow(() -> metrics.recordMessageReceived());
+    assertDoesNotThrow(() -> metrics.recordMessageReceived("topic-a"));
   }
 
   @Test
   void shouldRecordMessageProcessedWithoutThrowing() {
     final var metrics = ConsumerMetrics.noop();
-    assertDoesNotThrow(metrics::recordMessageProcessed);
+    assertDoesNotThrow(() -> metrics.recordMessageProcessed());
+    assertDoesNotThrow(() -> metrics.recordMessageProcessed("topic-a"));
   }
 
   @Test
   void shouldRecordProcessingErrorWithoutThrowing() {
     final var metrics = ConsumerMetrics.noop();
-    assertDoesNotThrow(metrics::recordProcessingError);
+    assertDoesNotThrow(() -> metrics.recordProcessingError());
+    assertDoesNotThrow(() -> metrics.recordProcessingError("topic-a"));
   }
 
   @Test
   void shouldRecordProcessingDurationWithoutThrowing() {
     final var metrics = ConsumerMetrics.noop();
     assertDoesNotThrow(() -> metrics.recordProcessingDuration(42L));
+    assertDoesNotThrow(() -> metrics.recordProcessingDuration("topic-a", 42L));
   }
 
   @Test


### PR DESCRIPTION
Consumer
- KPipeConsumer stores Map<String, MessagePipeline<?>> and dispatches by record.topic(). Builder.withPipelines(Map) for heterogeneous mode; withPipeline replicates one pipeline across all subscribed topics (homogeneous case). Unrouted topics drop+log+commit so a config error does not loop forever
- Builder.withTopics(Collection<String>) and withTopics(String...) alongside existing withTopic(String). Reject the silent-override case where withTopics and withPipelines are both set
- DLQ enrichment switched to record.topic() so per-record source-topic survives multi-topic
- Subscribe call passes the topic Set directly; processRecords iterates the full ConsumerRecords (no per-topic filter); thread name and 5 log call sites display the topic set

Facade
- KPipe.json/avro/protobuf/bytes/custom add Collection<String> overloads (homogeneous multi-topic). Single-string forms unchanged
- KPipe.multi(props).json(topic, configurator).avro(...).bytes(...).start() for heterogeneous routing through one consumer-group / one offset manager. MultiBuilder.withMetrics(ConsumerMetrics) wires custom metrics
- Stream<T>.skipBytes(int n) strips the first n bytes of every payload before deserialization (Confluent Schema Registry envelopes: 5 bytes for Avro, 6 for single-message Protobuf)
- Handle.awaitShutdown() no-arg form (no magic Duration values needed)
- DefaultStream now holds Set<String> topics; topics()/skipBytes() accessors used by DefaultSink.buildPipeline (factored out and shared with MultiBuilder)
- AvroFormat.defaultConsoleSink() factored out so KPipe and MultiBuilder share the schema-aware factory

Metrics
- ConsumerMetrics: add recordMessageReceived/Processed/Error(String topic) and recordProcessingDuration(String topic, long millis) as default methods that delegate to the no-arg form. Backward-compatible — external ConsumerMetrics impls keep working
- OtelConsumerMetrics: add a topic attribute alongside the existing pipeline attribute so multi-topic dashboards can break down per topic. Per-topic Attributes are cached via computeIfAbsent so the per-record metric path stays allocation-free after first observation
- KPipeConsumer: pass record.topic() into every otelMetrics.record*() call site (processRecord, RejectedExecutionException path, handleProcessingError)

Demo
- examples/demo collapsed from three separate KPipeRunners (~250 lines of explicit-API plumbing) into one KPipe.multi(...) consumer with three routes. One consumer-group, one offset manager, three typed pipelines. OTel wiring kept via withMetrics; the new topic attribute lights up per-topic Grafana breakdowns. Operators.addField reused instead of inline addField helper

Tests
- endToEndMultiTopicJsonStream: homogeneous, 3 topics
- endToEndHeterogeneousMulti: JSON + bytes through one consumer
- ConsumerMetricsTest, OtelConsumerMetricsTest: explicit lambdas (method references became ambiguous) + topic-scoped cases for the new overloads
- KPipeConsumerMockingTest: subscribe captor accepts Collection<String>; builderShouldThrowNullPointerExceptionWhenMissingRequiredFields aligned with the reordered build() validation

Docs
- README: new "Consuming from multiple topics" section, Spring Kafka added to the comparison table, dedicated "Coming from Spring Kafka?" subsection with migration sketch
- PLAN.md: P1 1 marked shipped; P4 18 javadoc warning resolved