### PR TITLE
refactor: extract backpressure-default constants + clarify dual-CLOSED path

### DIFF
--- a/lib/kpipe-consumer/src/main/java/org/kpipe/consumer/BackpressureController.java
+++ b/lib/kpipe-consumer/src/main/java/org/kpipe/consumer/BackpressureController.java
@@ -27,6 +27,13 @@ public record BackpressureController(long highWatermark, long lowWatermark, Stra
   /// Bounded timeout used for the `endOffsets()` broker call inside the lag strategy. Caps how
   /// long the consumer thread can be blocked when the broker is slow or unreachable.
   private static final Duration LAG_QUERY_TIMEOUT = Duration.ofSeconds(2);
+
+  /// Default high watermark (in-flight count or lag) at which the consumer pauses. Used by
+  /// `KPipeConsumer.Builder.withBackpressure()` (no-arg) and by the constructor when no
+  /// controller is explicitly configured.
+  public static final long DEFAULT_HIGH_WATERMARK = 10_000;
+  /// Default low watermark at which the consumer resumes (hysteresis floor).
+  public static final long DEFAULT_LOW_WATERMARK = 7_000;
   /// Creates a new BackpressureController with the same watermarks but a different strategy.
   ///
   /// @param strategy the new strategy to use

--- a/lib/kpipe-consumer/src/main/java/org/kpipe/consumer/KPipeConsumer.java
+++ b/lib/kpipe-consumer/src/main/java/org/kpipe/consumer/KPipeConsumer.java
@@ -468,7 +468,7 @@ public class KPipeConsumer<K> implements AutoCloseable {
     ///
     /// @return This builder instance for method chaining
     public Builder<K> withBackpressure() {
-      return withBackpressure(10_000, 7_000);
+      return withBackpressure(BackpressureController.DEFAULT_HIGH_WATERMARK, BackpressureController.DEFAULT_LOW_WATERMARK);
     }
 
     /// Enables backpressure control using the given high and low watermarks. When the number of
@@ -734,7 +734,7 @@ public class KPipeConsumer<K> implements AutoCloseable {
     this.backpressureController = (
       builder.backpressureController != null
         ? builder.backpressureController
-        : new BackpressureController(10_000, 7_000, null)
+        : new BackpressureController(BackpressureController.DEFAULT_HIGH_WATERMARK, BackpressureController.DEFAULT_LOW_WATERMARK, null)
     ).withStrategy(
       this.sequentialProcessing
         ? BackpressureController.lagStrategy()
@@ -1024,6 +1024,11 @@ public class KPipeConsumer<K> implements AutoCloseable {
           } catch (final Exception e) {
             LOGGER.log(Level.WARNING, "Error closing Kafka consumer", e);
           } finally {
+            // CLOSED is also set at the tail of close(); both paths are idempotent and
+            // CountDownLatch.countDown() past zero is a no-op. This path catches the case where
+            // the consumer thread terminates via an uncaught exception path (transitionToClosing
+            // → outer finally) — close() may not have been called externally, but awaitShutdown
+            // callers must still unblock.
             state.set(ConsumerState.CLOSED);
             shutdownLatch.countDown();
           }


### PR DESCRIPTION
## Summary

LOW-priority fixes from the [stack review](https://github.com/eschizoid/kpipe/pull/107):

1. **Default watermarks duplicated** — `KPipeConsumer.Builder.withBackpressure()` (no-arg) and the constructor's no-controller fallback each hard-coded `(10_000, 7_000)`. Moved to two public constants on `BackpressureController`: `DEFAULT_HIGH_WATERMARK` and `DEFAULT_LOW_WATERMARK`. Single source of truth.
2. **Dual `state.set(CLOSED)`** — both the consumer thread's terminal `finally` and `close()` run `state.set(CLOSED) + shutdownLatch.countDown()`. Both paths are idempotent and the second countdown is a no-op, but it wasn't obvious why. Added a brief comment explaining the thread-finally path catches uncaught-exception cases where `close()` is never called externally.

**Not done:** the agent's `registerEnum` → `registerOperatorEnum` rename suggestion. §7 of CLAUDE.md explicitly documents the asymmetry as intentional (operators unsuffixed = primary, sinks suffixed = secondary), so renaming would break the convention rather than enforce it.

## Stack
Stacks on top of [#112](https://github.com/eschizoid/kpipe/pull/112) (facade-start-helper). Top of the stack.