### PR TITLE
bench: latency-percentile companion to the parallel competitive suite

### DIFF
--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -43,7 +43,18 @@ Each invocation processes **100,000 records** across **8 partitions**. The previ
 startup-dominated; 100k pushes the harness into the steady-state regime where group-join and first-poll cost
 become statistically negligible.
 
-### 4. Batch Sink Throughput (`BatchSinkLatencyBenchmark`)
+### 4. Parallel Processing — Latency Percentiles (`ParallelProcessingLatencyBenchmark`)
+
+Same four runtimes and the same workload sweep as scenario 3, but reports `Mode.SampleTime` and
+`Mode.AverageTime` instead of throughput. JMH publishes `p(0.50)`, `p(0.95)`, `p(0.99)`,
+`p(0.999)`, and `p(1.00)` percentiles for each benchmark — the numbers competitive evaluators
+ask about when "average throughput" is a tie or when tail-latency matters.
+
+Two libraries can rank one way on throughput and the opposite way on p99: a runtime that
+schedules many records in parallel can achieve high average throughput while leaving a few
+records starved at the tail. Reporting both metrics from the same harness makes that visible.
+
+### 5. Batch Sink Throughput (`BatchSinkLatencyBenchmark`)
 
 Quantifies the win from `Stream.toBatch(...)` when the destination has nontrivial per-call cost. The benchmark
 parameterises over batch size (1 / 10 / 100) and a simulated sink latency (10 / 100 / 1000 µs) — the sink calls

--- a/benchmarks/src/jmh/java/org/kpipe/benchmarks/ParallelProcessingLatencyBenchmark.java
+++ b/benchmarks/src/jmh/java/org/kpipe/benchmarks/ParallelProcessingLatencyBenchmark.java
@@ -1,0 +1,61 @@
+package org.kpipe.benchmarks;
+
+import java.util.concurrent.TimeUnit;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OperationsPerInvocation;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+
+/// Latency-mode companion to [ParallelProcessingBenchmark]. Same four runtimes, same seeded
+/// topic, but reports the **distribution** of "time to drain N records" rather than steady-state
+/// throughput.
+///
+/// JMH `SampleTime` mode publishes the percentile histogram per benchmark — `p(0.50)`, `p(0.95)`,
+/// `p(0.99)`, `p(0.999)`, `p(1.00)` — which are the numbers competitive evaluators actually want
+/// from a parallel-Kafka library. Average throughput is half the story; tail latency is the other
+/// half, and the two libraries can rank differently on each.
+///
+/// Run:
+///
+/// ```bash
+/// ./gradlew :benchmarks:jmh -Pjmh.includes='ParallelProcessingLatencyBenchmark'
+/// ```
+///
+/// The reported time-per-op is "time to process [#TARGET_MESSAGES] records", not per-record
+/// latency. Divide by `TARGET_MESSAGES` for the per-record figure; the percentile *shape* (mean
+/// vs p99) is the headline, not the absolute number.
+@BenchmarkMode({ Mode.SampleTime, Mode.AverageTime })
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+public class ParallelProcessingLatencyBenchmark {
+
+  private static final int TARGET_MESSAGES = ParallelProcessingBenchmarkInfrastructure.TARGET_MESSAGES;
+
+  @Benchmark
+  @OperationsPerInvocation(TARGET_MESSAGES)
+  public void kpipe(final ParallelProcessingBenchmarkInfrastructure.KpipeInvocationContext context) {
+    context.start();
+    ParallelProcessingBenchmarkInfrastructure.awaitProcessedMessages("kpipe", context.processedCount());
+  }
+
+  @Benchmark
+  @OperationsPerInvocation(TARGET_MESSAGES)
+  public void confluent(final ParallelProcessingBenchmarkInfrastructure.ConfluentInvocationContext context) {
+    context.start();
+    ParallelProcessingBenchmarkInfrastructure.awaitProcessedMessages("confluent", context.processedCount());
+  }
+
+  @Benchmark
+  @OperationsPerInvocation(TARGET_MESSAGES)
+  public void reactor(final ParallelProcessingBenchmarkInfrastructure.ReactorInvocationContext context) {
+    context.start();
+    ParallelProcessingBenchmarkInfrastructure.awaitProcessedMessages("reactor", context.processedCount());
+  }
+
+  @Benchmark
+  @OperationsPerInvocation(TARGET_MESSAGES)
+  public void raw(final ParallelProcessingBenchmarkInfrastructure.RawInvocationContext context) {
+    context.start();
+    ParallelProcessingBenchmarkInfrastructure.awaitProcessedMessages("raw", context.processedCount());
+  }
+}


### PR DESCRIPTION
Stacked on top of #122.

Adds \`ParallelProcessingLatencyBenchmark\` using \`Mode.SampleTime\` + \`Mode.AverageTime\` so the same four runtimes publish p50/p95/p99/p999/p100 distributions alongside the throughput suite. Average throughput can hide tail issues — same harness, different timing model, both numbers reported.

README adds the new scenario.