### PR TITLE
feat(core): introduce Result<T> sealed type for pipeline outcomes (1.13.0)

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -192,19 +192,31 @@
 
 - **Decision (1.9.0)**: `MessagePipeline.apply()` no longer overloads `null` as both "filtered" and "failed". Failures
   throw; `null` means exactly one thing — intentional filtering by `process()`.
+- **Decision (1.13.0)**: `MessagePipeline.process()` returns a sealed `Result<T>` (`Passed | Filtered | Failed`). The
+  three outcomes are now distinct *types* enforced by the compiler — the §12 doctrine moved from "convention enforced
+  by discipline" to "guarantee enforced by exhaustive pattern matching". The byte-level entry points (`apply`,
+  `processToSink`, `processToValue`) preserve their pre-1.13 contracts by unwrapping the Result internally: `null` for
+  intentional filters, re-throwing the captured `Failed.cause` for failures. New code that wants typed handling calls
+  `process()` directly and switches on the result.
 - **Reasoning**: The pre-1.9.0 implementation caught all exceptions in `apply()` and returned `null`. The downstream
   `KPipeConsumer.processTypedRecord` then treated `processed == null` as intentional filtering and incremented
   `messagesProcessed` — masking deserialization errors as successes. The only signal something was wrong was a gauge
-  mismatch (`messagesProcessed` rising while `sinkInvocationCount` stayed at 0).
+  mismatch (`messagesProcessed` rising while `sinkInvocationCount` stayed at 0). 1.9 fixed the *behaviour*; 1.13
+  fixed the *type* so the bug is impossible at compile time.
 - **Real-world burn**: Discovered during the Grafana dashboard session — protobuf seed messages all failed
   deserialization because `skipBytes(5)` was wrong, but the consumer reported them as processed. ~10 minutes wasted on
-  a bug that should have been a single error log.
+  a bug that should have been a single error log. After 1.13.0 the same bug would surface as a `Result.Failed` at the
+  consumer's pattern-match site — no convention to remember, no discipline to maintain.
 - **Implementation invariants**:
     - Null record value throws `IllegalStateException` with a specific message (retryable via the normal exception
       path).
     - Null deserialization result throws `IllegalStateException` (implementations must throw, not return null).
-    - Null `process()` result is the *only* legitimate filter signal — mark offset processed, count as success, no
-      error.
+    - `process()` returns `Result.Passed` (value flows on), `Result.Filtered` (offset committed, sink skipped), or
+      `Result.Failed(cause)` (retry/DLQ/error-handler routes the cause). The `Filtered` value is a shared singleton
+      via `Result.filtered()` to avoid per-record allocation; `Passed` and `Failed` each allocate one record per call.
+    - Operators (`UnaryOperator<T>`) still return `T` (or null for filter) — the Result wrapping lives at the
+      pipeline level, not at every operator. `TypedPipelineBuilder.build()` catches `RuntimeException` from operators
+      and converts to `Result.failed(...)`; null returns become `Result.filtered()`.
 - **Generalizable rule**: When composing `Function<T, R>` chains, never use `null`/`Optional.empty()` to signal both
   "filtered" and "failed". If both states exist, model them as distinct types (sealed `Result<T>` or distinct
   exceptions). Triage heuristic: when a "processed" counter rises but downstream invocations stay at 0, suspect

--- a/.claude/PLAN.md
+++ b/.claude/PLAN.md
@@ -39,7 +39,7 @@ closing that gap, not adding more features.
 | 6 | **P3 — User-visible**  | Residual build/test config cleanup (consumer parallelism, fork tuning)                                                               | Refactor  | ~30 min   |
 | 7 | **P3 — Audience**      | Spring Boot starter — opt-in module, `@KPipeListener`, auto-wires from `application.yml`. **Only build if a Spring-shop user asks.** | Feature   | ~1 week   |
 | 8  | **P5 — 2.0 candidate** | `MessageTracker` collapse — add `KPipeConsumer.waitForInFlightDrain(Duration)`, delete the standalone class                                                                | Breaking | ~half day |
-| 9  | **P5 — 2.0 candidate** | `Result<T>` sealed type for pipeline outcomes — make filter vs fail explicit at the *type* level instead of through the §12 null/throw convention. See §P5 detail below.   | Breaking | ~1–2 days |
+| 9  | ~~**P5 — 2.0 candidate**~~ | ~~`Result<T>` sealed type for pipeline outcomes — make filter vs fail explicit at the *type* level~~ — shipping in 1.13.0 (`MessagePipeline.process()` now returns `Result<T>` with `Passed | Filtered | Failed`). | Breaking | shipped  |
 | 10 | **P5 — Speculative**   | Format serialization caches re-wire — only with JMH evidence of allocation/GC pressure                                                                                     | Perf     | ~1–2 days |
 
 **Why this ordering:**

--- a/lib/kpipe-consumer/src/test/java/org/kpipe/consumer/KPipeDlqTest.java
+++ b/lib/kpipe-consumer/src/test/java/org/kpipe/consumer/KPipeDlqTest.java
@@ -177,8 +177,8 @@ class KPipeDlqTest {
       }
 
       @Override
-      public String process(final String data) {
-        return data;
+      public org.kpipe.registry.Result<String> process(final String data) {
+        return org.kpipe.registry.Result.passed(data);
       }
     };
   }

--- a/lib/kpipe-core/src/main/java/org/kpipe/registry/MessagePipeline.java
+++ b/lib/kpipe-core/src/main/java/org/kpipe/registry/MessagePipeline.java
@@ -6,20 +6,21 @@ import org.kpipe.sink.MessageSink;
 /// A unified pipeline interface that encapsulates the lifecycle:
 /// byte[] (Kafka) -> T (Deserialized Object) -> T (Processed Object) -> byte[] (Kafka).
 ///
-/// ## Error contract
+/// ## Error contract (1.13.0+)
 ///
-/// `apply()` distinguishes three outcomes:
-/// - **Success** — non-null bytes returned.
-/// - **Intentional filter** — `null` returned. The caller should treat the message as
-///   handled (e.g. commit the offset) but skip downstream sinks.
-/// - **Failure** — any exception is propagated. Implementations of [#deserialize],
-///   [#process], or [#serialize] that fail (malformed input, schema mismatch, etc.)
-///   MUST throw rather than return `null`. The caller is responsible for routing
-///   exceptions to error metrics, retry logic, or DLQ.
+/// `process(T)` returns a [Result] that distinguishes three outcomes at the type level:
+/// - **`Passed<T>`** — non-null processed value flows to the sink.
+/// - **`Filtered<T>`** — intentional drop. The caller treats the message as handled (e.g. commits
+///   the offset) but skips downstream sinks.
+/// - **`Failed<T>`** — non-fatal exception captured. The caller routes the cause to retry / DLQ /
+///   error-handler logic.
 ///
-/// Implementations MUST NOT use `null` as a generic error signal — `null` is reserved
-/// for the intentional-filter case from [#process]. [#deserialize] returning `null`
-/// is treated as a contract violation.
+/// `deserialize(byte[])` still throws on malformed input — Result is reserved for the
+/// `process()` boundary where the filter-vs-fail distinction lives. The byte-level entry points
+/// [#apply], [#processToSink], and [#processToValue] preserve their pre-1.13.0 contracts
+/// (returning null / void for the filter case, propagating exceptions for failures) by
+/// unwrapping the Result internally — so users on the byte boundary need not change. New code
+/// that wants typed handling calls [#process] directly.
 ///
 /// @param <T> The type of the object in the pipeline.
 public interface MessagePipeline<T> extends UnaryOperator<byte[]> {
@@ -39,12 +40,13 @@ public interface MessagePipeline<T> extends UnaryOperator<byte[]> {
 
   /// Applies the chain of transformations to the typed object.
   ///
-  /// Returning `null` signals an intentional filter — the caller should skip the
-  /// message without treating it as an error. Throw to signal a real failure.
+  /// Returns a [Result] distinguishing Passed / Filtered / Failed at the type level. The
+  /// implementation may throw fatal exceptions (`Error`, `InterruptedException` etc.) — only
+  /// non-fatal `RuntimeException`s should be captured into `Failed`.
   ///
-  /// @param data The deserialized object.
-  /// @return The processed object, or `null` to filter the message.
-  T process(T data);
+  /// @param data the deserialized object
+  /// @return a `Result<T>` describing the outcome
+  Result<T> process(T data);
 
   /// Returns the terminal sink configured for this pipeline, if any.
   ///
@@ -58,21 +60,25 @@ public interface MessagePipeline<T> extends UnaryOperator<byte[]> {
   /// Use this when you want bytes back (e.g. forwarding to another topic). Use
   /// [#processToSink] when you only care about the side-effect of [#getSink].
   ///
-  /// Exceptions propagate; `null` indicates an intentional filter from [#process].
-  /// See the interface-level error contract.
+  /// Preserves the pre-1.13.0 byte-level contract: `null` for intentional filters, exceptions
+  /// propagate for failures. The Result is unwrapped internally so byte-level callers don't see
+  /// the type.
   ///
   /// @param data The input bytes.
   /// @return The output bytes, or `null` if the message was intentionally filtered.
   /// @throws IllegalStateException if [#deserialize] returns `null` (contract violation).
+  /// @throws RuntimeException re-throws the cause from a `Result.Failed` outcome.
   @Override
   default byte[] apply(byte[] data) {
     final var deserialized = deserialize(data);
     if (deserialized == null) throw new IllegalStateException(
       "deserialize() returned null — implementations must throw on malformed input"
     );
-    final var processed = process(deserialized);
-    if (processed == null) return null;
-    return serialize(processed);
+    return switch (process(deserialized)) {
+      case Result.Passed<T> p -> serialize(p.value());
+      case Result.Filtered<T> __ -> null;
+      case Result.Failed<T> f -> throw rethrow(f.cause());
+    };
   }
 
   /// Executes deserialize → process → sink without serializing back to bytes.
@@ -80,20 +86,27 @@ public interface MessagePipeline<T> extends UnaryOperator<byte[]> {
   /// Use this when the sink is the terminal step (the common consumer pattern) — it
   /// avoids the wasted serialize() call that [#apply] performs.
   ///
-  /// Exceptions propagate; intentionally filtered messages return silently without
-  /// invoking the sink. See the interface-level error contract.
+  /// Intentionally filtered messages return silently without invoking the sink; failures
+  /// re-throw the captured cause.
   ///
   /// @param data The input bytes.
   /// @throws IllegalStateException if [#deserialize] returns `null` (contract violation).
+  /// @throws RuntimeException re-throws the cause from a `Result.Failed` outcome.
   default void processToSink(byte[] data) {
     final var deserialized = deserialize(data);
     if (deserialized == null) throw new IllegalStateException(
       "deserialize() returned null — implementations must throw on malformed input"
     );
-    final var processed = process(deserialized);
-    if (processed == null) return;
-    final var sink = getSink();
-    if (sink != null) sink.accept(processed);
+    switch (process(deserialized)) {
+      case Result.Passed<T> p -> {
+        final var sink = getSink();
+        if (sink != null) sink.accept(p.value());
+      }
+      case Result.Filtered<T> __ -> {
+        /* intentional filter — no sink invocation */
+      }
+      case Result.Failed<T> f -> throw rethrow(f.cause());
+    }
   }
 
   /// Executes deserialize → process and returns the resulting value without invoking any sink
@@ -101,18 +114,23 @@ public interface MessagePipeline<T> extends UnaryOperator<byte[]> {
   /// can buffer the deserialized value alongside the originating Kafka record before flushing
   /// in batches.
   ///
-  /// Exceptions propagate exactly as in [#processToSink]. A `null` return means the message
-  /// was intentionally filtered by [#process] — callers should treat the offset as handled.
+  /// Preserves the pre-1.13.0 contract: `null` return = intentional filter; exceptions for
+  /// failures.
   ///
   /// @param data the input bytes
   /// @return the processed value, or `null` if the message was intentionally filtered
   /// @throws IllegalStateException if [#deserialize] returns `null` (contract violation)
+  /// @throws RuntimeException re-throws the cause from a `Result.Failed` outcome.
   default T processToValue(byte[] data) {
     final var deserialized = deserialize(data);
     if (deserialized == null) throw new IllegalStateException(
       "deserialize() returned null — implementations must throw on malformed input"
     );
-    return process(deserialized);
+    return switch (process(deserialized)) {
+      case Result.Passed<T> p -> p.value();
+      case Result.Filtered<T> __ -> null;
+      case Result.Failed<T> f -> throw rethrow(f.cause());
+    };
   }
 
   /// Composes this pipeline with another of the same type T, running this pipeline's
@@ -120,17 +138,10 @@ public interface MessagePipeline<T> extends UnaryOperator<byte[]> {
   /// type. The composed pipeline reuses this pipeline's deserializer/serializer; only
   /// the [#process] and [#getSink] steps from `next` are chained.
   ///
-  /// If this pipeline's `process` returns null (intentional filter), the next pipeline
-  /// is not invoked and the composed pipeline returns null.
+  /// If this pipeline's `process` returns `Filtered` or `Failed`, the next pipeline is not
+  /// invoked and the composed result is the first outcome.
   ///
   /// If `next` has a sink, it runs after this pipeline's sink.
-  ///
-  /// Example — chain enrichment then validation:
-  /// ```java
-  /// final var enrich = registry.pipeline(JsonFormat.INSTANCE).add(addTimestamp).build();
-  /// final var validate = registry.pipeline(JsonFormat.INSTANCE).add(checkRequiredFields).build();
-  /// final var combined = enrich.then(validate);
-  /// ```
   ///
   /// @param next the pipeline to run after this one
   /// @return a composed MessagePipeline driving both stages
@@ -148,10 +159,12 @@ public interface MessagePipeline<T> extends UnaryOperator<byte[]> {
       }
 
       @Override
-      public T process(final T data) {
-        final var first = self.process(data);
-        if (first == null) return null;
-        return next.process(first);
+      public Result<T> process(final T data) {
+        return switch (self.process(data)) {
+          case Result.Passed<T> p -> next.process(p.value());
+          case Result.Filtered<T> filtered -> filtered;
+          case Result.Failed<T> failed -> failed;
+        };
       }
 
       @Override
@@ -166,5 +179,15 @@ public interface MessagePipeline<T> extends UnaryOperator<byte[]> {
         };
       }
     };
+  }
+
+  /// Re-throws a captured cause as an unchecked exception. `RuntimeException` and `Error` pass
+  /// through directly; checked exceptions are wrapped in `RuntimeException` (the byte-level
+  /// callers don't declare checked throws). This preserves the pre-1.13.0 propagation behavior
+  /// at the byte-level entry points.
+  private static RuntimeException rethrow(final Throwable cause) {
+    if (cause instanceof RuntimeException re) return re;
+    if (cause instanceof Error err) throw err;
+    return new RuntimeException(cause);
   }
 }

--- a/lib/kpipe-core/src/main/java/org/kpipe/registry/Result.java
+++ b/lib/kpipe-core/src/main/java/org/kpipe/registry/Result.java
@@ -1,0 +1,103 @@
+package org.kpipe.registry;
+
+import java.util.Objects;
+
+/// Three-way outcome of a [MessagePipeline] stage. Replaces the pre-1.13.0 convention (`null =
+/// filter`, `throw = fail`) with a type-level distinction enforced by the compiler.
+///
+/// Use the static factories or pattern-match exhaustively:
+///
+/// ```java
+/// switch (pipeline.process(record)) {
+///   case Result.Passed<T> p   -> sink.accept(p.value());
+///   case Result.Filtered<T> _ -> markOffsetProcessed(record);
+///   case Result.Failed<T> f   -> handleProcessingError(record, f.cause());
+/// }
+/// ```
+///
+/// **Why this exists.** §12 of CLAUDE.md settled "null = filter, throw = fail" as a doctrine — a
+/// convention enforced by discipline. The protobuf `skipBytes(5)` burn that motivated §12 was
+/// caused by a caller accidentally treating a deserialization failure as an intentional filter.
+/// `Result<T>` upgrades the convention to a compile-time guarantee: `Passed`, `Filtered`, and
+/// `Failed` are distinct types, and pattern-matching is exhaustive.
+///
+/// **Allocation note.** `Passed` and `Failed` allocate one record per call (on the hot path that's
+/// one per record per pipeline stage). `Filtered` returns a shared singleton via [#filtered()] to
+/// avoid an allocation in the common filter case. JMH-validate before claiming "zero-cost" — the
+/// `Passed` allocation is the real cost.
+///
+/// @param <T> the pipeline value type
+public sealed interface Result<T> permits Result.Passed, Result.Filtered, Result.Failed {
+  /// The record passed through the stage successfully.
+  ///
+  /// @param value the processed value (must be non-null — use [#filtered()] for intentional
+  ///     drops)
+  /// @param <T>   the pipeline value type
+  record Passed<T>(T value) implements Result<T> {
+    /// Compact constructor enforcing the non-null invariant.
+    public Passed {
+      Objects.requireNonNull(value, "Passed.value cannot be null; use Filtered for intentional drops");
+    }
+  }
+
+  /// The record was intentionally filtered out by the pipeline. Carries no value because there is
+  /// no value to carry — the consumer should mark the offset as processed without invoking the
+  /// sink.
+  ///
+  /// Use [#filtered()] to obtain the shared singleton instead of `new Filtered<>()` on the hot
+  /// path.
+  ///
+  /// @param <T> the pipeline value type
+  record Filtered<T>() implements Result<T> {
+    @SuppressWarnings({ "rawtypes", "unchecked" })
+    private static final Filtered SHARED = new Filtered();
+
+    /// Returns the shared `Filtered` sentinel. Avoids per-record allocation on filter-heavy
+    /// pipelines. Safe to share across types since the record carries no state.
+    ///
+    /// @param <T> the pipeline value type
+    /// @return the shared singleton, cast to `Filtered<T>`
+    @SuppressWarnings("unchecked")
+    public static <T> Filtered<T> instance() {
+      return (Filtered<T>) SHARED;
+    }
+  }
+
+  /// The pipeline failed processing the record. Carries the non-fatal exception that caused the
+  /// failure — the consumer routes this to retry / DLQ / error-handler logic.
+  ///
+  /// @param cause the exception thrown by an operator or sink (must be non-null)
+  /// @param <T>   the pipeline value type
+  record Failed<T>(Throwable cause) implements Result<T> {
+    /// Compact constructor enforcing the non-null invariant.
+    public Failed {
+      Objects.requireNonNull(cause, "Failed.cause cannot be null");
+    }
+  }
+
+  /// Factory for the success case.
+  ///
+  /// @param value the processed value (must be non-null)
+  /// @param <T>   the pipeline value type
+  /// @return a new `Passed<T>` wrapping `value`
+  static <T> Result<T> passed(final T value) {
+    return new Passed<>(value);
+  }
+
+  /// Factory for the intentional-filter case. Returns the shared singleton.
+  ///
+  /// @param <T> the pipeline value type
+  /// @return the shared `Filtered<T>` singleton
+  static <T> Result<T> filtered() {
+    return Filtered.instance();
+  }
+
+  /// Factory for the failure case.
+  ///
+  /// @param cause the exception that caused the failure (must be non-null)
+  /// @param <T>   the pipeline value type
+  /// @return a new `Failed<T>` wrapping `cause`
+  static <T> Result<T> failed(final Throwable cause) {
+    return new Failed<>(cause);
+  }
+}

--- a/lib/kpipe-core/src/main/java/org/kpipe/registry/TypedPipelineBuilder.java
+++ b/lib/kpipe-core/src/main/java/org/kpipe/registry/TypedPipelineBuilder.java
@@ -135,14 +135,18 @@ public final class TypedPipelineBuilder<T> {
       }
 
       @Override
-      public T process(T data) {
-        if (data == null) return null;
+      public Result<T> process(T data) {
+        if (data == null) return Result.filtered();
         var current = data;
         for (final var operator : pipelineOperators) {
-          current = operator.apply(current);
-          if (current == null) return null;
+          try {
+            current = operator.apply(current);
+          } catch (final RuntimeException e) {
+            return Result.failed(e);
+          }
+          if (current == null) return Result.filtered();
         }
-        return current;
+        return Result.passed(current);
       }
     };
   }

--- a/lib/kpipe-core/src/test/java/org/kpipe/registry/MessagePipelineContractTest.java
+++ b/lib/kpipe-core/src/test/java/org/kpipe/registry/MessagePipelineContractTest.java
@@ -2,6 +2,7 @@ package org.kpipe.registry;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -11,10 +12,13 @@ import java.util.concurrent.atomic.AtomicReference;
 import org.junit.jupiter.api.Test;
 import org.kpipe.sink.MessageSink;
 
-/// Verifies the [MessagePipeline] error contract:
-/// - exceptions in any phase propagate (no silent swallowing)
-/// - [MessagePipeline#process] returning null is treated as an intentional filter
-/// - [MessagePipeline#deserialize] returning null is a contract violation
+/// Verifies the [MessagePipeline] error contract (1.13.0+):
+/// - exceptions thrown by `deserialize` propagate (no silent swallowing) — Result is reserved
+///   for the `process()` boundary.
+/// - [MessagePipeline#process] returns `Result<T>`: `Passed`, `Filtered`, or `Failed`.
+///   Byte-level entry points (`apply`, `processToSink`, `processToValue`) unwrap the Result:
+///   `Passed.value` flows through, `Filtered` yields null/skip, `Failed.cause` is re-thrown.
+/// - [MessagePipeline#deserialize] returning null is a contract violation.
 class MessagePipelineContractTest {
 
   private static final byte[] INPUT = new byte[] { 1, 2, 3 };
@@ -29,10 +33,9 @@ class MessagePipelineContractTest {
   }
 
   @Test
-  void shouldPropagateExceptionFromProcess() {
-    final var pipeline = pipelineWithProcess(_ -> {
-      throw new IllegalStateException("schema mismatch");
-    });
+  void shouldRethrowFailedCauseFromApply() {
+    final var cause = new IllegalStateException("schema mismatch");
+    final var pipeline = pipelineWithProcess(_ -> Result.failed(cause));
     final var ex = assertThrows(IllegalStateException.class, () -> pipeline.apply(INPUT));
     assertEquals("schema mismatch", ex.getMessage());
   }
@@ -47,9 +50,9 @@ class MessagePipelineContractTest {
   }
 
   @Test
-  void shouldReturnNullWhenProcessReturnsNull() {
-    final var pipeline = pipelineWithProcess(_ -> null);
-    assertNull(pipeline.apply(INPUT), "process() returning null is an intentional filter");
+  void shouldReturnNullWhenProcessReturnsFiltered() {
+    final var pipeline = pipelineWithProcess(_ -> Result.filtered());
+    assertNull(pipeline.apply(INPUT), "Filtered is an intentional drop");
   }
 
   @Test
@@ -62,7 +65,7 @@ class MessagePipelineContractTest {
   @Test
   void shouldRoundTripSuccessfully() {
     final byte[] output = new byte[] { 9, 9, 9 };
-    final var pipeline = new TestPipeline<String>(_ -> "v", s -> s, s -> output, null);
+    final var pipeline = new TestPipeline<String>(_ -> "v", Result::passed, s -> output, null);
     assertSame(output, pipeline.apply(INPUT));
   }
 
@@ -70,7 +73,7 @@ class MessagePipelineContractTest {
   void processToSinkShouldDeliverProcessedValueToSink() {
     final var captured = new AtomicReference<String>();
     final MessageSink<String> sink = captured::set;
-    final var pipeline = new TestPipeline<>(_ -> "raw", s -> s + "-processed", _ -> INPUT, sink);
+    final var pipeline = new TestPipeline<>(_ -> "raw", s -> Result.passed(s + "-processed"), _ -> INPUT, sink);
 
     pipeline.processToSink(INPUT);
 
@@ -78,10 +81,10 @@ class MessagePipelineContractTest {
   }
 
   @Test
-  void processToSinkShouldNotInvokeSinkWhenProcessReturnsNull() {
+  void processToSinkShouldNotInvokeSinkOnFiltered() {
     final var invoked = new AtomicReference<>(false);
     final MessageSink<String> sink = _ -> invoked.set(true);
-    final var pipeline = new TestPipeline<String>(_ -> "raw", _ -> null, _ -> INPUT, sink);
+    final var pipeline = new TestPipeline<String>(_ -> "raw", _ -> Result.filtered(), _ -> INPUT, sink);
 
     pipeline.processToSink(INPUT);
 
@@ -89,11 +92,23 @@ class MessagePipelineContractTest {
   }
 
   @Test
+  void processToSinkShouldRethrowFailedCause() {
+    final MessageSink<String> sink = _ -> {
+      // unreachable — Failed short-circuits before reaching the sink
+    };
+    final var cause = new RuntimeException("upstream failed");
+    final var pipeline = new TestPipeline<String>(_ -> "raw", _ -> Result.failed(cause), _ -> INPUT, sink);
+
+    final var ex = assertThrows(RuntimeException.class, () -> pipeline.processToSink(INPUT));
+    assertEquals("upstream failed", ex.getMessage());
+  }
+
+  @Test
   void processToSinkShouldPropagateExceptionFromSink() {
     final MessageSink<String> sink = _ -> {
       throw new RuntimeException("sink failed");
     };
-    final var pipeline = new TestPipeline<>(_ -> "raw", s -> s, _ -> INPUT, sink);
+    final var pipeline = new TestPipeline<>(_ -> "raw", Result::passed, _ -> INPUT, sink);
 
     final var ex = assertThrows(RuntimeException.class, () -> pipeline.processToSink(INPUT));
     assertEquals("sink failed", ex.getMessage());
@@ -101,7 +116,7 @@ class MessagePipelineContractTest {
 
   @Test
   void processToSinkShouldThrowWhenDeserializeReturnsNull() {
-    final var pipeline = new TestPipeline<String>(_ -> null, s -> s, _ -> INPUT, _ -> {});
+    final var pipeline = new TestPipeline<String>(_ -> null, Result::passed, _ -> INPUT, _ -> {});
 
     final var ex = assertThrows(IllegalStateException.class, () -> pipeline.processToSink(INPUT));
     assertTrue(ex.getMessage().contains("deserialize() returned null"));
@@ -109,23 +124,23 @@ class MessagePipelineContractTest {
 
   @Test
   void thenShouldChainProcessOfBothPipelines() {
-    final var first = new TestPipeline<>(_ -> "raw", s -> s + "-A", _ -> INPUT, null);
-    final var second = new TestPipeline<>(_ -> "raw", s -> s + "-B", _ -> INPUT, null);
+    final var first = new TestPipeline<>(_ -> "raw", s -> Result.passed(s + "-A"), _ -> INPUT, null);
+    final var second = new TestPipeline<>(_ -> "raw", s -> Result.passed(s + "-B"), _ -> INPUT, null);
 
     final var composed = first.then(second);
 
-    assertEquals("raw-A-B", composed.process("raw"));
+    assertEquals(Result.passed("raw-A-B"), composed.process("raw"));
   }
 
   @Test
   void thenShouldShortCircuitOnFilterFromFirstPipeline() {
     final var captured = new AtomicReference<String>();
-    final var first = new TestPipeline<String>(_ -> "raw", _ -> null, _ -> INPUT, null);
+    final var first = new TestPipeline<String>(_ -> "raw", _ -> Result.filtered(), _ -> INPUT, null);
     final var second = new TestPipeline<>(
       _ -> "raw",
       s -> {
         captured.set("should-not-run");
-        return s;
+        return Result.passed(s);
       },
       _ -> INPUT,
       null
@@ -133,16 +148,39 @@ class MessagePipelineContractTest {
 
     final var composed = first.then(second);
 
-    assertNull(composed.process("raw"));
+    assertInstanceOf(Result.Filtered.class, composed.process("raw"));
     assertNull(captured.get(), "second pipeline must not run when first filters");
+  }
+
+  @Test
+  void thenShouldShortCircuitOnFailedFromFirstPipeline() {
+    final var cause = new RuntimeException("first failed");
+    final var captured = new AtomicReference<String>();
+    final var first = new TestPipeline<String>(_ -> "raw", _ -> Result.failed(cause), _ -> INPUT, null);
+    final var second = new TestPipeline<>(
+      _ -> "raw",
+      s -> {
+        captured.set("should-not-run");
+        return Result.passed(s);
+      },
+      _ -> INPUT,
+      null
+    );
+
+    final var composed = first.then(second);
+
+    final var result = composed.process("raw");
+    final var failed = assertInstanceOf(Result.Failed.class, result);
+    assertSame(cause, failed.cause());
+    assertNull(captured.get(), "second pipeline must not run when first fails");
   }
 
   @Test
   void thenShouldComposeSinksWhenBothPresent() {
     final var firstCalled = new AtomicReference<>(false);
     final var secondCalled = new AtomicReference<>(false);
-    final var first = new TestPipeline<>(_ -> "raw", s -> s, _ -> INPUT, _ -> firstCalled.set(true));
-    final var second = new TestPipeline<>(_ -> "raw", s -> s, _ -> INPUT, _ -> secondCalled.set(true));
+    final var first = new TestPipeline<>(_ -> "raw", Result::passed, _ -> INPUT, _ -> firstCalled.set(true));
+    final var second = new TestPipeline<>(_ -> "raw", Result::passed, _ -> INPUT, _ -> secondCalled.set(true));
 
     final var composed = first.then(second);
 
@@ -154,7 +192,7 @@ class MessagePipelineContractTest {
   @Test
   void processToSinkShouldNoopWhenSinkAbsent() {
     // No sink configured; processToSink runs deserialize/process and returns silently.
-    final var pipeline = new TestPipeline<String>(_ -> "v", s -> s, _ -> INPUT, null);
+    final var pipeline = new TestPipeline<String>(_ -> "v", Result::passed, _ -> INPUT, null);
 
     // Just verifying no exception — implicit assertion.
     pipeline.processToSink(INPUT);
@@ -165,7 +203,7 @@ class MessagePipelineContractTest {
   }
 
   private interface ProcessFn<T> {
-    T apply(T value);
+    Result<T> apply(T value);
   }
 
   private interface SerializeFn<T> {
@@ -173,7 +211,7 @@ class MessagePipelineContractTest {
   }
 
   private static MessagePipeline<String> pipelineWithDeserialize(final DeserializeFn<String> fn) {
-    return new TestPipeline<>(fn, s -> s, s -> INPUT, null);
+    return new TestPipeline<>(fn, Result::passed, s -> INPUT, null);
   }
 
   private static MessagePipeline<String> pipelineWithProcess(final ProcessFn<String> fn) {
@@ -181,10 +219,12 @@ class MessagePipelineContractTest {
   }
 
   private static MessagePipeline<String> pipelineWithSerialize(final SerializeFn<String> fn) {
-    return new TestPipeline<>(bytes -> "v", s -> s, fn, null);
+    return new TestPipeline<>(bytes -> "v", Result::passed, fn, null);
   }
 
-  /// Minimal record-style pipeline used to drive the contract tests.
+  /// Minimal record-style pipeline used to drive the contract tests. `process` returns
+  /// `Result<T>` directly; callers construct `Result.passed(...)` / `Result.filtered()` /
+  /// `Result.failed(...)` explicitly.
   private record TestPipeline<T>(
     DeserializeFn<T> deserializer,
     ProcessFn<T> processor,
@@ -202,7 +242,7 @@ class MessagePipelineContractTest {
     }
 
     @Override
-    public T process(final T data) {
+    public Result<T> process(final T data) {
       return processor.apply(data);
     }
 


### PR DESCRIPTION
## Summary

First of three parallel 1.13.0 PRs (no stack — disjoint files; can be reviewed/merged in any order).

§12 of CLAUDE.md settled `"null = filter, throw = fail"` as a doctrine enforced by *discipline*. The protobuf `skipBytes(5)` burn that motivated §12 was a caller accidentally treating a deserialization failure as an intentional filter. This PR upgrades the convention to a compile-time guarantee.

```java
sealed interface Result<T> permits Passed, Filtered, Failed {
  record Passed<T>(T value) {}
  record Filtered<T>() {}                 // shared singleton via Result.filtered()
  record Failed<T>(Throwable cause) {}
}

MessagePipeline.process(T) -> Result<T>
```

### Byte-level entry points preserve their existing contracts

`apply`, `processToSink`, `processToValue` pattern-match the Result internally — `Filtered` yields null/skip, `Failed` re-throws the captured cause. Existing callers on the byte boundary don't need to change. New code that wants typed handling calls `process()` directly and switches exhaustively.

### TypedPipelineBuilder wraps UnaryOperator at the pipeline boundary

`UnaryOperator<T>` is the public operator API and won't change. The pipeline builder catches `RuntimeException` from operators and converts to `Result.failed(...)`; null returns become `Result.filtered()`. The wrapping lives **at** the boundary, not at every operator.

### Allocation cost

`Passed` and `Failed` each allocate one record per call (1 per record per pipeline stage on the hot path). `Filtered` returns a shared singleton via `Result.filtered()` to avoid an allocation in the common filter case. JMH-validate before claiming "zero-cost" — the `Passed` allocation is the real cost.

### Tests
- `MessagePipelineContractTest` rewritten to drive Result directly (private `ProcessFn` fixture now returns `Result<T>`, no null/throw bridging).
- `KPipeDlqTest`'s anonymous pipeline returns `Result.passed(...)`.
- All `kpipe-core` + `kpipe-consumer` unit tests green.

### Docs
- `CLAUDE.md` §12: added "Decision (1.13.0)" row, allocation notes, operator-vs-pipeline boundary doctrine.
- `PLAN.md` row #9 (was P5 2.0 candidate) marked shipped.

Per §16 — no deprecation shim. Callers migrated in this commit.

## Stack
**Independent.** Targets main directly. Two sibling PRs coming for the rest of 1.13:
- `feature/1.13-format-split` (kills `Format.INSTANCE` footgun)
- `feature/1.13-health-controller` (collapses PauseCoordinator + Backpressure + CB + Stats)

## Test plan
- [x] \`./gradlew :lib:kpipe-core:test :lib:kpipe-consumer:test\` green
- [x] CI green