### PR TITLE
ci: include kpipe-schema-registry-confluent + kpipe-tracing-otel in coverage and release

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -40,7 +40,9 @@ jobs:
             :lib:kpipe-format-json:jacocoTestReport \
             :lib:kpipe-format-protobuf:jacocoTestReport \
             :lib:kpipe-consumer:jacocoTestReport \
-            :lib:kpipe-producer:jacocoTestReport
+            :lib:kpipe-producer:jacocoTestReport \
+            :lib:kpipe-schema-registry-confluent:jacocoTestReport \
+            :lib:kpipe-tracing-otel:jacocoTestReport
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v5
@@ -57,6 +59,8 @@ jobs:
             ./lib/kpipe-format-protobuf/build/reports/jacoco/test/jacocoTestReport.xml
             ./lib/kpipe-consumer/build/reports/jacoco/test/jacocoTestReport.xml
             ./lib/kpipe-producer/build/reports/jacoco/test/jacocoTestReport.xml
+            ./lib/kpipe-schema-registry-confluent/build/reports/jacoco/test/jacocoTestReport.xml
+            ./lib/kpipe-tracing-otel/build/reports/jacoco/test/jacocoTestReport.xml
 
       - name: Upload test results to Codecov
         if: ${{ !cancelled() }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -65,11 +65,13 @@ jobs:
             :lib:kpipe-core:build :lib:kpipe-core:publish \
             :lib:kpipe-metrics:build :lib:kpipe-metrics:publish \
             :lib:kpipe-metrics-otel:build :lib:kpipe-metrics-otel:publish \
+            :lib:kpipe-tracing-otel:build :lib:kpipe-tracing-otel:publish \
             :lib:kpipe-producer:build :lib:kpipe-producer:publish \
             :lib:kpipe-consumer:build :lib:kpipe-consumer:publish \
             :lib:kpipe-format-json:build :lib:kpipe-format-json:publish \
             :lib:kpipe-format-avro:build :lib:kpipe-format-avro:publish \
             :lib:kpipe-format-protobuf:build :lib:kpipe-format-protobuf:publish \
+            :lib:kpipe-schema-registry-confluent:build :lib:kpipe-schema-registry-confluent:publish \
             :lib:kpipe-api:build \
             :lib:kpipe-api:publish \
             -x test


### PR DESCRIPTION
## Summary

- `ci.yaml`: add `kpipe-schema-registry-confluent` and `kpipe-tracing-otel` to the `:jacocoTestReport` task list and to the Codecov XML upload paths. Their tests were running on CI but their coverage was being silently dropped.
- `release.yaml`: add `:build` + `:publish` for both modules to the release job's gradle invocation so the artifacts ship to Maven Central alongside the rest.

Both modules already have `jacoco` and `maven-publish` configured in their `build.gradle.kts`, so no module-side changes are needed.

## Test plan
- [x] CI green on this PR (jacoco step lists 11 modules; codecov upload picks up the two new XMLs)
- [ ] On the next release run, both modules appear in the published artifact list