### PR TITLE
bench: re-architect on Testcontainers Kafka so the broker stops being the bottleneck

### DIFF
--- a/benchmarks/METHODOLOGY.md
+++ b/benchmarks/METHODOLOGY.md
@@ -134,26 +134,22 @@ numbers run with `forks=2` minimum.
 
 A few things to keep in mind whenever you quote a number from this suite:
 
-- **Embedded Kafka shares cores with the consumer.** The broker is in-process. It competes with
-  the consumer for CPU. In production the broker is across the network. The headline ordering is
-  usually preserved, but absolute numbers will be lower here than in a production setup.
-- **TARGET_MESSAGES defaults to 10,000 for that reason.** Pushing past 10–25k on the in-process
-  broker makes the broker the bottleneck rather than the consumer under test. Group-join latency
-  and KRaft controller events on the same JVM stretch every iteration past the safety timeout.
-  For a "real" 100k+ steady-state number, externalise the broker (Testcontainers Kafka with
-  `--cpus` constraints or a sidecar broker on dedicated hardware) and bump the constant in
-  `ParallelProcessingBenchmarkInfrastructure`. The four-runtime + `workMicros` surface is the
-  actual upgrade in 1.13; the record count stays at the prior baseline so cross-run comparisons
-  keep working.
-- **In-memory disk.** The Kafka test kit uses a tmpfs-style path; `fsync` cost is artificially
-  low. Production brokers under replication factor 3 + acks=all have very different write
-  latency.
-- **Single-broker.** No replication, no leader election, no rebalance under load. Real failure
-  modes don't show up.
+- **Broker runs in Docker (Testcontainers Kafka 4.2.0), not in-process.** That's the right call
+  for a competitive bench — the broker isn't fighting consumers for cores — but it also means
+  network IO is real (loopback to a container) and absolute numbers are still **lower than a
+  production setup with a network broker on dedicated hardware**. The headline *ordering*
+  between runtimes is what's meaningful; absolute records-per-second is a function of how much
+  of the host's cores Docker / the container runtime is giving the broker.
+- **Single-broker, single-container.** No replication, no leader election, no rebalance under
+  load. The broker container runs replication factor 1 and `min.insync.replicas=1`. Real
+  failure modes won't show up.
 - **Single payload size.** The seed payload is small JSON (~50 bytes). Reactor Kafka's
   `flatMap` strategy can behave differently under 10KB payloads.
 - **Macros vs micros.** This suite measures consumer-side throughput. End-to-end latency
   (produce → consume → process → ack) needs a separate harness.
+- **Docker overhead is real.** The first iteration of every trial pays the container-startup
+  cost. JMH's warmup phase absorbs most of that; if you're spot-checking with `-wi 0`, expect
+  the first measurement iteration to look slow.
 
 ## When the numbers should change
 

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -25,7 +25,9 @@ Measures the efficiency of KPipe's magic byte offset handling vs. traditional by
 
 ### 3. Parallel Processing — Competitive Suite (`ParallelProcessingBenchmark`)
 
-Four parallel-consumer runtimes drink from the same seeded topic on the same in-process Kafka broker:
+Four parallel-consumer runtimes drink from the same seeded topic on a **Testcontainers-managed
+Kafka 4.2.0 broker** (Docker; broker runs in its own JVM on its own cores so it isn't fighting the
+consumer under test for CPU):
 
 - **KPipe** — virtual-thread-per-record on Loom; no pool, no queue.
 - **Confluent Parallel Consumer** — `ProcessingOrder.UNORDERED` with a 100-worker pool. The de-facto industry
@@ -39,13 +41,10 @@ covers three workload regimes: pure framework overhead (0 µs), local enrichment
 trip (1000 µs). At `workMicros=0` the comparison is "who has the lowest per-record overhead?"; at
 `workMicros=1000` it's "who schedules blocking work best?" — those two questions usually have different winners.
 
-Each invocation processes **10,000 records** across **8 partitions** by default — matching the prior baseline so
-cross-run comparisons stay meaningful. The in-process broker shares CPU cores with the consumer under test; on
-commodity dev hardware (Apple Silicon, 10c), pushing past 10–25k makes the broker the bottleneck rather than the
-consumer and stretches every iteration past the safety timeout. The constant in
-`ParallelProcessingBenchmarkInfrastructure.TARGET_MESSAGES` is the knob to turn when running against an externalised
-broker (Testcontainers Kafka with `--cpus` constraints, or a dedicated sidecar). See METHODOLOGY.md and the
-"in-process broker bottleneck" caveat for the full story.
+Each invocation processes **25,000 records** across **8 partitions**. Because the broker is in its own container
+(not in-process), pushing the record count higher actually scales the consumer workload instead of bottlenecking on
+broker contention. **Docker must be running** before invoking the bench; Testcontainers will pull
+`apache/kafka:4.2.0` and start the container at trial setup.
 
 ### 4. Batch Sink Throughput (`BatchSinkLatencyBenchmark`)
 

--- a/benchmarks/build.gradle.kts
+++ b/benchmarks/build.gradle.kts
@@ -23,7 +23,11 @@ dependencies {
   // Logging for JMH forks
   implementation(libs.slf4jSimple)
 
-  implementation(libs.kafkaTestCommonRuntime)
+  // Broker for the bench. Testcontainers boots a real Kafka 4.2.0 container in Docker, so the
+  // broker runs in its own JVM on its own cores instead of competing with the consumer under
+  // test for CPU. The old in-process `kafka-test-common-runtime` harness collapsed under load
+  // (consumer + KRaft controller + group coordinator on the same cores).
+  implementation(libs.testcontainersKafka)
 
   implementation(libs.junitJupiterApi)
 }

--- a/benchmarks/src/jmh/java/org/kpipe/benchmarks/ParallelProcessingBenchmarkInfrastructure.java
+++ b/benchmarks/src/jmh/java/org/kpipe/benchmarks/ParallelProcessingBenchmarkInfrastructure.java
@@ -22,8 +22,6 @@ import org.apache.kafka.clients.producer.ProducerConfig;
 import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.kafka.common.serialization.ByteArrayDeserializer;
 import org.apache.kafka.common.serialization.ByteArraySerializer;
-import org.apache.kafka.common.test.KafkaClusterTestKit;
-import org.apache.kafka.common.test.TestKitNodes;
 import org.kpipe.consumer.KPipeConsumer;
 import org.kpipe.registry.MessageFormat;
 import org.kpipe.registry.MessageProcessorRegistry;
@@ -33,6 +31,8 @@ import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
 import org.openjdk.jmh.annotations.TearDown;
+import org.testcontainers.kafka.KafkaContainer;
+import org.testcontainers.utility.DockerImageName;
 import reactor.core.publisher.Flux;
 import reactor.kafka.receiver.KafkaReceiver;
 import reactor.kafka.receiver.ReceiverOptions;
@@ -54,14 +54,12 @@ public final class ParallelProcessingBenchmarkInfrastructure {
 
   static final String TOPIC = "benchmark-topic";
 
-  /// Default number of records seeded per trial. 10k matches the prior baseline so cross-run
-  /// comparisons stay meaningful. The in-process broker shares CPU cores with the consumer under
-  /// test; on commodity dev hardware (Apple Silicon, 10c) pushing past 10–25k makes the broker
-  /// the bottleneck rather than the consumer, group-join latency stretches past the safety
-  /// timeout, and the run never completes a warmup iteration. For a "real" 100k+ steady-state
-  /// number, externalise the broker (Testcontainers Kafka with `--cpus` constraints or a
-  /// dedicated sidecar) and bump this constant.
-  static final int TARGET_MESSAGES = 10_000;
+  /// Default number of records seeded per trial. 25k pushes the harness into the steady-state
+  /// regime where group-join and first-poll cost are statistically small but the run still
+  /// completes in a useful timeframe. Now that the broker runs in a Docker container (not
+  /// in-process), the broker stops fighting the consumer for cores and the consumer is the
+  /// thing being measured.
+  static final int TARGET_MESSAGES = 25_000;
 
   /// Topic partitions used to expose parallel scheduler behavior.
   static final int TOPIC_PARTITIONS = 8;
@@ -69,9 +67,10 @@ public final class ParallelProcessingBenchmarkInfrastructure {
   /// Confluent Parallel Consumer max concurrency (number of worker threads it spins up).
   static final int CONFLUENT_MAX_CONCURRENCY = 100;
 
-  /// Safety timeout for per-invocation completion checks. The in-process broker can stutter on
-  /// group-join and metadata-update; leave headroom for a slow first poll.
-  private static final long MAX_WAIT_NANOS = TimeUnit.MINUTES.toNanos(3);
+  /// Safety timeout for per-invocation completion checks. Generous so a single slow first poll
+  /// on container startup doesn't kill an iteration. Steady-state iterations finish well under
+  /// this; the timeout is a circuit-breaker, not a measurement.
+  private static final long MAX_WAIT_NANOS = TimeUnit.MINUTES.toNanos(2);
 
   private static final Duration PC_CLOSE_TIMEOUT = Duration.ofSeconds(5);
 
@@ -380,41 +379,41 @@ public final class ParallelProcessingBenchmarkInfrastructure {
     }
   }
 
+  /// Testcontainers-backed Kafka broker. Replaces the prior in-process `KafkaClusterTestKit`
+  /// because that harness collapsed under benchmark load on shared cores — the broker, the KRaft
+  /// controller, the group coordinator, and the consumer under test all fought for the same
+  /// CPUs and the consumer never reached its real throughput. Running the broker in a Docker
+  /// container puts it on its own JVM with its own cores, so the consumer is the bottleneck the
+  /// bench is actually trying to measure.
+  ///
+  /// Pinned to the `apache/kafka:4.2.0` image to match the `kafka-clients` version on the
+  /// classpath. Auto-create topics is on so the seed step doesn't have to fight a race with
+  /// topic-metadata propagation.
   private static final class EmbeddedKafkaBackend implements AutoCloseable {
 
-    private KafkaClusterTestKit cluster;
+    private static final DockerImageName KAFKA_IMAGE = DockerImageName.parse("apache/kafka:4.2.0");
+
+    private KafkaContainer container;
 
     void start() {
-      try {
-        final var nodes = new TestKitNodes.Builder()
-          .setCombined(true)
-          .setNumBrokerNodes(1)
-          .setNumControllerNodes(1)
-          .build();
-        cluster = new KafkaClusterTestKit.Builder(nodes)
-          .setConfigProp("auto.create.topics.enable", "true")
-          .setConfigProp("offsets.topic.replication.factor", "1")
-          .setConfigProp("transaction.state.log.replication.factor", "1")
-          .setConfigProp("transaction.state.log.min.isr", "1")
-          .setConfigProp("min.insync.replicas", "1")
-          .build();
-        cluster.format();
-        cluster.startup();
-        cluster.waitForReadyBrokers();
-      } catch (final Exception e) {
-        throw new IllegalStateException("Unable to start embedded Kafka broker", e);
-      }
+      container = new KafkaContainer(KAFKA_IMAGE)
+        .withEnv("KAFKA_AUTO_CREATE_TOPICS_ENABLE", "true")
+        .withEnv("KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR", "1")
+        .withEnv("KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR", "1")
+        .withEnv("KAFKA_TRANSACTION_STATE_LOG_MIN_ISR", "1")
+        .withEnv("KAFKA_MIN_INSYNC_REPLICAS", "1");
+      container.start();
     }
 
     Properties getClientProperties() {
-      final var copy = new Properties();
-      copy.putAll(cluster.clientProperties());
-      return copy;
+      final var props = new Properties();
+      props.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, container.getBootstrapServers());
+      return props;
     }
 
     @Override
-    public void close() throws Exception {
-      if (cluster != null) cluster.close();
+    public void close() {
+      if (container != null) container.stop();
     }
   }
 }


### PR DESCRIPTION
## Why

The in-process \`KafkaClusterTestKit\` harness was the wrong primitive for this bench. With four invocation contexts loaded (KPipe, Confluent PC, Reactor Kafka, raw VT) plus the KRaft controller plus the consumer under test all on the same JVM, **the broker becomes the bottleneck before any framework reaches its real throughput**. Smoke tests on Apple Silicon showed ~40–50 records/sec ceilings across all four runtimes — that's the broker, not the frameworks.

## What

Replaces \`EmbeddedKafkaBackend\` with a Testcontainers \`KafkaContainer\` running \`apache/kafka:4.2.0\`. The broker now lives in its own JVM in a Docker container, on its own cores, so the bench actually measures the consumer.

| | Before | After |
| --- | --- | --- |
| Broker | \`KafkaClusterTestKit\` (in-process) | \`KafkaContainer\` (Docker, apache/kafka:4.2.0) |
| Cores | Shared with consumer | Container's own |
| \`TARGET_MESSAGES\` | 10_000 (capped by in-process bottleneck) | 25_000 |
| \`MAX_WAIT_NANOS\` | 3 min (slack for slow broker) | 2 min (broker now fast, fail faster on genuine hang) |
| Deps | \`kafka-test-common-runtime\` | \`testcontainersKafka\` |

## Requires

Docker must be running on the host before invoking the bench. Testcontainers will pull \`apache/kafka:4.2.0\` on first run.

## What this doesn't do

Nothing about the four-runtime surface, the \`workMicros\` sweep, or the latency-percentile companion. Those land on top of this harness unchanged.

## Test plan

- [x] \`./gradlew :benchmarks:compileJmhJava\` succeeds.
- [ ] \`just bench mode=smoke\` completes a single iteration cleanly with Docker running.
- [ ] Full \`just bench\` produces measured scores for every \`workMicros\` cell across all four runtimes (no timeouts).
- [ ] CI green.