### PR TITLE
ci: upload JUnit test results to Codecov Test Analytics

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -57,3 +57,12 @@ jobs:
             ./lib/kpipe-format-protobuf/build/reports/jacoco/test/jacocoTestReport.xml
             ./lib/kpipe-consumer/build/reports/jacoco/test/jacocoTestReport.xml
             ./lib/kpipe-producer/build/reports/jacoco/test/jacocoTestReport.xml
+
+      - name: Upload test results to Codecov
+        if: ${{ !cancelled() }}
+        uses: codecov/test-results-action@v1
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          slug: eschizoid/kpipe
+          files: |
+            ./**/build/test-results/test/*.xml


### PR DESCRIPTION
## Summary

One CI step at the end of the build job uploads every `build/test-results/test/*.xml` to Codecov. `if: ${{ !cancelled() }}` runs even when an earlier step (typically `./gradlew build test`) fails — that's the whole point: surface failed tests on the PR comment instead of making reviewers dig through raw CI logs.

## What we get
- **Failed-test summary** on every PR
- **Flakiness tracking** over time (the schema-registry test that flaked on the recovery PR would have been visible immediately)
- **Slowest-test dashboard** (the `StreamBatchIntegrationTest` + `StreamParallelBatchBackpressureIntegrationTest` pair is the long pole — visibility motivates triage)
- **Per-test history**

## Notes
- Uses the same `CODECOV_TOKEN` secret already configured for coverage uploads.
- No code changes; CI workflow only.
- Independent of the 1.13 PRs (`#115` Result<T>, upcoming Format split + ConsumerHealthController).

## Test plan
- [x] Merge and watch the next PR's CI for the test-results upload step