### PR TITLE
docs(consumer): add javadoc @param/@return on CB + EntryMetricsReporter (recovery follow-up)

### DIFF
--- a/lib/kpipe-consumer/src/main/java/org/kpipe/consumer/CircuitBreakerController.java
+++ b/lib/kpipe-consumer/src/main/java/org/kpipe/consumer/CircuitBreakerController.java
@@ -30,6 +30,8 @@ import java.util.Objects;
 /// @param windowSize       the rolling sample size — must match the stats window
 /// @param openDuration     how long the breaker stays in `OPEN` before probing
 public record CircuitBreakerController(double failureThreshold, int windowSize, Duration openDuration) {
+  /// Canonical constructor; validates `failureThreshold` is in `(0, 1]`, `windowSize` is positive,
+  /// and `openDuration` is non-null and positive.
   public CircuitBreakerController {
     if (failureThreshold <= 0.0 || failureThreshold > 1.0) {
       throw new IllegalArgumentException("failureThreshold must be in (0.0, 1.0], got %f".formatted(failureThreshold));
@@ -44,6 +46,9 @@ public record CircuitBreakerController(double failureThreshold, int windowSize, 
   /// In `CLOSED` state, returns `true` iff the window is full AND the failure rate has crossed
   /// the threshold. Requiring a full window avoids tripping on the first few failures before the
   /// breaker has any signal to work with.
+  ///
+  /// @param stats the rolling outcome window the breaker is observing
+  /// @return `true` if the breaker should transition CLOSED → OPEN
   public boolean shouldTrip(final CircuitBreakerStats stats) {
     if (stats.totalSamples() < windowSize) return false;
     return stats.failureRate() >= failureThreshold;
@@ -52,6 +57,11 @@ public record CircuitBreakerController(double failureThreshold, int windowSize, 
   /// In `OPEN` state, returns `true` iff `openDuration` has elapsed since the breaker tripped.
   /// `openedAtNanos` is `System.nanoTime()` from the trip; a `0L` sentinel (never tripped) always
   /// returns `false`.
+  ///
+  /// @param openedAtNanos `System.nanoTime()` captured at the trip, or `0L` if never tripped
+  /// @param nowNanos      the current `System.nanoTime()`
+  /// @return `true` if `openDuration` has elapsed and the consumer should transition
+  ///     OPEN → HALF_OPEN
   public boolean shouldProbe(final long openedAtNanos, final long nowNanos) {
     if (openedAtNanos == 0L) return false;
     return (nowNanos - openedAtNanos) >= openDuration.toNanos();

--- a/lib/kpipe-consumer/src/main/java/org/kpipe/consumer/metrics/EntryMetricsReporter.java
+++ b/lib/kpipe-consumer/src/main/java/org/kpipe/consumer/metrics/EntryMetricsReporter.java
@@ -78,12 +78,19 @@ public record EntryMetricsReporter(
 
   /// Creates a reporter for every operator registered in `registry`, with default log-based
   /// output. Use [#forProcessors(MessageProcessorRegistry, Set)] for a specific subset.
+  ///
+  /// @param registry the processor registry whose operator namespace to report on
+  /// @return a new reporter wired with the [#LOGGING] default output
   public static EntryMetricsReporter forProcessors(final MessageProcessorRegistry registry) {
     Objects.requireNonNull(registry, "registry cannot be null");
     return new EntryMetricsReporter("Processor", registry::getKeys, registry::getMetrics, LOGGING);
   }
 
   /// Creates a reporter for the given subset of operator keys, with default log-based output.
+  ///
+  /// @param registry the processor registry whose operator namespace to report on
+  /// @param keys     the specific operator keys to include in each report
+  /// @return a new reporter wired with the [#LOGGING] default output
   public static EntryMetricsReporter forProcessors(
     final MessageProcessorRegistry registry,
     final Set<RegistryKey<?>> keys
@@ -94,12 +101,19 @@ public record EntryMetricsReporter(
   }
 
   /// Creates a reporter for every sink registered in `registry`, with default log-based output.
+  ///
+  /// @param registry the processor registry whose sink namespace to report on
+  /// @return a new reporter wired with the [#LOGGING] default output
   public static EntryMetricsReporter forSinks(final MessageProcessorRegistry registry) {
     Objects.requireNonNull(registry, "registry cannot be null");
     return new EntryMetricsReporter("Sink", registry::getSinkKeys, registry::getSinkMetrics, LOGGING);
   }
 
   /// Creates a reporter for the given subset of sink keys, with default log-based output.
+  ///
+  /// @param registry the processor registry whose sink namespace to report on
+  /// @param keys     the specific sink keys to include in each report
+  /// @return a new reporter wired with the [#LOGGING] default output
   public static EntryMetricsReporter forSinks(final MessageProcessorRegistry registry, final Set<RegistryKey<?>> keys) {
     Objects.requireNonNull(registry, "registry cannot be null");
     Objects.requireNonNull(keys, "keys cannot be null");
@@ -107,6 +121,9 @@ public record EntryMetricsReporter(
   }
 
   /// Returns a new reporter with the specified output consumer. The other fields are preserved.
+  ///
+  /// @param reporter the consumer to receive each formatted report line
+  /// @return a new reporter routing output through `reporter`
   public EntryMetricsReporter toConsumer(final Consumer<String> reporter) {
     Objects.requireNonNull(reporter, "reporter cannot be null");
     return new EntryMetricsReporter(this.entryKind, this.namesSupplier, this.metricsFetcher, reporter);


### PR DESCRIPTION
## Summary

The doc-fix commits I made on the original PR #105 / #106 layered branches got dropped during the recovery PR's cherry-pick chain — git's "already applied" detection saw them as redundant relative to the rebase point, but they hadn't actually reached main. CI confirmed by reporting 18 javadoc warnings on `kpipe-consumer` after #113 merged.

This PR restores those doc fixes directly against main:

- **`CircuitBreakerController`** — constructor doc, `@param`/`@return` on `shouldTrip` and `shouldProbe`.
- **`EntryMetricsReporter`** — `@param`/`@return` on all four factories (`forProcessors`, `forProcessors(_, keys)`, `forSinks`, `forSinks(_, keys)`) and `toConsumer`.

No code changes. `./gradlew javadoc` now clean across all 10 modules.

## Test plan
- [x] `./gradlew :lib:kpipe-consumer:javadoc --rerun-tasks` clean
- [x] `./gradlew javadoc` clean (full codebase)