### PR TITLE
refactor(metrics): drop null-default trick + add LOGGING constant

### DIFF
--- a/lib/kpipe-consumer/src/main/java/org/kpipe/consumer/metrics/EntryMetricsReporter.java
+++ b/lib/kpipe-consumer/src/main/java/org/kpipe/consumer/metrics/EntryMetricsReporter.java
@@ -3,6 +3,7 @@ package org.kpipe.consumer.metrics;
 import java.lang.System.Logger;
 import java.lang.System.Logger.Level;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.function.Consumer;
 import java.util.function.Function;
@@ -20,16 +21,11 @@ import org.kpipe.registry.RegistryKey;
 ///
 /// ```java
 /// // Report operator metrics
-/// final var processorReporter = EntryMetricsReporter.forProcessors(registry);
-/// processorReporter.reportMetrics();
+/// EntryMetricsReporter.forProcessors(registry).reportMetrics();
 ///
-/// // Report sink metrics
-/// final var sinkReporter = EntryMetricsReporter.forSinks(registry);
-/// sinkReporter.reportMetrics();
-///
-/// // Custom output sink
-/// EntryMetricsReporter.forProcessors(registry)
-///   .toConsumer(metric -> PrometheusClient.pushMetric("processor_stats", metric))
+/// // Report sink metrics, with a subset of keys and a Prometheus consumer
+/// EntryMetricsReporter.forSinks(registry, Set.of(dbSinkKey))
+///   .toConsumer(metric -> prometheus.push("sink_stats", metric))
 ///   .reportMetrics();
 /// ```
 ///
@@ -37,8 +33,9 @@ import org.kpipe.registry.RegistryKey;
 ///                          log-message prefix and the reporter's identity in mixed pipelines
 /// @param namesSupplier     supplier of the set of [RegistryKey]s to report on
 /// @param metricsFetcher    function from a key to its metric snapshot
-/// @param reporter          consumer for each formatted report line (defaults to a logger when
-///                          constructed with `null`)
+/// @param reporter          consumer for each formatted report line. Must be non-null — use
+///                          [#LOGGING] for the default log-based behaviour, or supply your own
+///                          via [#toConsumer(Consumer)]
 public record EntryMetricsReporter(
   String entryKind,
   Supplier<Set<RegistryKey<?>>> namesSupplier,
@@ -48,17 +45,17 @@ public record EntryMetricsReporter(
 
   private static final Logger LOGGER = System.getLogger(EntryMetricsReporter.class.getName());
 
-  /// Canonical constructor; defaults `reporter` to a logger when null.
-  public EntryMetricsReporter(
-    final String entryKind,
-    final Supplier<Set<RegistryKey<?>>> namesSupplier,
-    final Function<RegistryKey<?>, Map<String, Object>> metricsFetcher,
-    final Consumer<String> reporter
-  ) {
-    this.entryKind = entryKind;
-    this.namesSupplier = namesSupplier;
-    this.metricsFetcher = metricsFetcher;
-    this.reporter = reporter != null ? reporter : this::logMetrics;
+  /// Default reporter that logs each line at INFO via the package logger. Use as the `reporter`
+  /// argument to the canonical constructor when you want log-based output.
+  public static final Consumer<String> LOGGING = line -> LOGGER.log(Level.INFO, line);
+
+  /// Canonical constructor; rejects null fields so the record is transparent (`reporter()` always
+  /// returns the value the caller supplied).
+  public EntryMetricsReporter {
+    Objects.requireNonNull(entryKind, "entryKind cannot be null");
+    Objects.requireNonNull(namesSupplier, "namesSupplier cannot be null");
+    Objects.requireNonNull(metricsFetcher, "metricsFetcher cannot be null");
+    Objects.requireNonNull(reporter, "reporter cannot be null — use EntryMetricsReporter.LOGGING for the default");
   }
 
   @Override
@@ -69,9 +66,7 @@ public record EntryMetricsReporter(
         .forEach(key -> {
           try {
             final var metrics = metricsFetcher.apply(key);
-            if (!metrics.isEmpty()) {
-              reporter.accept("%s '%s' metrics: %s".formatted(entryKind, key.name(), metrics));
-            }
+            if (!metrics.isEmpty()) reporter.accept("%s '%s' metrics: %s".formatted(entryKind, key.name(), metrics));
           } catch (final Exception e) {
             LOGGER.log(Level.WARNING, "Error retrieving metrics for %s: %s".formatted(entryKind.toLowerCase(), key.name()), e);
           }
@@ -81,38 +76,39 @@ public record EntryMetricsReporter(
     }
   }
 
-  private void logMetrics(final String metrics) {
-    LOGGER.log(Level.INFO, metrics);
-  }
-
-  /// Creates a reporter for every operator registered in `registry`.
+  /// Creates a reporter for every operator registered in `registry`, with default log-based
+  /// output. Use [#forProcessors(MessageProcessorRegistry, Set)] for a specific subset.
   public static EntryMetricsReporter forProcessors(final MessageProcessorRegistry registry) {
-    return new EntryMetricsReporter("Processor", registry::getKeys, registry::getMetrics, null);
+    Objects.requireNonNull(registry, "registry cannot be null");
+    return new EntryMetricsReporter("Processor", registry::getKeys, registry::getMetrics, LOGGING);
   }
 
-  /// Creates a reporter for a specific subset of operators.
+  /// Creates a reporter for the given subset of operator keys, with default log-based output.
   public static EntryMetricsReporter forProcessors(
     final MessageProcessorRegistry registry,
     final Set<RegistryKey<?>> keys
   ) {
-    return new EntryMetricsReporter("Processor", () -> keys, registry::getMetrics, null);
+    Objects.requireNonNull(registry, "registry cannot be null");
+    Objects.requireNonNull(keys, "keys cannot be null");
+    return new EntryMetricsReporter("Processor", () -> keys, registry::getMetrics, LOGGING);
   }
 
-  /// Creates a reporter for every sink registered in `registry`.
+  /// Creates a reporter for every sink registered in `registry`, with default log-based output.
   public static EntryMetricsReporter forSinks(final MessageProcessorRegistry registry) {
-    return new EntryMetricsReporter("Sink", registry::getSinkKeys, registry::getSinkMetrics, null);
+    Objects.requireNonNull(registry, "registry cannot be null");
+    return new EntryMetricsReporter("Sink", registry::getSinkKeys, registry::getSinkMetrics, LOGGING);
   }
 
-  /// Creates a reporter for a specific subset of sinks.
-  public static EntryMetricsReporter forSinks(
-    final MessageProcessorRegistry registry,
-    final Set<RegistryKey<?>> keys
-  ) {
-    return new EntryMetricsReporter("Sink", () -> keys, registry::getSinkMetrics, null);
+  /// Creates a reporter for the given subset of sink keys, with default log-based output.
+  public static EntryMetricsReporter forSinks(final MessageProcessorRegistry registry, final Set<RegistryKey<?>> keys) {
+    Objects.requireNonNull(registry, "registry cannot be null");
+    Objects.requireNonNull(keys, "keys cannot be null");
+    return new EntryMetricsReporter("Sink", () -> keys, registry::getSinkMetrics, LOGGING);
   }
 
-  /// Returns a new reporter with the specified output consumer.
+  /// Returns a new reporter with the specified output consumer. The other fields are preserved.
   public EntryMetricsReporter toConsumer(final Consumer<String> reporter) {
+    Objects.requireNonNull(reporter, "reporter cannot be null");
     return new EntryMetricsReporter(this.entryKind, this.namesSupplier, this.metricsFetcher, reporter);
   }
 }

--- a/lib/kpipe-consumer/src/test/java/org/kpipe/consumer/metrics/EntryMetricsReporterTest.java
+++ b/lib/kpipe-consumer/src/test/java/org/kpipe/consumer/metrics/EntryMetricsReporterTest.java
@@ -79,11 +79,20 @@ class EntryMetricsReporterTest {
   }
 
   @Test
-  void forProcessors_defaultsToLoggerWhenConsumerIsNull() {
+  void forProcessors_defaultReporterUsesLOGGING() {
     doReturn(keys).when(registry).getKeys();
     doReturn(testMetrics).when(registry).getMetrics(any(RegistryKey.class));
 
-    assertDoesNotThrow(() -> EntryMetricsReporter.forProcessors(registry).reportMetrics());
+    final var rep = EntryMetricsReporter.forProcessors(registry);
+    assertSame(EntryMetricsReporter.LOGGING, rep.reporter(), "factory must wire the LOGGING reporter");
+    assertDoesNotThrow(rep::reportMetrics);
+  }
+
+  @Test
+  void canonicalConstructorRejectsNullReporter() {
+    assertThrows(NullPointerException.class, () ->
+      new EntryMetricsReporter("Processor", namesSupplier, metricsFetcher, null)
+    );
   }
 
   // ─────────────────────────────── forSinks ────────────────────────────────


### PR DESCRIPTION
## Summary

Two MEDIUM-priority fixes from the [stack review](https://github.com/eschizoid/kpipe/pull/107):

1. **Drop null-default trick** — `EntryMetricsReporter`'s canonical constructor silently replaced a `null` reporter with `this::logMetrics`, breaking record transparency (`new EntryMetricsReporter(..., null).reporter()` returned a non-null method ref, not `null`). Now the constructor rejects `null`; callers asking for log-based output use the new public `LOGGING` constant.
2. **Factory wiring** — the four static factories (`forProcessors`, `forProcessors(_, keys)`, `forSinks`, `forSinks(_, keys)`) now wire `LOGGING` explicitly instead of relying on the null trick.

Tests: `forProcessors_defaultsToLoggerWhenConsumerIsNull` renamed to `forProcessors_defaultReporterUsesLOGGING` and sharpened to assert the wiring uses the public constant. Added `canonicalConstructorRejectsNullReporter` for the new invariant.

## Stack
Stacks on top of [#109](https://github.com/eschizoid/kpipe/pull/109) (consumer-lifecycle-fixes).