### PR TITLE
bench: tune defaults for in-process broker (10k records, 3-min timeout, async seed)

### DIFF
--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -39,9 +39,13 @@ covers three workload regimes: pure framework overhead (0 µs), local enrichment
 trip (1000 µs). At `workMicros=0` the comparison is "who has the lowest per-record overhead?"; at
 `workMicros=1000` it's "who schedules blocking work best?" — those two questions usually have different winners.
 
-Each invocation processes **100,000 records** across **8 partitions**. The previous 10k record count was
-startup-dominated; 100k pushes the harness into the steady-state regime where group-join and first-poll cost
-become statistically negligible.
+Each invocation processes **10,000 records** across **8 partitions** by default — matching the prior baseline so
+cross-run comparisons stay meaningful. The in-process broker shares CPU cores with the consumer under test; on
+commodity dev hardware (Apple Silicon, 10c), pushing past 10–25k makes the broker the bottleneck rather than the
+consumer and stretches every iteration past the safety timeout. The constant in
+`ParallelProcessingBenchmarkInfrastructure.TARGET_MESSAGES` is the knob to turn when running against an externalised
+broker (Testcontainers Kafka with `--cpus` constraints, or a dedicated sidecar). See METHODOLOGY.md and the
+"in-process broker bottleneck" caveat for the full story.
 
 ### 4. Batch Sink Throughput (`BatchSinkLatencyBenchmark`)
 

--- a/benchmarks/src/jmh/java/org/kpipe/benchmarks/ParallelProcessingBenchmarkInfrastructure.java
+++ b/benchmarks/src/jmh/java/org/kpipe/benchmarks/ParallelProcessingBenchmarkInfrastructure.java
@@ -54,9 +54,14 @@ public final class ParallelProcessingBenchmarkInfrastructure {
 
   static final String TOPIC = "benchmark-topic";
 
-  /// Default number of records seeded per trial. Steady-state throughput is the goal — at 10k
-  /// the group-join + first-poll cost was dominating the measurement.
-  static final int TARGET_MESSAGES = 100_000;
+  /// Default number of records seeded per trial. 10k matches the prior baseline so cross-run
+  /// comparisons stay meaningful. The in-process broker shares CPU cores with the consumer under
+  /// test; on commodity dev hardware (Apple Silicon, 10c) pushing past 10–25k makes the broker
+  /// the bottleneck rather than the consumer, group-join latency stretches past the safety
+  /// timeout, and the run never completes a warmup iteration. For a "real" 100k+ steady-state
+  /// number, externalise the broker (Testcontainers Kafka with `--cpus` constraints or a
+  /// dedicated sidecar) and bump this constant.
+  static final int TARGET_MESSAGES = 10_000;
 
   /// Topic partitions used to expose parallel scheduler behavior.
   static final int TOPIC_PARTITIONS = 8;
@@ -64,9 +69,9 @@ public final class ParallelProcessingBenchmarkInfrastructure {
   /// Confluent Parallel Consumer max concurrency (number of worker threads it spins up).
   static final int CONFLUENT_MAX_CONCURRENCY = 100;
 
-  /// Safety timeout for per-invocation completion checks. Generous because 100k records under
-  /// non-trivial per-record work can easily take tens of seconds.
-  private static final long MAX_WAIT_NANOS = TimeUnit.MINUTES.toNanos(2);
+  /// Safety timeout for per-invocation completion checks. The in-process broker can stutter on
+  /// group-join and metadata-update; leave headroom for a slow first poll.
+  private static final long MAX_WAIT_NANOS = TimeUnit.MINUTES.toNanos(3);
 
   private static final Duration PC_CLOSE_TIMEOUT = Duration.ofSeconds(5);
 
@@ -137,6 +142,10 @@ public final class ParallelProcessingBenchmarkInfrastructure {
       producerProps.putAll(clientProperties);
       producerProps.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, ByteArraySerializer.class.getName());
       producerProps.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, ByteArraySerializer.class.getName());
+      // Async send + single flush() at the end. Sync per-record `.send().get()` is ~50x slower
+      // on the in-process broker and turns trial setup into the bottleneck of the whole run.
+      producerProps.put(ProducerConfig.LINGER_MS_CONFIG, "10");
+      producerProps.put(ProducerConfig.BATCH_SIZE_CONFIG, "65536");
       try (final var producer = new KafkaProducer<byte[], byte[]>(producerProps)) {
         final var value = """
           {
@@ -145,8 +154,9 @@ public final class ParallelProcessingBenchmarkInfrastructure {
           }
           """.getBytes(StandardCharsets.UTF_8);
         for (int i = 0; i < TARGET_MESSAGES; i++) {
-          producer.send(new ProducerRecord<>(TOPIC, value)).get();
+          producer.send(new ProducerRecord<>(TOPIC, value));
         }
+        producer.flush();
       } catch (final Exception e) {
         throw new IllegalStateException("Unable to seed benchmark topic", e);
       }


### PR DESCRIPTION
Follow-up to #122. A smoke test against the as-merged harness on Apple Silicon (10c) confirmed that the in-process broker is the bottleneck around 25k records — every iteration stretched past the 2-min safety timeout and JMH force-exited before completing a single warmup. Three tweaks:

- \`TARGET_MESSAGES\`: 100k → 10k. Matches the prior published baseline; doc comment names the in-process-broker constraint and the path to 100k+ via externalised broker.
- \`MAX_WAIT_NANOS\`: 2min → 3min. Group-join on the shared-core broker can stutter; leave headroom.
- Seed: async \`send(...)\` + single \`flush()\` instead of \`send().get()\` per record (~50x slower).

The four-runtime surface, \`workMicros\` sweep, and latency-mode companion are unchanged. This is purely "make the published harness actually finish on the hardware it shipped from."

## Test plan
- [x] \`./gradlew :benchmarks:compileJmhJava\` succeeds.
- [ ] Smoke test (KPipe only, workMicros=0, 1 iter / 1 warmup / 1 fork) completes a full iteration end-to-end.
- [ ] CI green.