### PR TITLE
just: add `just bench` target wrapping the parallel-consumer benchmark

### DIFF
--- a/justfile
+++ b/justfile
@@ -51,3 +51,32 @@ grafana:
 # Trigger the Release workflow on GitHub Actions (releaseType: patch / minor / major)
 release type="minor":
     gh workflow run release.yaml --ref main -f releaseType={{type}}
+
+# Run the parallel-consumer bench (mode=full|smoke|latency, profilers=gc by default)
+bench mode="full" profilers="gc":
+    #!/usr/bin/env bash
+    set -euo pipefail
+    rm -f benchmarks/build/tmp/jmh/jmh.lock
+    ./gradlew :benchmarks:jmhJar
+    JAR=$(find benchmarks/build/libs -name '*-jmh.jar' | head -1)
+    OUT=benchmarks/results/$(date +%Y-%m-%d)
+    PROF=""
+    if [ -n "{{profilers}}" ]; then PROF="-prof {{profilers}}"; fi
+    mkdir -p benchmarks/results
+    case "{{mode}}" in
+      smoke)
+        java -jar "$JAR" 'ParallelProcessingBenchmark.kpipe' \
+          -p workMicros=0 -wi 1 -i 1 -f 1 \
+          -rf JSON -rff "$OUT-smoke.json" | tee "$OUT-smoke.log"
+        ;;
+      latency)
+        java -jar "$JAR" 'ParallelProcessingLatencyBenchmark' \
+          -wi 3 -i 5 -f 2 $PROF \
+          -rf JSON -rff "$OUT-latency.json" | tee "$OUT-latency.log"
+        ;;
+      full|*)
+        java -jar "$JAR" 'ParallelProcessingBenchmark' \
+          -wi 3 -i 5 -f 2 $PROF \
+          -rf JSON -rff "$OUT.json" | tee "$OUT.log"
+        ;;
+    esac


### PR DESCRIPTION
Single entry point for the bench so adopters don't have to remember the JMH jar path or the parameter incantation:

\`\`\`bash
just bench               # full publishing run (~1–3 h), JSON output to benchmarks/results/<date>.json
just bench mode=smoke    # ~3–5 min sanity check, KPipe only at workMicros=0
just bench mode=latency  # latency-percentile companion (p50/p95/p99/p999)
\`\`\`

\`profilers\` defaults to \`gc\`; pass \`profilers=\` to disable. The recipe cleans the JMH lock, rebuilds the JMH jar, and tees stdout to a sibling log file.

\`mode=latency\` needs \`ParallelProcessingLatencyBenchmark\` on main — that file lands via #129 (recovery PR). \`mode=full\` and \`mode=smoke\` work today.