### PR TITLE
bench: methodology doc + results snapshot template

### DIFF
--- a/benchmarks/METHODOLOGY.md
+++ b/benchmarks/METHODOLOGY.md
@@ -1,0 +1,160 @@
+# KPipe Benchmark Methodology
+
+This document is how to read the numbers in `benchmarks/results/` and how to reproduce them. If
+you're tempted to quote a single number from a single run, read this first.
+
+## What the suite measures
+
+| Bench | Question it answers |
+|---|---|
+| `JsonPipelineBenchmark` | What does KPipe's single-SerDe-cycle save vs naive byte-to-byte chaining? (Design validation, not competitive.) |
+| `AvroPipelineBenchmark` | What does zero-copy magic-byte handling save vs `Arrays.copyOfRange`? (Design validation.) |
+| `ParallelProcessingBenchmark` | How does **throughput** compare across KPipe, Confluent Parallel Consumer, Reactor Kafka, and a hand-rolled `KafkaConsumer + virtual threads`? |
+| `ParallelProcessingLatencyBenchmark` | How do those four runtimes compare on **per-batch latency** (p50, p95, p99)? |
+| `BatchSinkLatencyBenchmark` | What does `Stream.toBatch(...)` save when the destination has nontrivial per-call cost? |
+
+The first two are KPipe-vs-straw-man. They show the design choices paid off but are not
+competitive claims. Use them in design docs, not in pitches.
+
+The next two are the competitive suite. **These are the ones to quote** when comparing KPipe to
+the alternatives a JVM team would actually pick.
+
+The last one is KPipe alone, parameterised across batch size and sink latency.
+
+## What the four parallel runtimes look like
+
+| Runtime | Concurrency primitive | Configured concurrency |
+|---|---|---|
+| **KPipe** | Virtual thread per record (Loom) | Unbounded (virtual-thread-per-record); the consumer's in-flight watermark caps memory |
+| **Confluent Parallel Consumer** | Platform-thread worker pool, `ProcessingOrder.UNORDERED` | `maxConcurrency=100` |
+| **Reactor Kafka** | Reactor `parallel` scheduler via `Flux.parallel(N)` | `parallel(100)` to match Confluent's pool size |
+| **Raw `KafkaConsumer` + virtual threads** | `Executors.newVirtualThreadPerTaskExecutor()` driven from a platform-thread poll loop | Unbounded virtual threads |
+
+Two of the four (KPipe, raw) lean on Loom. The other two (Confluent, Reactor) lean on platform
+threads. That's the interesting axis. At `workMicros=0` the comparison is essentially "framework
+overhead"; at `workMicros=1000` it's "how does each runtime schedule blocking work?". Those two
+questions often have different winners.
+
+## JMH configuration
+
+The Gradle JMH plugin is configured in `benchmarks/build.gradle.kts`. Defaults:
+
+| Parameter | Default | Override |
+|---|---|---|
+| Warmup iterations | 3 | `-Pjmh.warmupIterations=N` |
+| Measurement iterations | 5 | `-Pjmh.iterations=N` |
+| Forks | 1 | `-Pjmh.fork=N` |
+| Threads | 1 | `-Pjmh.threads=N` |
+| Benchmark mode | `thrpt` | n/a (per-benchmark) |
+| Time unit | `s` | n/a |
+| Failure handling | `failOnError = true` | n/a |
+| Result format | `TEXT` | `-Pjmh.resultFormat=JSON` |
+
+Per-benchmark overrides:
+
+- `ParallelProcessingLatencyBenchmark` sets `Mode.SampleTime + Mode.AverageTime` and
+  `OutputTimeUnit.MILLISECONDS` to publish percentile histograms.
+- `BatchSinkLatencyBenchmark` parameterises over `batchSize × sinkLatencyMicros`.
+- `ParallelProcessingBenchmark` parameterises over `workMicros` (`0 / 100 / 1000`).
+
+### Recommended publishing run
+
+```bash
+./gradlew :benchmarks:jmh \
+  -Pjmh.includes='ParallelProcessingBenchmark|ParallelProcessingLatencyBenchmark' \
+  -Pjmh.warmupIterations=3 \
+  -Pjmh.iterations=5 \
+  -Pjmh.fork=2 \
+  -Pjmh.profilers='gc' \
+  -Pjmh.resultFormat=JSON
+```
+
+Two forks instead of one cuts the cross-fork noise on the latency percentiles. The `gc` profiler
+adds allocation rate and GC count per benchmark — required input to the "throughput vs
+allocation-cost" trade-off.
+
+### Quick smoke run (for local sanity-check)
+
+```bash
+./gradlew :benchmarks:jmh \
+  -Pjmh.includes='ParallelProcessingBenchmark.kpipe.*workMicros=0' \
+  -Pjmh.iterations=1 \
+  -Pjmh.warmupIterations=1 \
+  -Pjmh.fork=1
+```
+
+One iteration, one warmup, one fork, only the KPipe / 0-µs cell. Useful for verifying the
+harness didn't break after changes; meaningless as a measurement.
+
+## What to write down with every published number
+
+A bench number without context is unverifiable. Each entry in `results/` should record:
+
+1. **Date** — when the run completed.
+2. **Hardware** — CPU model, core count, RAM. (Apple Silicon M2 Pro 10c/16GB, AWS m7i.4xlarge,
+   GitHub Actions Linux runner spec, etc.)
+3. **OS + kernel** — affects scheduler behaviour, especially for Loom.
+4. **JDK build** — `java -version`. Loom semantics changed across 21 → 25.
+5. **JMH config** — iterations / warmup / forks / profilers actually used.
+6. **Benchmark scope** — which classes and which `@Param` cells.
+7. **Result file** — the raw `results.json` or `results.text` from the run, committed alongside
+   the summary.
+
+## Reading the numbers
+
+### Throughput mode (`ops/s`)
+
+The `ParallelProcessingBenchmark` uses `@OperationsPerInvocation(TARGET_MESSAGES)` where
+`TARGET_MESSAGES = 100_000`. So the JMH "ops/s" number is **records processed per second**.
+
+Don't multiply by `TARGET_MESSAGES`. The `@OperationsPerInvocation` annotation already
+normalises.
+
+### Sample-time mode (latency percentiles)
+
+`ParallelProcessingLatencyBenchmark` reports per-op time in milliseconds. Same
+`@OperationsPerInvocation` so an "op" is one record, but the published number is "median time to
+process one record at this position in the run". Look at the histogram, not the mean:
+
+- **p50** — typical record. Lower is better.
+- **p95 / p99** — tail. This is what matters when SLA-bound consumers are involved.
+- **p100** — the worst observation in the run. Highly noisy; don't quote.
+
+A runtime can win on average throughput while losing on p99 — `Flux.parallel(N)` schedules
+records in a fan-out / fan-in pattern that produces good average throughput but occasional
+stragglers.
+
+### Within-iteration vs cross-fork variance
+
+The default `forks=1` means all iterations share the same JVM process. Cross-fork variance (JIT
+warmup differences, GC profile differences across forks) doesn't get exposed. For published
+numbers run with `forks=2` minimum.
+
+## Caveats
+
+A few things to keep in mind whenever you quote a number from this suite:
+
+- **Embedded Kafka shares cores with the consumer.** The broker is in-process. It competes with
+  the consumer for CPU. In production the broker is across the network. The headline ordering is
+  usually preserved, but absolute numbers will be lower here than in a production setup.
+- **In-memory disk.** The Kafka test kit uses a tmpfs-style path; `fsync` cost is artificially
+  low. Production brokers under replication factor 3 + acks=all have very different write
+  latency.
+- **Single-broker.** No replication, no leader election, no rebalance under load. Real failure
+  modes don't show up.
+- **Single payload size.** The seed payload is small JSON (~50 bytes). Reactor Kafka's
+  `flatMap` strategy can behave differently under 10KB payloads.
+- **Macros vs micros.** This suite measures consumer-side throughput. End-to-end latency
+  (produce → consume → process → ack) needs a separate harness.
+
+## When the numbers should change
+
+Re-publish the results file when **any** of these change:
+
+- A new runtime is added or an existing one is upgraded (Confluent PC version bump, Reactor
+  Kafka version bump, Kafka client version bump).
+- KPipe's hot-path code changes (offset manager, pipeline builder, consumer thread loop).
+- The JMH config changes (different iteration count, different fork count).
+- The hardware changes.
+
+A single number without a date is misleading. The `results/` directory holds dated snapshots.

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -1,8 +1,14 @@
 # KPipe Benchmarks
 
-JMH benchmarks for KPipe — pipeline efficiency, Avro byte handling, parallel processing, and batch sink throughput. Each
-scenario pits KPipe against either a hand-rolled equivalent or a well-known alternative (Confluent Parallel Consumer) so
-the numbers mean something concrete.
+JMH benchmarks for KPipe — pipeline efficiency, Avro byte handling, parallel processing (vs Confluent Parallel
+Consumer / Reactor Kafka / a hand-rolled `KafkaConsumer + virtual-thread executor` baseline), and batch sink
+throughput.
+
+**Read this before quoting numbers:** [METHODOLOGY.md](METHODOLOGY.md) — what each bench measures, how the four
+parallel runtimes are configured, what to record for every published run.
+
+**Latest published numbers:** [results/](results/) — dated snapshots with hardware + JDK + JMH config. Use
+[TEMPLATE.md](results/TEMPLATE.md) when adding a new one.
 
 ## Benchmark Scenarios
 

--- a/benchmarks/results/TEMPLATE.md
+++ b/benchmarks/results/TEMPLATE.md
@@ -1,0 +1,102 @@
+# Benchmark snapshot — YYYY-MM-DD
+
+Copy this file when publishing a fresh benchmark run. Fill in every section. If a section
+doesn't apply (e.g., no `perfnorm` data because the run was on macOS), say so explicitly.
+
+## Environment
+
+| Field | Value |
+|---|---|
+| Date (UTC) | `YYYY-MM-DD HH:MM` |
+| Hardware | e.g., `Apple Silicon M2 Pro, 10 cores, 16 GB` |
+| OS / Kernel | e.g., `macOS 14.5 (Darwin 24.6.0)` |
+| JDK | `java -version` output |
+| Kafka | `4.2.0` (in-process via Apache Kafka test-kit) |
+| KPipe | `git rev-parse HEAD` |
+| Confluent Parallel Consumer | from `gradle/libs.versions.toml` |
+| Reactor Kafka | from `gradle/libs.versions.toml` |
+
+## JMH configuration
+
+| Parameter | Value |
+|---|---|
+| Warmup iterations | 3 (default) |
+| Measurement iterations | 5 (default) |
+| Forks | 2 (recommended for publishing) |
+| Profilers | `gc` |
+| Result format | `JSON` (artifact attached: `results-YYYY-MM-DD.json`) |
+
+## Scope
+
+```bash
+./gradlew :benchmarks:jmh \
+  -Pjmh.includes='ParallelProcessingBenchmark|ParallelProcessingLatencyBenchmark' \
+  -Pjmh.fork=2 \
+  -Pjmh.profilers='gc' \
+  -Pjmh.resultFormat=JSON
+```
+
+## Throughput — ParallelProcessingBenchmark
+
+Records / second, higher is better. `workMicros` is per-record simulated work via
+`LockSupport.parkNanos`.
+
+| Runtime | workMicros=0 | workMicros=100 | workMicros=1000 |
+|---|---:|---:|---:|
+| KPipe | TBD ± TBD | TBD ± TBD | TBD ± TBD |
+| Confluent Parallel Consumer | TBD ± TBD | TBD ± TBD | TBD ± TBD |
+| Reactor Kafka | TBD ± TBD | TBD ± TBD | TBD ± TBD |
+| Raw `KafkaConsumer` + VT | TBD ± TBD | TBD ± TBD | TBD ± TBD |
+
+### Observations
+
+- (Which runtime leads at `workMicros=0`? What's the gap?)
+- (Where does the leader change as `workMicros` increases?)
+- (Anything surprising in the error band?)
+
+## Latency percentiles — ParallelProcessingLatencyBenchmark
+
+Per-record time (ms), lower is better. Reported at `workMicros=100` (typical local enrichment).
+
+| Runtime | p50 | p95 | p99 |
+|---|---:|---:|---:|
+| KPipe | TBD | TBD | TBD |
+| Confluent Parallel Consumer | TBD | TBD | TBD |
+| Reactor Kafka | TBD | TBD | TBD |
+| Raw `KafkaConsumer` + VT | TBD | TBD | TBD |
+
+### Observations
+
+- (Does the throughput leader also have the best tail?)
+- (Where does the p99 gap widen?)
+
+## Allocation profile (GC profiler)
+
+`gc.alloc.rate.norm` (B / op, lower is better) at `workMicros=100`.
+
+| Runtime | B/op |
+|---|---:|
+| KPipe | TBD |
+| Confluent Parallel Consumer | TBD |
+| Reactor Kafka | TBD |
+| Raw `KafkaConsumer` + VT | TBD |
+
+## Batch sink
+
+See `BatchSinkLatencyBenchmark` — single-runtime, separate sweep. Headline:
+
+| batchSize | sinkLatencyMicros | Throughput (ops/s) |
+|---:|---:|---:|
+| 1 | 10 | TBD |
+| 1 | 1000 | TBD |
+| 100 | 10 | TBD |
+| 100 | 1000 | TBD |
+
+## Raw output
+
+The full JMH JSON output is attached as `results-YYYY-MM-DD.json`. The `gc` profiler section in
+that file is the source of truth for allocation rates.
+
+## Pitfalls in this run
+
+(Anything weird? A flaky iteration? A different OS than the reference? Note it here.)


### PR DESCRIPTION
Stacked on top of #123.

- \`benchmarks/METHODOLOGY.md\` — what each bench measures, how the four parallel runtimes are configured (KPipe / Confluent PC / Reactor / raw), JMH defaults + recommended-publishing config, what to record with every run, caveats around the in-process broker.
- \`benchmarks/results/TEMPLATE.md\` — the format for dated benchmark snapshots. Environment + JMH config + throughput / latency / allocation tables. Drop new files in \`results/\` whenever a runtime version bumps or the suite changes.
- \`benchmarks/README.md\` — lede now cross-links to both.