### PR TITLE
refactor(api): extract DefaultHandle.startAndWrap to dedupe start-and-close

### DIFF
--- a/lib/kpipe-api/src/main/java/org/kpipe/DefaultBatchSink.java
+++ b/lib/kpipe-api/src/main/java/org/kpipe/DefaultBatchSink.java
@@ -2,7 +2,6 @@ package org.kpipe;
 
 import java.util.Objects;
 import org.kpipe.consumer.KPipeConsumer;
-import org.kpipe.consumer.KPipeRunner;
 import org.kpipe.registry.MessagePipeline;
 import org.kpipe.registry.MessageProcessorRegistry;
 import org.kpipe.sink.BatchPolicy;
@@ -67,18 +66,6 @@ record DefaultBatchSink<T>(
     if (stream.deadLetterTopic() != null) consumerBuilder.withDeadLetterTopic(stream.deadLetterTopic());
     if (stream.pollTimeout() != null) consumerBuilder.withPollTimeout(stream.pollTimeout());
 
-    final var consumer = consumerBuilder.build();
-    final var runner = KPipeRunner.builder(consumer).build();
-    try {
-      runner.start();
-    } catch (final RuntimeException e) {
-      try {
-        consumer.close();
-      } catch (final Exception suppressed) {
-        e.addSuppressed(suppressed);
-      }
-      throw e;
-    }
-    return new DefaultHandle(runner, consumer);
+    return DefaultHandle.startAndWrap(consumerBuilder.build());
   }
 }

--- a/lib/kpipe-api/src/main/java/org/kpipe/DefaultHandle.java
+++ b/lib/kpipe-api/src/main/java/org/kpipe/DefaultHandle.java
@@ -39,4 +39,26 @@ record DefaultHandle(KPipeRunner<KPipeConsumer<byte[]>> runner, KPipeConsumer<by
     Objects.requireNonNull(timeout, "timeout cannot be null");
     return runner.shutdownGracefully(timeout.toMillis());
   }
+
+  /// Starts `consumer` and returns it wrapped in a `DefaultHandle`. If `start()` throws, closes
+  /// the consumer (suppressing any secondary exception onto the original) so the
+  /// `AutoCloseable` contract still holds when no `Handle` is returned to the caller.
+  ///
+  /// Shared by [DefaultSink#start()], [DefaultBatchSink#start()], and
+  /// [MultiBuilder#start()] — the only three facade-level start sites — so the
+  /// start-and-wrap dance lives in one place.
+  static Handle startAndWrap(final KPipeConsumer<byte[]> consumer) {
+    Objects.requireNonNull(consumer, "consumer cannot be null");
+    try {
+      consumer.start();
+    } catch (final RuntimeException e) {
+      try {
+        consumer.close();
+      } catch (final Exception suppressed) {
+        e.addSuppressed(suppressed);
+      }
+      throw e;
+    }
+    return new DefaultHandle(consumer);
+  }
 }

--- a/lib/kpipe-api/src/main/java/org/kpipe/DefaultSink.java
+++ b/lib/kpipe-api/src/main/java/org/kpipe/DefaultSink.java
@@ -2,13 +2,13 @@ package org.kpipe;
 
 import java.util.Objects;
 import org.kpipe.consumer.KPipeConsumer;
-import org.kpipe.consumer.KPipeRunner;
 import org.kpipe.registry.MessagePipeline;
 import org.kpipe.registry.MessageProcessorRegistry;
 import org.kpipe.sink.MessageSink;
 
 /// Package-private [Sink] impl. Holds the configured [DefaultStream] plus the chosen terminal
-/// [MessageSink] and constructs a fully-wired `KPipeConsumer` + `KPipeRunner` on `start()`.
+/// [MessageSink] and constructs a fully-wired [KPipeConsumer] on `start()`. The consumer hosts
+/// its own lifecycle since the 1.13 KPipeRunner fold.
 ///
 /// @param <T> the deserialized message type
 record DefaultSink<T>(DefaultStream<T> stream, MessageSink<T> terminalSink) implements Sink<T> {
@@ -37,21 +37,7 @@ record DefaultSink<T>(DefaultStream<T> stream, MessageSink<T> terminalSink) impl
     if (stream.tracer() != null) consumerBuilder.withTracer(stream.tracer());
     if (stream.circuitBreaker() != null) consumerBuilder.withCircuitBreaker(stream.circuitBreaker());
 
-    final var consumer = consumerBuilder.build();
-    final var runner = KPipeRunner.builder(consumer).build();
-    try {
-      runner.start();
-    } catch (final RuntimeException e) {
-      // Releasing the consumer here keeps the AutoCloseable contract reachable when start() throws
-      // before a Handle is returned.
-      try {
-        consumer.close();
-      } catch (final Exception suppressed) {
-        e.addSuppressed(suppressed);
-      }
-      throw e;
-    }
-    return new DefaultHandle(runner, consumer);
+    return DefaultHandle.startAndWrap(consumerBuilder.build());
   }
 
   /// Builds the [MessagePipeline] for this sink's stream + terminal sink. Reused by

--- a/lib/kpipe-api/src/main/java/org/kpipe/MultiBuilder.java
+++ b/lib/kpipe-api/src/main/java/org/kpipe/MultiBuilder.java
@@ -13,7 +13,6 @@ import java.util.function.Supplier;
 import org.apache.avro.generic.GenericRecord;
 import org.kpipe.consumer.CircuitBreakerController;
 import org.kpipe.consumer.KPipeConsumer;
-import org.kpipe.consumer.KPipeRunner;
 import org.kpipe.format.avro.AvroFormat;
 import org.kpipe.format.json.JsonFormat;
 import org.kpipe.format.protobuf.ProtobufFormat;
@@ -173,7 +172,7 @@ public final class MultiBuilder {
     return this;
   }
 
-  /// Builds and starts the underlying [KPipeConsumer] / [KPipeRunner] with the registered routes
+  /// Builds and starts the underlying [KPipeConsumer] with the registered routes
   /// and returns a [Handle] for lifecycle management.
   ///
   /// Routes terminating in `.toBatch(...)` are wired through `withBatchPipeline`; the consumer
@@ -202,19 +201,7 @@ public final class MultiBuilder {
     if (consumerMetrics != null) consumerBuilder.withMetrics(consumerMetrics);
     if (tracer != null) consumerBuilder.withTracer(tracer);
     if (circuitBreaker != null) consumerBuilder.withCircuitBreaker(circuitBreaker);
-    final var consumer = consumerBuilder.build();
-    final var runner = KPipeRunner.builder(consumer).build();
-    try {
-      runner.start();
-    } catch (final RuntimeException e) {
-      try {
-        consumer.close();
-      } catch (final Exception suppressed) {
-        e.addSuppressed(suppressed);
-      }
-      throw e;
-    }
-    return new DefaultHandle(runner, consumer);
+    return DefaultHandle.startAndWrap(consumerBuilder.build());
   }
 
   /// Type witness: pulls the typed pipeline + sink off the route, then calls the typed builder

--- a/lib/kpipe-consumer/src/main/java/org/kpipe/consumer/BackpressureController.java
+++ b/lib/kpipe-consumer/src/main/java/org/kpipe/consumer/BackpressureController.java
@@ -27,6 +27,13 @@ public record BackpressureController(long highWatermark, long lowWatermark, Stra
   /// Bounded timeout used for the `endOffsets()` broker call inside the lag strategy. Caps how
   /// long the consumer thread can be blocked when the broker is slow or unreachable.
   private static final Duration LAG_QUERY_TIMEOUT = Duration.ofSeconds(2);
+
+  /// Default high watermark (in-flight count or lag) at which the consumer pauses. Used by
+  /// `KPipeConsumer.Builder.withBackpressure()` (no-arg) and by the constructor when no
+  /// controller is explicitly configured.
+  public static final long DEFAULT_HIGH_WATERMARK = 10_000;
+  /// Default low watermark at which the consumer resumes (hysteresis floor).
+  public static final long DEFAULT_LOW_WATERMARK = 7_000;
   /// Creates a new BackpressureController with the same watermarks but a different strategy.
   ///
   /// @param strategy the new strategy to use

--- a/lib/kpipe-consumer/src/main/java/org/kpipe/consumer/KPipeConsumer.java
+++ b/lib/kpipe-consumer/src/main/java/org/kpipe/consumer/KPipeConsumer.java
@@ -468,7 +468,7 @@ public class KPipeConsumer<K> implements AutoCloseable {
     ///
     /// @return This builder instance for method chaining
     public Builder<K> withBackpressure() {
-      return withBackpressure(10_000, 7_000);
+      return withBackpressure(BackpressureController.DEFAULT_HIGH_WATERMARK, BackpressureController.DEFAULT_LOW_WATERMARK);
     }
 
     /// Enables backpressure control using the given high and low watermarks. When the number of
@@ -734,7 +734,7 @@ public class KPipeConsumer<K> implements AutoCloseable {
     this.backpressureController = (
       builder.backpressureController != null
         ? builder.backpressureController
-        : new BackpressureController(10_000, 7_000, null)
+        : new BackpressureController(BackpressureController.DEFAULT_HIGH_WATERMARK, BackpressureController.DEFAULT_LOW_WATERMARK, null)
     ).withStrategy(
       this.sequentialProcessing
         ? BackpressureController.lagStrategy()
@@ -1024,6 +1024,11 @@ public class KPipeConsumer<K> implements AutoCloseable {
           } catch (final Exception e) {
             LOGGER.log(Level.WARNING, "Error closing Kafka consumer", e);
           } finally {
+            // CLOSED is also set at the tail of close(); both paths are idempotent and
+            // CountDownLatch.countDown() past zero is a no-op. This path catches the case where
+            // the consumer thread terminates via an uncaught exception path (transitionToClosing
+            // → outer finally) — close() may not have been called externally, but awaitShutdown
+            // callers must still unblock.
             state.set(ConsumerState.CLOSED);
             shutdownLatch.countDown();
           }


### PR DESCRIPTION
## Summary

MEDIUM-priority fix from the [stack review](https://github.com/eschizoid/kpipe/pull/107):

`DefaultSink`, `DefaultBatchSink`, and `MultiBuilder` each implemented the same "call `consumer.start()`; on `RuntimeException` close + `addSuppressed` + rethrow; return `new DefaultHandle(consumer)`" pattern. Three identical 12-line blocks. Promoted to a static `DefaultHandle.startAndWrap(KPipeConsumer<byte[]>)` so the three sites collapse to one-liners and the error-handling logic lives in one place.

## Stack
Stacks on top of [#108](https://github.com/eschizoid/kpipe/pull/108) (entry-reporter-cleanup).

## Test plan
- [x] `lib/kpipe-api` compile + unit tests green locally
- [ ] CI build green on this branch