### PR TITLE
refactor: collapse api module

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -28,12 +28,14 @@
 
 ### 3. Java 25 Virtual Threads and Scoped Values
 
-- **Decision**: Use Virtual Threads (Project Loom) for parallel processing and `ScopedValue` for context sharing and
-  high-performance caching.
+- **Decision**: Use Virtual Threads (Project Loom) for parallel processing. When per-record context-sharing is needed,
+  prefer `ScopedValue` over `ThreadLocal`.
 - **Reasoning**: Virtual Threads replace complex thread pool management with a simple "thread-per-record" model.
-  `ScopedValue` provides a modern, lightweight alternative to `ThreadLocal` that is specifically optimized for large
-  numbers of virtual threads.
-- **Result**: Massive concurrency with minimal memory overhead, avoiding `ThreadLocal` scalability issues.
+  `ScopedValue` is the VT-friendly alternative to `ThreadLocal`, avoiding the scalability traps of inheritable
+  thread-locals on a thread-per-record consumer.
+- **Current state**: VT is used everywhere (consumer poll → record processing). `ScopedValue` is **not** currently
+  used — earlier per-format SerDe caches were torn out as dead infrastructure. The doctrine still stands for any
+  future thread-local-like state we might add (e.g. tenant context, span propagation).
 
 ### 4. Reliable Offset Management ("Lowest Pending Offset")
 
@@ -206,11 +208,12 @@
   This keeps the user-facing import path clean (`import org.kpipe.KPipe;`) and avoids the `org.kpipe.facade` split-
   package cost while still letting `kpipe-core` own the registry/sink/format types in `org.kpipe.registry` and
   `org.kpipe.sink`.
-- **Immutability contract on `Stream<T>`**: every fluent method returns a NEW `DefaultStream` instance carrying the
-  updated configuration. The original is never mutated. Branching from a common root is safe — `s.pipe(a)` and
-  `s.pipe(b)` produce independent streams. Operators are stored as an immutable `List.copyOf(...)`. This matches the
-  Java Stream API's functional style; the alternative (mutate-and-return-this, like `StringBuilder`) is a foot gun
-  for users who reuse the root reference.
+- **Immutability contract on `Stream<T>`**: `DefaultStream` is a Java record. Every fluent method returns a NEW
+  `DefaultStream` instance carrying the updated configuration. The original is never mutated. Branching from a
+  common root is safe — `s.pipe(a)` and `s.pipe(b)` produce independent streams. Operators are stored as an
+  immutable `List.copyOf(...)`. The record form keeps "adding a fluent setter is a one-place change" honest:
+  declare the component, add the `with*` method, reference it in `DefaultSink.buildPipeline` if it affects pipeline
+  construction.
 - **`Handle` is `AutoCloseable`** with a default `close()` that performs `shutdownGracefully(Duration.ofSeconds(5))`.
   Use try-with-resources to guarantee cleanup. `metrics()` returns `Map<String, Long>` (typed), not `Map<String,
   Object>`.
@@ -247,3 +250,37 @@ These patterns came out of the deep internal audit work and should be preserved 
 - **Don't expose internal counters through public APIs**: if a method takes an `AtomicLong` parameter for
   "optionally update this counter on success," it's leaking implementation detail. Return a `boolean` and let the
   caller update its own counter.
+
+### 15. Multi-Topic Dispatch (1.11.0)
+
+- **Decision**: One `KPipeConsumer` can host either one shared pipeline across N topics (homogeneous) or a
+  per-topic pipeline map (heterogeneous), but always through one Kafka consumer / one consumer-group / one
+  offset manager.
+- **Internal model**: `KPipeConsumer` stores `Map<String, MessagePipeline<?>> pipelines`. The homogeneous path
+  (`Builder.withPipeline(...)`) replicates the same pipeline reference across every subscribed topic at construction
+  time; the heterogeneous path (`Builder.withPipelines(Map)`) takes the map directly and derives the topic set from
+  its keys. `tryProcessRecord` does a single `pipelines.get(record.topic())` per record. The map is built via
+  `Map.copyOf(...)`, so for typical small route counts it's `Map1`/`MapN` (identity-fast `String#equals` lookup),
+  not `HashMap`.
+- **Unrouted-topic policy**: if a record arrives for a topic with no registered pipeline (rebalance race, config
+  error), **drop + log at WARNING + mark offset processed**. Never throw (would crash the consumer thread for a
+  config error) and never DLQ (we don't have a per-topic DLQ). The "mark processed" part is critical — without
+  it, the same record gets re-fetched forever.
+- **Facade split**: homogeneous via `KPipe.json/avro/protobuf/bytes/custom(Collection<String>, Properties)`;
+  heterogeneous via `KPipe.multi(props).json(topic, configurator).avro(...)...start()`. Single-string overloads
+  remain unchanged. Mixing `withTopic`/`withTopics` with `withPipelines` is rejected as a config error (silent
+  override would mask user mistakes).
+- **Metrics**: OTel `kpipe.consumer.*` instruments now carry both a `pipeline` attribute (consumer-wide) and a
+  `topic` attribute (per record). Per-topic `Attributes` are cached via `computeIfAbsent` so the per-record metric
+  path is allocation-free after each topic has been seen once.
+
+### 16. No-Deprecation Policy
+
+- **Decision**: When a public API has to go, **delete it and migrate all callers**. Do not deprecate, do not add
+  `@Deprecated`, do not add `since = "..."` annotations.
+- **Reasoning**: Deprecation cycles bloat the surface, train users to ignore warnings, and rot in place when the
+  promised "removal in next major" never happens. The library is pre-1.x-stable enough that hard breaks with a
+  release-note migration are cleaner than carrying dead overloads. Tests and examples are migrated in the same PR
+  that deletes the method, so callers always have a working reference.
+- **Enforcement**: zero `@Deprecated` annotations and zero `@deprecated` Javadoc tags should ever land in the
+  codebase. If something needs to be removed, the PR description mentions the removal explicitly.

--- a/.claude/PLAN.md
+++ b/.claude/PLAN.md
@@ -1,8 +1,8 @@
 # KPipe — Roadmap & State of the Library
 
-**Last updated:** 2026-05-07
+**Last updated:** 2026-05-08
 **Current released line:** 1.10.0 (Maven Central)
-**Active branch state:** `feature/1.11.1-test-coverage` (PR #94) plus `fix/critical-bugs` cleanup branch
+**Active work:** `refactor/api-cleanup` (DefaultStream record + test dedup + deprecated removal)
 
 ---
 
@@ -33,7 +33,7 @@ Single source of truth for what's left across the whole library.
 | #  | Priority                  | Item                                                                                                                         | Type              | Effort    |
 |----|---------------------------|------------------------------------------------------------------------------------------------------------------------------|-------------------|-----------|
 | 1  | ~~**P1 — Adoption blocker**~~ | ~~Multi-topic Phase 1 (homogeneous) + Phase 2 (heterogeneous via `KPipe.multi`)~~ — both landed 2026-05-07               | Feature           | shipped   |
-| 2  | **P1 — Adoption blocker** | Java baseline decision (stay on 25 vs drop to 21 LTS)                                                                        | Strategy          | decision  |
+| 2  | ~~**P1 — Adoption blocker**~~ | ~~Java baseline decision~~ — **stay on Java 25** (decided 2026-05-07)                                                    | Strategy          | decided   |
 | 3  | **P2 — Real footgun**     | `Format.INSTANCE` global mutable state (Avro/Protobuf)                                                                       | Hardening         | ~1 day    |
 | 4  | **P2 — Real footgun**     | HTTP fetcher remaining extraction from `kpipe-format-avro` (drop `java.net.http` + `jackson.core`; dsl-json already removed) | Cleanup           | ~2–3 hr   |
 | 5  | **P2 — Bug surface**      | Batch sinks (`BatchSink<T>` interface + size/time flush + partial-failure semantics)                                         | Feature           | ~5–7 days |
@@ -47,31 +47,26 @@ Single source of truth for what's left across the whole library.
 | 13 | **P5 — 2.0 candidates**   | `MessageTracker` collapse — add `KPipeConsumer.waitForInFlightDrain(Duration)`, delete the standalone class                  | Breaking refactor | ~half day |
 | 14 | **P5 — Speculative perf** | Format serialization caches re-wire (only with JMH evidence)                                                                 | Perf              | ~1–2 days |
 
-**Recommendation:** ship P1 (#1, #2) and P2 (#3–#6) — those move the adoption needle. P3 items are correct
-fixes but invisible to users. P4 internal-polish backlog was cleared on 2026-05-07 (8 audits/refactors landed
-in one branch — see "Recently completed" below). Multi-topic Phase 1 is the next focused effort.
+**Recommendation:** P1 (#1, #2) shipped. Next adoption needle is **P2 #5 — batch sinks**; that's the
+"can I batch-insert into Postgres?" feature Spring Kafka users evaluate against. Circuit breaker (#6) and
+HTTP-fetcher cleanup (#4) compose on top. P3 items are correct fixes but invisible to users — defer until
+something forces them. **No further internal polish** — diminishing returns.
 
-### Recently completed (P4 internal polish — 2026-05-07)
+### Recently shipped
 
-- Moved `OffsetState` and `ConsumerState` out of the `org.kpipe.consumer.enums` sub-package; deleted the
-  one-package-deep folder.
-- Added a discoverable docstring to `kpipe-metrics-otel/module-info.java`. (`kpipe-bom` is a `java-platform`
-  BOM with no `module-info.java` — its description in `build.gradle.kts` is the appropriate doc.)
-- **Audited and removed** `MessageProcessorRegistry.sourceAppName` — confirmed vestigial (set by 17 callers,
-  read by zero). Deleted the field, both `String`-taking constructors, the getter, and `withSourceAppName`.
-  Updated all 17 call sites.
-- **Audited** `KafkaConsumerConfig` — confirmed canonical (parallels `KafkaProducerConfig`, used by all 4
-  example apps + own test). No change.
-- **Audited** `MessageTracker` — keep as-is. Well-tested public class; potential 2.0 collapse target moved
-  to P5.
-- **Fixed** `KPipeProducer.sendAsync` silent-metrics footgun: previously returned the raw producer Future
-  with no instrumentation; now wraps with a callback that increments `messages.sent` / `messages.failed`.
-- **Tightened** `OffsetManager.createRebalanceListener()` — moved the no-op default into the interface as a
-  `default` method. Custom external offset stores no longer need to implement Kafka rebalance plumbing.
-- **Audited** `ConsumerCommand` sealed hierarchy — keep as-is. `CommitOffsets` is the cross-thread bridge
-  for both scheduled commits and `close()` path; `withOffsets` has a real callsite in `RebalanceListener`.
-- **Audited** `BackpressureController` public surface — already minimal. All instance methods are used,
-  factories are intentional escape hatches, `calculateTotalLag` is a useful static utility.
+- **2026-05-08 — api module cleanup** (`refactor/api-cleanup`): `DefaultStream` converted to record (11
+  field decls + 11 ctor assignments + 9 trivial accessors → auto-generated); `KPipeConsumer.Builder.enableMetrics(boolean)`
+  deleted (only `@Deprecated` in the codebase, all 9 callers migrated); `ToConsoleDispatchTest` parameterized;
+  redundant `KPipeFacadeBuildTest` factory tests dropped; `validateTopics` single-pass. Net **−160 lines**.
+- **2026-05-07 — multi-topic** (`feature/multi-topic`): both phases landed in one branch. Homogeneous via
+  `KPipe.json/avro/.../bytes/custom(Collection<String>, Properties)`; heterogeneous via
+  `KPipe.multi(props).json(topic, configurator).avro(...).start()`. Topic-aware OTel metrics with
+  `computeIfAbsent` `Attributes` cache. `Stream.skipBytes(int)` for Confluent envelope handling. Demo
+  collapsed from 3 explicit-API runners (~250 lines) to one `KPipe.multi(...)` (~50 lines).
+- **2026-05-07 — P4 internal polish backlog cleared**: `OffsetState`/`ConsumerState` out of the
+  `enums` sub-package; vestigial `MessageProcessorRegistry.sourceAppName` deleted; `KPipeProducer.sendAsync`
+  silent-metrics footgun fixed; `OffsetManager.createRebalanceListener()` made a `default` interface
+  method; `kpipe-metrics-otel/module-info.java` docstring added. 8 audits/refactors total.
 
 ---
 
@@ -117,18 +112,12 @@ Both phases landed in a single branch:
 - **Coverage:** `KPipeFacadeIntegrationTest.endToEndMultiTopicJsonStream` (homogeneous, 3 topics) and
   `endToEndHeterogeneousMulti` (JSON + bytes through one consumer).
 
-### P1 #2 — Java baseline decision (THINKING)
+### P1 #2 — Java baseline decision (DECIDED 2026-05-07: stay on Java 25)
 
-- **Status:** under consideration, not committed. Java 25 floor locks out ~95% of production Java teams (most
-  on 17 or 21).
-- **Option A — stay on 25:** ideologically pure (full `ScopedValue` stable, /// markdown javadoc, latest
-  pattern matching), niche audience, slow adoption. Fine if positioning is "for teams already on 25."
-- **Option B — drop to 21 LTS + ScopedValue preview:** keeps the §3 design (VT + ScopedValue, no
-  ThreadLocal). Costs users `--enable-preview`, awkward for some shops. VT itself is stable in 21.
-- **Option C — drop to 21 LTS stable, ScopedValue → ThreadLocal in fallback path:** broadest reach, but
-  regresses §3. Considered a regression.
-- **Recommendation:** Option B if we want adoption now; Option A if we wait for 25 to age into prod (~2027).
-  Multi-topic / batch sinks / circuit breaker should ship regardless; baseline choice is orthogonal.
+Stay on Java 25. Trade-off accepted: smaller initial audience (most prod teams still on 17/21) in exchange
+for `///` markdown javadoc, stable `ScopedValue` if we ever re-introduce thread-local-like state, modern
+pattern matching, and unnamed variables (`_`) in switch patterns. Re-evaluate if adoption hits a wall purely
+because of the baseline.
 
 ### P2 #3 — `Format.INSTANCE` singletons remain a footgun
 

--- a/.claude/PLAN.md
+++ b/.claude/PLAN.md
@@ -44,7 +44,7 @@ Single source of truth for what's left across the whole library.
 | 10 | **P5 — 2.0 candidates**   | Type-name shortening (`MessageProcessorRegistry` → `Pipelines`, etc.)                                                        | Breaking refactor | ~1 day    |
 | 11 | **P5 — 2.0 candidates**   | `Result<T>` sealed type for pipeline errors                                                                                  | Breaking refactor | ~1 day    |
 | 12 | **P5 — 2.0 candidates**   | Fold `KPipeRunner` into `KPipeConsumer`                                                                                      | Breaking refactor | ~half day |
-| 13 | **P5 — 2.0 candidates**   | `MessageTracker` collapse — add `KPipeConsumer.waitForInFlightDrain(Duration)`, deprecate the standalone class               | Breaking refactor | ~half day |
+| 13 | **P5 — 2.0 candidates**   | `MessageTracker` collapse — add `KPipeConsumer.waitForInFlightDrain(Duration)`, delete the standalone class                  | Breaking refactor | ~half day |
 | 14 | **P5 — Speculative perf** | Format serialization caches re-wire (only with JMH evidence)                                                                 | Perf              | ~1–2 days |
 
 **Recommendation:** ship P1 (#1, #2) and P2 (#3–#6) — those move the adoption needle. P3 items are correct

--- a/examples/avro/src/main/java/org/kpipe/App.java
+++ b/examples/avro/src/main/java/org/kpipe/App.java
@@ -127,7 +127,6 @@ public class App implements AutoCloseable {
       .withPollTimeout(config.pollTimeout())
       .withCommandQueue(commandQueue)
       .withOffsetManagerProvider(createOffsetManagerProvider(Duration.ofSeconds(30), commandQueue))
-      .enableMetrics(true)
       .build();
   }
 

--- a/examples/json/src/main/java/org/kpipe/App.java
+++ b/examples/json/src/main/java/org/kpipe/App.java
@@ -112,7 +112,6 @@ public class App implements AutoCloseable {
       .withPollTimeout(config.pollTimeout())
       .withCommandQueue(commandQueue)
       .withOffsetManagerProvider(createOffsetManagerProvider(Duration.ofSeconds(30), commandQueue))
-      .enableMetrics(true)
       .build();
   }
 

--- a/examples/protobuf/src/main/java/org/kpipe/App.java
+++ b/examples/protobuf/src/main/java/org/kpipe/App.java
@@ -112,7 +112,6 @@ public class App implements AutoCloseable {
       .withPollTimeout(config.pollTimeout())
       .withCommandQueue(commandQueue)
       .withOffsetManagerProvider(createOffsetManagerProvider(Duration.ofSeconds(30), commandQueue))
-      .enableMetrics(true)
       .build();
   }
 

--- a/lib/kpipe-api/src/main/java/org/kpipe/DefaultStream.java
+++ b/lib/kpipe-api/src/main/java/org/kpipe/DefaultStream.java
@@ -3,7 +3,6 @@ package org.kpipe;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Objects;
 import java.util.Properties;
@@ -17,29 +16,29 @@ import org.kpipe.registry.Operators;
 import org.kpipe.sink.CompositeMessageSink;
 import org.kpipe.sink.MessageSink;
 
-/// Package-private immutable implementation of [Stream]. Each fluent method returns a NEW
+/// Package-private immutable record-based [Stream]. Each fluent method returns a NEW
 /// `DefaultStream` carrying the updated configuration; the original instance is never mutated.
 /// This makes branching safe (`s.pipe(a)` and `s.pipe(b)` produce independent streams) and
 /// matches the Java Stream API's functional style.
 ///
-/// On [#toCustom] / [#toConsole] / [#toMulti] the configuration is frozen into a [DefaultSink];
-/// any further fluent calls on the original stream cannot affect the already-terminated chain.
+/// Adding a new fluent setter is a one-place change: declare the component, add the `with*`
+/// fluent method, and reference it in [DefaultSink#buildPipeline] if it affects pipeline
+/// construction.
 ///
 /// @param <T> the deserialized message type
-final class DefaultStream<T> implements Stream<T> {
-
-  private final Set<String> topics;
-  private final Properties kafkaProps;
-  private final MessageFormat<T> format;
-  private final Supplier<MessageSink<T>> defaultConsoleSinkFactory;
-  private final List<UnaryOperator<T>> operators;
-  private final int maxRetries;
-  private final Duration retryBackoff;
-  private final Long backpressureHigh;
-  private final Long backpressureLow;
-  private final boolean sequentialProcessing;
-  private final int skipBytes;
-
+record DefaultStream<T>(
+  Set<String> topics,
+  Properties kafkaProps,
+  MessageFormat<T> format,
+  Supplier<MessageSink<T>> defaultConsoleSinkFactory,
+  List<UnaryOperator<T>> operators,
+  int maxRetries,
+  Duration retryBackoff,
+  Long backpressureHigh,
+  Long backpressureLow,
+  boolean sequentialProcessing,
+  int skipBytes
+) implements Stream<T> {
   /// Public constructor used by [KPipe] factories — single topic, empty pipeline, default
   /// retry / backpressure settings.
   DefaultStream(
@@ -51,11 +50,9 @@ final class DefaultStream<T> implements Stream<T> {
     this(Set.of(Objects.requireNonNull(topic, "topic cannot be null")), kafkaProps, format, defaultConsoleSinkFactory);
   }
 
-  /// Public constructor used by [KPipe] factories — multiple topics, single shared pipeline,
-  /// empty operator chain, default retry / backpressure settings.
-  ///
-  /// Defensively copies `kafkaProps` so that subsequent caller mutations do not silently affect
-  /// the in-flight stream. Defensively copies `topics` into an immutable insertion-ordered set.
+  /// Public constructor used by [KPipe] factories — multiple topics, single shared pipeline.
+  /// Defensively copies `kafkaProps` and `topics` so subsequent caller mutations cannot affect
+  /// the in-flight stream.
   DefaultStream(
     final Collection<String> topics,
     final Properties kafkaProps,
@@ -80,56 +77,10 @@ final class DefaultStream<T> implements Stream<T> {
   private static Set<String> validateTopics(final Collection<String> topics) {
     Objects.requireNonNull(topics, "topics cannot be null");
     if (topics.isEmpty()) throw new IllegalArgumentException("topics cannot be empty");
-    final var copy = new LinkedHashSet<String>(topics.size());
     for (final var t : topics) {
       if (t == null || t.isBlank()) throw new IllegalArgumentException("topic name cannot be null or blank");
-      copy.add(t);
     }
-    return Set.copyOf(copy);
-  }
-
-  private DefaultStream(
-    final Set<String> topics,
-    final Properties kafkaProps,
-    final MessageFormat<T> format,
-    final Supplier<MessageSink<T>> defaultConsoleSinkFactory,
-    final List<UnaryOperator<T>> operators,
-    final int maxRetries,
-    final Duration retryBackoff,
-    final Long backpressureHigh,
-    final Long backpressureLow,
-    final boolean sequentialProcessing,
-    final int skipBytes
-  ) {
-    this.topics = topics;
-    this.kafkaProps = kafkaProps;
-    this.format = format;
-    this.defaultConsoleSinkFactory = defaultConsoleSinkFactory;
-    this.operators = operators;
-    this.maxRetries = maxRetries;
-    this.retryBackoff = retryBackoff;
-    this.backpressureHigh = backpressureHigh;
-    this.backpressureLow = backpressureLow;
-    this.sequentialProcessing = sequentialProcessing;
-    this.skipBytes = skipBytes;
-  }
-
-  private DefaultStream<T> withOperator(final UnaryOperator<T> op) {
-    final var next = new ArrayList<>(operators);
-    next.add(op);
-    return new DefaultStream<>(
-      topics,
-      kafkaProps,
-      format,
-      defaultConsoleSinkFactory,
-      List.copyOf(next),
-      maxRetries,
-      retryBackoff,
-      backpressureHigh,
-      backpressureLow,
-      sequentialProcessing,
-      skipBytes
-    );
+    return Set.copyOf(topics);
   }
 
   @Override
@@ -160,6 +111,7 @@ final class DefaultStream<T> implements Stream<T> {
   @Override
   public Stream<T> withRetry(final int maxRetries, final Duration backoff) {
     if (maxRetries < 0) throw new IllegalArgumentException("maxRetries cannot be negative");
+    Objects.requireNonNull(backoff, "backoff cannot be null");
     return new DefaultStream<>(
       topics,
       kafkaProps,
@@ -167,7 +119,7 @@ final class DefaultStream<T> implements Stream<T> {
       defaultConsoleSinkFactory,
       operators,
       maxRetries,
-      Objects.requireNonNull(backoff, "backoff cannot be null"),
+      backoff,
       backpressureHigh,
       backpressureLow,
       sequentialProcessing,
@@ -182,7 +134,7 @@ final class DefaultStream<T> implements Stream<T> {
 
   @Override
   public Stream<T> withBackpressure(final long high, final long low) {
-    if (high <= 0 || low < 0 || low >= high) throw new IllegalArgumentException(
+    if (low < 0 || low >= high) throw new IllegalArgumentException(
       "Invalid watermarks: high must be positive and > low (got high=%d, low=%d)".formatted(high, low)
     );
     return new DefaultStream<>(
@@ -254,43 +206,21 @@ final class DefaultStream<T> implements Stream<T> {
     return new DefaultSink<>(this, new CompositeMessageSink<>(List.of(sinks)));
   }
 
-  Set<String> topics() {
-    return topics;
-  }
-
-  Properties kafkaProps() {
-    return kafkaProps;
-  }
-
-  MessageFormat<T> format() {
-    return format;
-  }
-
-  List<UnaryOperator<T>> operators() {
-    return operators;
-  }
-
-  int maxRetries() {
-    return maxRetries;
-  }
-
-  Duration retryBackoff() {
-    return retryBackoff;
-  }
-
-  Long backpressureHigh() {
-    return backpressureHigh;
-  }
-
-  Long backpressureLow() {
-    return backpressureLow;
-  }
-
-  boolean sequentialProcessing() {
-    return sequentialProcessing;
-  }
-
-  int skipBytes() {
-    return skipBytes;
+  private DefaultStream<T> withOperator(final UnaryOperator<T> op) {
+    final var next = new ArrayList<>(operators);
+    next.add(op);
+    return new DefaultStream<>(
+      topics,
+      kafkaProps,
+      format,
+      defaultConsoleSinkFactory,
+      List.copyOf(next),
+      maxRetries,
+      retryBackoff,
+      backpressureHigh,
+      backpressureLow,
+      sequentialProcessing,
+      skipBytes
+    );
   }
 }

--- a/lib/kpipe-api/src/main/java/org/kpipe/KPipe.java
+++ b/lib/kpipe-api/src/main/java/org/kpipe/KPipe.java
@@ -28,17 +28,16 @@ import org.kpipe.sink.MessageSink;
 ///     .start();
 /// ```
 ///
-/// This facade is purely additive — it delegates to the existing
-/// [org.kpipe.registry.MessageProcessorRegistry] / [org.kpipe.consumer.KPipeConsumer.Builder] /
-/// [org.kpipe.consumer.KPipeRunner.Builder] stack and does not replace any public API.
+/// Each format exposes two overloads: one taking a single `String topic` and one taking a
+/// `Collection<String> topics` for homogeneous multi-topic consumption (single shared pipeline).
+/// For heterogeneous routes (per-topic typing) use [#multi].
 public final class KPipe {
 
   private static final Logger LOGGER = System.getLogger(KPipe.class.getName());
 
   private KPipe() {}
 
-  /// Creates a JSON-typed stream that consumes from the given topic. Messages are deserialized
-  /// to `Map<String, Object>`.
+  /// JSON-typed stream consuming from `topic`. Messages deserialize to `Map<String, Object>`.
   ///
   /// @param topic the Kafka topic to consume
   /// @param kafkaProps the Kafka consumer properties
@@ -47,8 +46,7 @@ public final class KPipe {
     return new DefaultStream<>(topic, kafkaProps, JsonFormat.INSTANCE, JsonFormat::consoleSink);
   }
 
-  /// Creates a JSON-typed stream that consumes from multiple homogeneous topics through a single
-  /// shared pipeline. All topics must produce the same payload shape.
+  /// JSON-typed stream consuming from multiple homogeneous topics through a single shared pipeline.
   ///
   /// @param topics the Kafka topics to consume (must be non-empty)
   /// @param kafkaProps the Kafka consumer properties
@@ -57,12 +55,12 @@ public final class KPipe {
     return new DefaultStream<>(topics, kafkaProps, JsonFormat.INSTANCE, JsonFormat::consoleSink);
   }
 
-  /// Creates an Avro-typed stream that consumes from the given topic. Messages are deserialized
-  /// to `GenericRecord` using the format's configured default schema.
+  /// Avro-typed stream consuming from `topic`. Messages deserialize to `GenericRecord` using the
+  /// format's configured default schema.
   ///
-  /// `toConsole()` will throw [IllegalStateException] if no default schema has been registered
-  /// under key `"1"` on [AvroFormat#INSTANCE], since the console sink needs the schema to
-  /// re-encode payloads as JSON.
+  /// `toConsole()` throws [IllegalStateException] if no default schema is registered under key
+  /// `"1"` on [AvroFormat#INSTANCE] — the console sink needs the schema to re-encode payloads
+  /// as JSON. Pass `.toCustom(AvroFormat.consoleSink(schema))` to bind a specific schema.
   ///
   /// @param topic the Kafka topic to consume
   /// @param kafkaProps the Kafka consumer properties
@@ -71,7 +69,8 @@ public final class KPipe {
     return new DefaultStream<>(topic, kafkaProps, AvroFormat.INSTANCE, AvroFormat::defaultConsoleSink);
   }
 
-  /// Multi-topic Avro variant. See [#avro(String, Properties)] for the schema requirement.
+  /// Avro-typed stream consuming from multiple homogeneous topics. See [#avro(String, Properties)]
+  /// for the schema requirement.
   ///
   /// @param topics the Kafka topics to consume (must be non-empty)
   /// @param kafkaProps the Kafka consumer properties
@@ -80,8 +79,8 @@ public final class KPipe {
     return new DefaultStream<>(topics, kafkaProps, AvroFormat.INSTANCE, AvroFormat::defaultConsoleSink);
   }
 
-  /// Creates a Protobuf-typed stream that consumes from the given topic. Messages are
-  /// deserialized to `com.google.protobuf.Message`.
+  /// Protobuf-typed stream consuming from `topic`. Messages deserialize to
+  /// `com.google.protobuf.Message`.
   ///
   /// @param topic the Kafka topic to consume
   /// @param kafkaProps the Kafka consumer properties
@@ -90,7 +89,7 @@ public final class KPipe {
     return new DefaultStream<>(topic, kafkaProps, ProtobufFormat.INSTANCE, ProtobufFormat::consoleSink);
   }
 
-  /// Multi-topic Protobuf variant.
+  /// Protobuf-typed stream consuming from multiple homogeneous topics.
   ///
   /// @param topics the Kafka topics to consume (must be non-empty)
   /// @param kafkaProps the Kafka consumer properties
@@ -99,10 +98,8 @@ public final class KPipe {
     return new DefaultStream<>(topics, kafkaProps, ProtobufFormat.INSTANCE, ProtobufFormat::consoleSink);
   }
 
-  /// Creates a raw `byte[]` stream — identity passthrough, no SerDe.
-  ///
-  /// `toConsole()` returns a sink that logs a UTF-8 preview when the bytes look like text and a
-  /// hex preview otherwise.
+  /// Raw `byte[]` stream — identity passthrough, no SerDe. `toConsole()` logs a UTF-8 preview
+  /// when the payload looks like text, hex preview otherwise.
   ///
   /// @param topic the Kafka topic to consume
   /// @param kafkaProps the Kafka consumer properties
@@ -111,7 +108,7 @@ public final class KPipe {
     return new DefaultStream<>(topic, kafkaProps, MessageFormat.bytes(), KPipe::bytesConsoleSink);
   }
 
-  /// Multi-topic raw `byte[]` variant.
+  /// Raw `byte[]` stream consuming from multiple homogeneous topics.
   ///
   /// @param topics the Kafka topics to consume (must be non-empty)
   /// @param kafkaProps the Kafka consumer properties
@@ -120,9 +117,8 @@ public final class KPipe {
     return new DefaultStream<>(topics, kafkaProps, MessageFormat.bytes(), KPipe::bytesConsoleSink);
   }
 
-  /// Creates a stream backed by a user-supplied [MessageFormat]. The default `toConsole()` for
-  /// custom streams logs values via `String.valueOf(value)` — pass `toCustom(...)` for richer
-  /// formatting.
+  /// Stream backed by a user-supplied [MessageFormat]. The default `toConsole()` for custom
+  /// streams logs values via `String.valueOf(value)` — pass `toCustom(...)` for richer formatting.
   ///
   /// @param topic the Kafka topic to consume
   /// @param kafkaProps the Kafka consumer properties
@@ -130,10 +126,10 @@ public final class KPipe {
   /// @param <T> the deserialized message type
   /// @return a fluent [Stream] for the supplied format
   public static <T> Stream<T> custom(final String topic, final Properties kafkaProps, final MessageFormat<T> format) {
-    return new DefaultStream<>(topic, kafkaProps, format, () -> value -> LOGGER.log(Level.INFO, "{0}", value));
+    return new DefaultStream<>(topic, kafkaProps, format, KPipe::loggingSink);
   }
 
-  /// Multi-topic custom-format variant.
+  /// Custom-format stream consuming from multiple homogeneous topics.
   ///
   /// @param topics the Kafka topics to consume (must be non-empty)
   /// @param kafkaProps the Kafka consumer properties
@@ -145,13 +141,11 @@ public final class KPipe {
     final Properties kafkaProps,
     final MessageFormat<T> format
   ) {
-    return new DefaultStream<>(topics, kafkaProps, format, () -> value -> LOGGER.log(Level.INFO, "{0}", value));
+    return new DefaultStream<>(topics, kafkaProps, format, KPipe::loggingSink);
   }
 
-  /// Creates a heterogeneous multi-topic builder. Each route registers a per-topic pipeline,
-  /// so different topics can carry different payload shapes through one consumer-group / one
-  /// offset manager.
-  ///
+  /// Heterogeneous multi-topic builder. Each route registers a per-topic pipeline so different
+  /// topics can carry different payload shapes through one consumer-group / one offset manager.
   /// Records arriving for unrouted topics are dropped at WARNING and their offsets are still
   /// committed.
   ///
@@ -168,8 +162,8 @@ public final class KPipe {
     return new MultiBuilder(kafkaProps);
   }
 
-  /// Returns a [MessageSink] that prints `byte[]` values as either UTF-8 (when the payload looks
-  /// like text) or as a hex preview. This is the default sink used by [#bytes] for `toConsole`.
+  /// `MessageSink` that prints `byte[]` values as either UTF-8 (when the payload looks like
+  /// text) or as a hex preview. Used by [#bytes] for `toConsole`.
   ///
   /// @return a console sink for `byte[]` payloads
   public static MessageSink<byte[]> bytesConsoleSink() {
@@ -182,9 +176,12 @@ public final class KPipe {
         LOGGER.log(Level.INFO, "empty");
         return;
       }
-      final var rendered = renderBytes(value);
-      LOGGER.log(Level.INFO, "{0}", rendered);
+      LOGGER.log(Level.INFO, "{0}", renderBytes(value));
     };
+  }
+
+  private static <T> MessageSink<T> loggingSink() {
+    return value -> LOGGER.log(Level.INFO, "{0}", value);
   }
 
   private static String renderBytes(final byte[] value) {

--- a/lib/kpipe-api/src/test/java/org/kpipe/KPipeApiTest.java
+++ b/lib/kpipe-api/src/test/java/org/kpipe/KPipeApiTest.java
@@ -1,8 +1,6 @@
 package org.kpipe;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -48,6 +46,6 @@ class KPipeApiTest {
     for (final var op : ds.operators()) v = op.apply(v);
 
     assertEquals(42L, v.get("ts"));
-    assertTrue(!v.containsKey("password"), "removeFields should drop the password field");
+    assertFalse(v.containsKey("password"), "removeFields should drop the password field");
   }
 }

--- a/lib/kpipe-api/src/test/java/org/kpipe/KPipeBytesConsoleSinkTest.java
+++ b/lib/kpipe-api/src/test/java/org/kpipe/KPipeBytesConsoleSinkTest.java
@@ -88,7 +88,7 @@ class KPipeBytesConsoleSinkTest {
   }
 
   /// JUL [Handler] that captures each [LogRecord]'s formatted message into an in-memory buffer.
-  /// Handles parameterized messages (e.g. `{0}`) via [MessageFormat#format].
+  /// Handles parameterized messages (e.g. `{0}`) via [MessageFormat#format(Object)].
   private static final class CapturingHandler extends Handler {
 
     private final ByteArrayOutputStream buffer = new ByteArrayOutputStream();

--- a/lib/kpipe-api/src/test/java/org/kpipe/KPipeFacadeBuildTest.java
+++ b/lib/kpipe-api/src/test/java/org/kpipe/KPipeFacadeBuildTest.java
@@ -2,16 +2,11 @@ package org.kpipe;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-import com.google.protobuf.Message;
-import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 import java.util.concurrent.atomic.AtomicReference;
-import org.apache.avro.generic.GenericRecord;
 import org.junit.jupiter.api.Test;
 import org.kpipe.format.json.JsonFormat;
-import org.kpipe.registry.MessageFormat;
 
 /// Verifies that each top-level [KPipe] factory returns a non-null [Stream] and that the chain
 /// of fluent operations accumulates state correctly without requiring a real Kafka connection.
@@ -24,37 +19,6 @@ class KPipeFacadeBuildTest {
     props.setProperty("key.deserializer", "org.apache.kafka.common.serialization.ByteArrayDeserializer");
     props.setProperty("value.deserializer", "org.apache.kafka.common.serialization.ByteArrayDeserializer");
     return props;
-  }
-
-  @Test
-  void jsonFactoryReturnsStream() {
-    final Stream<Map<String, Object>> stream = KPipe.json("events", props());
-    assertNotNull(stream);
-    assertInstanceOf(DefaultStream.class, stream);
-  }
-
-  @Test
-  void avroFactoryReturnsStream() {
-    final Stream<GenericRecord> stream = KPipe.avro("events", props());
-    assertNotNull(stream);
-  }
-
-  @Test
-  void protobufFactoryReturnsStream() {
-    final Stream<Message> stream = KPipe.protobuf("events", props());
-    assertNotNull(stream);
-  }
-
-  @Test
-  void bytesFactoryReturnsStream() {
-    final Stream<byte[]> stream = KPipe.bytes("events", props());
-    assertNotNull(stream);
-  }
-
-  @Test
-  void customFactoryReturnsStream() {
-    final Stream<byte[]> stream = KPipe.custom("events", props(), MessageFormat.bytes());
-    assertNotNull(stream);
   }
 
   @Test
@@ -73,31 +37,6 @@ class KPipeFacadeBuildTest {
     assertNotSame(root, chained, "immutable fluent chain should return a new instance per step");
     assertEquals(0, root.operators().size(), "root stream remains untouched");
     assertEquals(4, chained.operators().size());
-  }
-
-  @Test
-  void operatorsAreInvokedInAdditionOrder() {
-    final var trace = new java.util.ArrayList<Integer>();
-    final var stream = (DefaultStream<Map<String, Object>>) KPipe.json("topic", props())
-      .pipe(m -> {
-        trace.add(1);
-        return m;
-      })
-      .pipe(m -> {
-        trace.add(2);
-        return m;
-      })
-      .pipe(m -> {
-        trace.add(3);
-        return m;
-      });
-
-    final var ops = stream.operators();
-    assertEquals(3, ops.size());
-
-    Map<String, Object> v = new HashMap<>();
-    for (final var op : ops) v = op.apply(v);
-    assertEquals(List.of(1, 2, 3), trace);
   }
 
   @Test

--- a/lib/kpipe-api/src/test/java/org/kpipe/KPipeFacadeIntegrationTest.java
+++ b/lib/kpipe-api/src/test/java/org/kpipe/KPipeFacadeIntegrationTest.java
@@ -119,7 +119,7 @@ class KPipeFacadeIntegrationTest {
       assertTrue(handle.isHealthy(), "Handle should be healthy after start()");
 
       // Produce messages with ids 1..6; expect only 1, 3, 5 to make it through.
-      produceFixedAndWait(topic, 6, captured, 3, Duration.ofSeconds(20));
+      produceFixedAndWait(captured, Duration.ofSeconds(20));
 
       assertAll(
         "Filtered captures",
@@ -293,26 +293,21 @@ class KPipeFacadeIntegrationTest {
 
   /// Produces `count` JSON payloads with sequential ids 1..count and waits for `expected`
   /// messages to land in the sink (used by the filter test to confirm only odd-id messages pass).
-  private static void produceFixedAndWait(
-    final String topic,
-    final int count,
-    final List<Map<String, Object>> sink,
-    final int expected,
-    final Duration timeout
-  ) throws Exception {
+  private static void produceFixedAndWait(final List<Map<String, Object>> sink, final Duration timeout)
+    throws Exception {
     final var producerProps = producerProps();
     try (final var producer = new KafkaProducer<byte[], byte[]>(producerProps)) {
-      for (int i = 1; i <= count; i++) {
+      for (int i = 1; i <= 6; i++) {
         final var json = """
           {"id":%d,"value":"v%d"}""".formatted(i, i)
           .getBytes(StandardCharsets.UTF_8);
-        producer.send(new ProducerRecord<>(topic, json)).get();
+        producer.send(new ProducerRecord<>("kpipe-facade-filter-test", json)).get();
       }
       producer.flush();
     }
     // Wait until the sink stops growing OR we hit `expected`. Then give a small grace period to
     // ensure any extra (unwanted) messages would have arrived too.
-    waitFor(() -> sink.size() >= expected, timeout, "Timed out waiting for %d filtered messages".formatted(expected));
+    waitFor(() -> sink.size() >= 3, timeout, "Timed out waiting for %d filtered messages".formatted(3));
     // Grace period: ensure no extra messages slip through after expected reached.
     TimeUnit.MILLISECONDS.sleep(500);
   }

--- a/lib/kpipe-api/src/test/java/org/kpipe/StreamCompositionTest.java
+++ b/lib/kpipe-api/src/test/java/org/kpipe/StreamCompositionTest.java
@@ -7,6 +7,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Properties;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.UnaryOperator;
@@ -153,8 +154,8 @@ class StreamCompositionTest {
       return m;
     });
 
-    assertEquals("left", apply(left, new HashMap<>()).get("branch"));
-    assertEquals("right", apply(right, new HashMap<>()).get("branch"));
+    assertEquals("left", Objects.requireNonNull(apply(left, new HashMap<>())).get("branch"));
+    assertEquals("right", Objects.requireNonNull(apply(right, new HashMap<>())).get("branch"));
     assertEquals(0, root.operators().size(), "root should remain unchanged");
   }
 }

--- a/lib/kpipe-api/src/test/java/org/kpipe/ToConsoleDispatchTest.java
+++ b/lib/kpipe-api/src/test/java/org/kpipe/ToConsoleDispatchTest.java
@@ -1,22 +1,27 @@
 package org.kpipe;
 
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import com.google.protobuf.Message;
 import java.util.Map;
 import java.util.Properties;
 import org.apache.avro.SchemaBuilder;
-import org.apache.avro.generic.GenericRecord;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.kpipe.format.avro.AvroConsoleSink;
 import org.kpipe.format.avro.AvroFormat;
 import org.kpipe.format.json.JsonConsoleSink;
 import org.kpipe.format.protobuf.ProtobufConsoleSink;
+import org.kpipe.sink.CompositeMessageSink;
 import org.kpipe.sink.MessageSink;
 
-/// Verifies that `Stream<T>.toConsole()` dispatches to the format-appropriate sink type.
+/// Verifies that `Stream<T>.toConsole()` dispatches to the format-appropriate sink type, and that
+/// `toCustom` / `toMulti` produce the expected wrappers.
 class ToConsoleDispatchTest {
 
   private static Properties props() {
@@ -26,68 +31,36 @@ class ToConsoleDispatchTest {
     return props;
   }
 
-  @Test
-  void jsonToConsoleProducesJsonConsoleSink() {
-    final var sink = (DefaultSink<Map<String, Object>>) KPipe.json("t", props()).toConsole();
-    assertTrue(sink.terminalSink() instanceof JsonConsoleSink<?>);
+  /// Format → expected `toConsole()` sink type. `bytes` uses a lambda sink (no class to assert
+  /// on), so its expected type is `null` and the test just verifies non-null.
+  static java.util.stream.Stream<Arguments> consoleDispatchCases() {
+    return java.util.stream.Stream.of(
+      Arguments.of("json", (StreamFactory) KPipe::json, JsonConsoleSink.class),
+      Arguments.of("avro", (StreamFactory) KPipe::avro, AvroConsoleSink.class),
+      Arguments.of("protobuf", (StreamFactory) KPipe::protobuf, ProtobufConsoleSink.class),
+      Arguments.of("bytes", (StreamFactory) KPipe::bytes, null)
+    );
   }
 
-  @Test
-  void avroToConsoleRequiresRegisteredSchema() {
-    AvroFormat.INSTANCE.clearSchemas();
-    final var stream = KPipe.avro("t", props());
-    assertThrows(IllegalStateException.class, stream::toConsole);
-  }
-
-  @Test
-  void avroToConsoleSucceedsWithRegisteredSchema() {
-    AvroFormat.INSTANCE.clearSchemas();
-    final var schema = SchemaBuilder.record("Test")
-      .namespace("org.kpipe.test")
-      .fields()
-      .requiredString("id")
-      .endRecord();
-    AvroFormat.INSTANCE.addSchema("1", schema.toString());
+  @ParameterizedTest(name = "{0}.toConsole() dispatches to expected sink")
+  @MethodSource("consoleDispatchCases")
+  void toConsoleDispatchesToFormatAppropriateSink(
+    final String formatName,
+    final StreamFactory factory,
+    final Class<?> expectedSinkType
+  ) {
+    if ("avro".equals(formatName)) registerAvroSchema();
     try {
-      final var sink = (DefaultSink<GenericRecord>) KPipe.avro("t", props()).toConsole();
-      assertTrue(sink.terminalSink() instanceof AvroConsoleSink<?>);
+      final var sink = (DefaultSink<?>) factory.create("t", props()).toConsole();
+      if (expectedSinkType == null) assertNotNull(sink.terminalSink());
+      else assertTrue(expectedSinkType.isInstance(sink.terminalSink()), () ->
+        "expected %s, got %s".formatted(expectedSinkType.getSimpleName(), sink.terminalSink().getClass())
+      );
     } finally {
-      AvroFormat.INSTANCE.clearSchemas();
+      if ("avro".equals(formatName)) AvroFormat.INSTANCE.clearSchemas();
     }
   }
 
-  @Test
-  void protobufToConsoleProducesProtobufConsoleSink() {
-    final var sink = (DefaultSink<Message>) KPipe.protobuf("t", props()).toConsole();
-    assertTrue(sink.terminalSink() instanceof ProtobufConsoleSink<?>);
-  }
-
-  @Test
-  void bytesToConsoleProducesNonNullSink() {
-    final var sink = (DefaultSink<byte[]>) KPipe.bytes("t", props()).toConsole();
-    assertNotNull(sink.terminalSink());
-  }
-
-  @Test
-  void toCustomReturnsProvidedSink() {
-    final MessageSink<Map<String, Object>> custom = _ -> {};
-    final var sink = (DefaultSink<Map<String, Object>>) KPipe.json("t", props()).toCustom(custom);
-    assertTrue(sink.terminalSink() == custom);
-  }
-
-  @Test
-  void toMultiWrapsCompositeSink() {
-    final MessageSink<Map<String, Object>> a = _ -> {};
-    final MessageSink<Map<String, Object>> b = _ -> {};
-    final var sink = (DefaultSink<Map<String, Object>>) KPipe.json("t", props()).toMulti(a, b);
-    assertNotNull(sink.terminalSink());
-    assertTrue(sink.terminalSink() instanceof org.kpipe.sink.CompositeMessageSink<?>);
-  }
-
-  /// Asserts that `KPipe.avro(...).toConsole()` fails fast when no default Avro schema has been
-  /// registered under key `"1"` on [AvroFormat#INSTANCE]. The schema map on `INSTANCE` is
-  /// process-wide state, so we explicitly clear it before constructing the stream to make this
-  /// test deterministic regardless of test ordering within the same JVM.
   @Test
   void avroToConsoleThrowsWhenNoDefaultSchemaRegistered() {
     AvroFormat.INSTANCE.clearSchemas();
@@ -95,5 +68,36 @@ class ToConsoleDispatchTest {
     final var ex = assertThrows(IllegalStateException.class, stream::toConsole);
     assertTrue(ex.getMessage().contains("Avro"), () -> "expected message to mention Avro: " + ex.getMessage());
     assertTrue(ex.getMessage().contains("schema"), () -> "expected message to mention schema: " + ex.getMessage());
+  }
+
+  @Test
+  void toCustomReturnsProvidedSink() {
+    final MessageSink<Map<String, Object>> custom = _ -> {};
+    final var sink = (DefaultSink<Map<String, Object>>) KPipe.json("t", props()).toCustom(custom);
+    assertSame(custom, sink.terminalSink());
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  void toMultiWrapsCompositeSink() {
+    final MessageSink<Map<String, Object>> a = _ -> {};
+    final MessageSink<Map<String, Object>> b = _ -> {};
+    final var sink = (DefaultSink<Map<String, Object>>) KPipe.json("t", props()).toMulti(a, b);
+    assertInstanceOf(CompositeMessageSink.class, sink.terminalSink());
+  }
+
+  private static void registerAvroSchema() {
+    AvroFormat.INSTANCE.clearSchemas();
+    final var schema = SchemaBuilder.record("Test")
+      .namespace("org.kpipe.test")
+      .fields()
+      .requiredString("id")
+      .endRecord();
+    AvroFormat.INSTANCE.addSchema("1", schema.toString());
+  }
+
+  @FunctionalInterface
+  private interface StreamFactory {
+    Stream<?> create(String topic, Properties props);
   }
 }

--- a/lib/kpipe-consumer/src/main/java/org/kpipe/consumer/KPipeConsumer.java
+++ b/lib/kpipe-consumer/src/main/java/org/kpipe/consumer/KPipeConsumer.java
@@ -273,22 +273,7 @@ public class KPipeConsumer<K> implements AutoCloseable {
       return this;
     }
 
-    /// Enables or disables metrics collection.
-    ///
-    /// As of `1.10.0`, metrics are enabled by default. Prefer [#disableMetrics()] to opt out;
-    /// this overload is retained for backwards compatibility.
-    ///
-    /// @param enable Whether to enable a metrics collection
-    /// @return This builder instance for method chaining
-    /// @deprecated since `1.10.0` — metrics default to enabled. Call [#disableMetrics()] to turn
-    ///     them off; no replacement is needed when leaving them enabled.
-    @Deprecated(since = "1.10.0")
-    public Builder<K> enableMetrics(final boolean enable) {
-      this.enableMetrics = enable;
-      return this;
-    }
-
-    /// Disables metrics collection. Metrics are enabled by default as of `1.10.0`.
+    /// Disables metrics collection. Metrics are enabled by default.
     ///
     /// @return This builder instance for method chaining
     public Builder<K> disableMetrics() {

--- a/lib/kpipe-consumer/src/test/java/org/kpipe/consumer/KPipeConsumerMockingTest.java
+++ b/lib/kpipe-consumer/src/test/java/org/kpipe/consumer/KPipeConsumerMockingTest.java
@@ -471,7 +471,7 @@ class KPipeConsumerMockingTest {
         .withProperties(properties)
         .withTopic(TOPIC)
         .withPipeline(TestPipelines.identity())
-        .enableMetrics(false)
+        .disableMetrics()
         .build()
     ) {
       assertTrue(consumer.getMetrics().isEmpty(), "Metrics should be empty when disabled");
@@ -490,9 +490,7 @@ class KPipeConsumerMockingTest {
     final KPipeConsumer.ErrorHandler<String> errorHandler = error -> {};
     final var maxRetries = 3;
     final var retryBackoff = Duration.ofMillis(100);
-    final var enableMetrics = true;
 
-    // Create a consumer with all options
     final var consumer = KPipeConsumer.<String>builder()
       .withProperties(properties)
       .withTopic(TOPIC)
@@ -500,7 +498,6 @@ class KPipeConsumerMockingTest {
       .withPollTimeout(pollTimeout)
       .withErrorHandler(errorHandler)
       .withRetry(maxRetries, retryBackoff)
-      .enableMetrics(enableMetrics)
       .build();
 
     // Assert

--- a/lib/kpipe-consumer/src/test/java/org/kpipe/consumer/KPipeConsumerTest.java
+++ b/lib/kpipe-consumer/src/test/java/org/kpipe/consumer/KPipeConsumerTest.java
@@ -155,7 +155,6 @@ class KPipeConsumerTest {
       .withTopic(TOPIC)
       .withPipeline(TestPipelines.sideEffect(retryProcessor))
       .withRetry(2, Duration.ofMillis(10))
-      .enableMetrics(true)
       .build();
     final var record = createRecord(0, "key", "hello");
 
@@ -186,7 +185,6 @@ class KPipeConsumerTest {
       .withPipeline(TestPipelines.sideEffect(failingProcessor))
       .withRetry(2, Duration.ofMillis(10))
       .withErrorHandler(errorHandler)
-      .enableMetrics(true)
       .build();
     final var record = createRecord(0, "key", "hello");
 
@@ -223,7 +221,6 @@ class KPipeConsumerTest {
       .withTopic(TOPIC)
       .withPipeline(TestPipelines.sideEffect(intermittentProcessor))
       .withRetry(5, Duration.ofMillis(10))
-      .enableMetrics(true)
       .build();
 
     // Act
@@ -344,7 +341,7 @@ class KPipeConsumerTest {
       .withProperties(properties)
       .withTopic(TOPIC)
       .withPipeline(TestPipelines.identity())
-      .enableMetrics(false)
+      .disableMetrics()
       .build();
     final var record = createRecord(1, "k", "v");
 
@@ -502,7 +499,7 @@ class KPipeConsumerTest {
         .withProperties(properties)
         .withTopic(TOPIC)
         .withPipeline(TestPipelines.identity())
-        .enableMetrics(false)
+        .disableMetrics()
         .withBackpressure(10_000, 7_000)
         .build()
     );


### PR DESCRIPTION


DefaultStream -> record
- Convert from class to record. 11 explicit field declarations + 11 constructor assignments + 9 trivial accessors -> all auto-generated. Single canonical constructor, two delegating constructors for single-topic vs Collection<String> input
- Adding a new fluent setter is now a one-place change: declare the component, add the with* method, reference it in DefaultSink.buildPipeline if it affects pipeline construction
- validateTopics: single-pass -- drop the redundant LinkedHashSet intermediate, iterate once for null/blank validation, single Set.copyOf for the immutable result. Insertion-order claim was vestigial (Set.copyOf doesn't preserve it; no caller depends on it)

KPipe.java
- Trim repetitive class- and method-level Javadoc while keeping @param / @return tags so the published javadoc jar stays clean
- Factor the inline custom() default sink into a private loggingSink() helper

Test cleanup
- ToConsoleDispatchTest: 6 nearly-identical toConsole() dispatch tests collapsed into one @ParameterizedTest with a MethodSource. Kept the 3 distinct focused tests (avro-no-schema-throws, toCustom, toMulti)
- KPipeFacadeBuildTest: drop 5 trivial XfactoryReturnsStream tests (covered by ToConsoleDispatchTest's parameterized run + the full chainingWithoutStartingDoesNotThrow case) and 1 operator-order test that overlapped with StreamCompositionTest. 14 -> 9 tests in the file
- KPipeApiTest, KPipeBytesConsoleSinkTest, KPipeFacadeIntegrationTest, StreamCompositionTest: minor lint/formatting touch-ups from the record conversion

Deprecation purge
- Delete KPipeConsumer.Builder.enableMetrics(boolean), the only @Deprecated method in the codebase. Migrate all 9 callers: 3 example apps drop the no-op .enableMetrics(true), 4 tests drop the same, 3 tests with .enableMetrics(false) switch to .disableMetrics(), 1 variable-driven test case is rewritten
- Codebase now has zero @Deprecated annotations and zero @deprecated Javadoc tags

PLAN.md
- Row #13 (MessageTracker collapse): "deprecate the standalone class" -> "delete the standalone class" -- match the no-deprecation policy