### PR TITLE
ergonomics: 1.14 bundle — registry rename, deser hints, observers, SR auto-lookup, observability, escape-hatches

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1,418 +1,327 @@
 # KPipe Architecture and Design Principles
 
-## Core Architectural Decisions
+This file is the long-term memory for working in this repo. It records the non-obvious invariants, the footguns that
+have already burned us, and the architectural decisions that aren't recoverable just by reading the code. Things that
+_are_ recoverable from the code (package layout, type signatures, who calls what) are deliberately omitted — read the
+code for those.
 
-### 1. The Byte Boundary Strategy
+## Core invariants
 
-- **Decision**: The top-level `KPipeConsumer` and its pipelines always operate on `byte[]` at their entry and exit
-  points.
-- **Reasoning**: Kafka is natively a byte-array storage and transport system. Keeping the boundary at the `byte[]` level
-  allows for:
-    - Transparent handling of wire formats (e.g., Confluent Magic Bytes).
-    - Flexibility to handle mixed formats in the same application.
-    - Decoupling of Kafka's low-level client configuration from the application's SerDe logic.
-    - Centralized error handling for deserialization failures.
+- **Byte boundary at the consumer entry.** `KPipeConsumer<K>` operates on `byte[]` values. Format SerDe lives inside the
+  pipeline. Mixed wire formats and Confluent magic-byte prefixes are handled inside operators (`skipBytes(n)`), not at
+  the consumer level.
+- **Single SerDe cycle per record.** Deserialize once → chain `UnaryOperator<T>` transforms on the typed object →
+  serialize once. Never compose `Function<byte[], byte[]>` chains; that's the "SerDe tax" the typed pipeline was built
+  to eliminate.
+- **Lowest-pending-offset commits.** `ConcurrentSkipListSet` per partition; offset 102 is not committed until 101 also
+  finishes. This is what makes "at-least-once with parallel processing" honest.
 
-### 2. High-Performance "Single SerDe Cycle" Pipeline
+## Coding standards
 
-- **Decision**: Modernize all message transformations from `Function<byte[], byte[]>` to `UnaryOperator<Object>` (e.g.,
-  `Map<String, Object>` for JSON, `GenericRecord` for Avro).
-- **Reasoning**: Chaining byte-to-byte functions incurs a massive "SerDe tax" by re-serializing data at every step.
-- **Implementation**: The `TypedPipelineBuilder<T>` (via `MessageProcessorRegistry.pipeline()`) acts as the
-  high-performance bridge. It:
-    1. Receives `byte[]`.
-    2. Deserializes **once** into an object of type `T`.
-    3. Applies a chain of `UnaryOperator<T>` transformations on the same object (avoiding copies).
-    4. Optionally sends the typed object to a terminal `MessageSink<T>`.
-    5. Serializes **once** back to `byte[]`.
+- **Java 25 triple-slash Javadoc** (`///`), markdown code blocks (`java ... `). No legacy `/** ... */` or HTML
+  `<pre>{@code ... }</pre>`.
+- **`final var` for locals** wherever possible.
+- **`java.lang.System.Logger`** — not SLF4J, not direct Log4j. Keeps the core library dependency-free.
+- **No `e.printStackTrace()`** — always use the logger.
+- **No fully-qualified class names in code** — if you have to write `java.util.concurrent.ConcurrentHashMap` instead of
+  just `ConcurrentHashMap`, add an import and reformat the code.
 
-### 3. Java 25 Virtual Threads and Scoped Values
+## Testing strategy
 
-- **Decision**: Use Virtual Threads (Project Loom) for parallel processing. When per-record context-sharing is needed,
-  prefer `ScopedValue` over `ThreadLocal`.
-- **Reasoning**: Virtual Threads replace complex thread pool management with a simple "thread-per-record" model.
-  `ScopedValue` is the VT-friendly alternative to `ThreadLocal`, avoiding the scalability traps of inheritable
-  thread-locals on a thread-per-record consumer.
-- **Current state**: VT is used everywhere (consumer poll → record processing). `ScopedValue` is **not** currently
-  used — earlier per-format SerDe caches were torn out as dead infrastructure. The doctrine still stands for any
-  future thread-local-like state we might add (e.g. tenant context, span propagation).
+- **Unit tests**: `lib/{module}/src/test/java`. Focus on pure function transformations.
+- **Integration tests**: `examples/{format}/src/test/java`.
+- **Testcontainers** for end-to-end with Kafka / Schema Registry. Use a `CapturingSink` to verify the actual payload
+  transformation.
+- **Virtual-thread tests** use `Thread.ofVirtual()` directly (not `CompletableFuture`) with `CountDownLatch` for sync.
+  Exercises real VT behaviour.
 
-### 4. Reliable Offset Management ("Lowest Pending Offset")
+---
 
-- **Decision**: Use a `ConcurrentSkipListSet` to track all in-flight offsets per partition.
-- **Reasoning**: Parallel processing leads to out-of-order completions. To ensure "at-least-once" delivery and avoid "
-  gaps" in committed data:
-    - Only the **lowest pending offset** for each partition is eligible for commitment.
-    - Ensures that even if message 102 finishes before message 101, 102 will not be committed until 101 is also
-      finished.
+## §3 Virtual Threads + ScopedValue doctrine
 
-## Coding Standards and Patterns
+VT is used everywhere (consumer poll → record processing). **`ScopedValue` is NOT currently used** — earlier per-format
+SerDe caches were torn out as dead infrastructure. The doctrine still stands for any future thread-local-like state we
+might add (tenant context, span propagation): prefer `ScopedValue` over `ThreadLocal` to avoid the
+inheritable-thread-local scalability trap on a thread-per-record consumer.
 
-### Modern Javadoc Format
+## §5 Strategy-based backpressure
 
-- Use Java 25 triple-slash (///) comments instead of legacy `/** ... */`.
-- Use Markdown-style code blocks (```java ... ```) instead of HTML `<pre>{@code ... }</pre>`.
+`BackpressureController` encapsulates the decision logic. Two strategies, always with hysteresis (high/low watermarks)
+to prevent thrashing:
 
-### Clean Code Principles
+- **In-flight (parallel)** — counts active virtual threads.
+- **Lag (sequential)** — `Σ (end_offset - position)`, the only meaningful metric for one-at-a-time processing.
 
-- Always use `final var` for local variable declarations whenever possible.
-- Use `java.lang.System.Logger` (Standard Java System Logger) instead of SLF4J or direct Log4j to keep the core library
-  dependency-free.
-- Avoid `e.printStackTrace()`; always use the logger for error reporting.
+## §7 Unified Registry (1.13.0, refined 1.14.0)
 
-### Testing Strategy
+**One registry type, two namespaces.** `MessageProcessorRegistry` holds operators (`UnaryOperator<T>`) and sinks
+(`MessageSink<T>`) in separate internal maps, keyed identically by `RegistryKey<T>`. The registration entry points are
+split by namespace — `registerOperator(key, op)` / `registerSink(key, sink)` — and the static error-handling helpers
+follow the same naming: `withOperatorErrorHandling(UnaryOperator<T>)` / `withSinkErrorHandling(MessageSink<T>)`. Lookups
+are `getOperator(key)` / `getSink(key)`, and per-namespace utilities carry the `Sink` suffix (`getSinkKeys`,
+`getAllSinks`, `getSinkMetrics`, `unregisterSink`, `clearSinks`, `compositeSink`).
 
-- **Unit Tests**: Place in `lib/{module}/src/test/java`. Focus on pure function transformations.
-- **Integration Tests**: Place in `examples/{format}/src/test/java`.
-- **Testcontainers**: Use for end-to-end validation involving Kafka and Schema Registry. Always use a `CapturingSink` to
-  verify the actual payload transformation.
-- **Virtual Thread Tests**: Concurrency tests should use `Thread.ofVirtual()` directly rather than `CompletableFuture`
-  to exercise real virtual thread behavior. Use `CountDownLatch` for synchronization between threads.
+**Historical note:** through 1.13 these were `register` / `withErrorHandling` overloaded by argument type. Bare lambdas
+like `x -> x` were ambiguous and needed an explicit cast. 1.14 renamed both pairs per §16 (delete + migrate) to kill the
+overload-ambiguity footgun.
 
-### 5. Strategy-Based Backpressure
+## §8 Centralized error handling
 
-- **Decision**: Decouple backpressure monitoring from the consumer core using a strategy pattern.
-- **In-Flight Strategy (Parallel)**: Monitors active virtual threads to prevent memory exhaustion.
-- **Lag Strategy (Sequential)**: Monitors total consumer lag (`Σ (end_offset - position)`) as the only meaningful metric
-  when processing messages one-by-one.
-- **Hysteresis**: Always uses high and low watermarks to prevent "thrashing" (rapidly toggling between pause and resume
-  states).
-- **Implementation**: `BackpressureController` encapsulates the decision logic, providing static factory methods (
-  `lagStrategy()`, `inFlightStrategy()`) to the `KPipeConsumer`.
+`RegistryFunctions.withOperatorErrorHandling` (for `UnaryOperator<T>`) and `withConsumerErrorHandling` (for
+`MessageSink<T>`) wrap user code so one failing component can't crash the pipeline.
 
-### 6. Refinement of Core Components
+## §9 Modular architecture
 
-- **KPipeConsumer Simplicity**: Minimized internal fields and delegated lifecycle management (initialization, shutdown,
-  backpressure) to specialized controllers (`BackpressureController`, `OffsetManager`).
-- **Composition over Inheritance**: Message transformations are composed using functional operators (Stream.reduce) in
-  `MessageProcessorRegistry` rather than deep inheritance or manual chaining.
+`kpipe-metrics` ← `kpipe-producer` ← `kpipe-consumer`. Each module is published individually to Maven Central;
+`kpipe-consumer` transitively pulls the other two.
 
-### 7. Unified Registry (1.13.0)
+**Split-package rule (JPMS):** no two modules may export the same Java package. When a class references types from
+another module, it stays in the module that owns those types.
 
-- **Decision**: One registry type, two namespaces. `MessageProcessorRegistry` holds both operators
-  (`UnaryOperator<T>`) and sinks (`MessageSink<T>`) in separate internal maps, keyed identically by
-  `RegistryKey<T>`. `MessageSinkRegistry` was deleted in 1.13.0 and its surface absorbed.
-- **Reasoning**: Processors and sinks share lifecycle, metrics, and type-safe key shape; keeping
-  two structurally-identical types behind a colocated facade (1.12's `registry.sinkRegistry().X()`
-  pattern) leaked the layering through callers. Collapsing to one type concentrates the "what is a
-  registry entry, what metrics does it carry, how does error-handling wrap a value" answer in one
-  place.
-- **Implementation**:
-    - `register` is overloaded: `register(RegistryKey<T>, UnaryOperator<T>)` for the operator
-      namespace, `register(RegistryKey<T>, MessageSink<T>)` for the sink namespace. Java resolves
-      by argument type; bare lambdas like `x -> x` are still ambiguous and need an explicit cast.
-    - Symmetric pairs: `getOperator` / `getSink`, `getKeys` / `getSinkKeys`, `getAll` / `getAllSinks`,
-      `getMetrics` / `getSinkMetrics`, `unregister` / `unregisterSink`, `clear` / `clearSinks`,
-      `registerEnum` / `registerSinkEnum`. The operator side keeps the unsuffixed names because it
-      was the larger pre-existing surface; the sink side carries the `Sink` suffix.
-    - `compositeSink(RegistryKey<T>...)` is an instance method on the registry (moved from the
-      former `TypedPipelineBuilder.compositeSink` static).
-    - `withErrorHandling` is overloaded too: one for `UnaryOperator<T>`, one for `MessageSink<T>`.
-    - The shared `RegistryEntry<T>` still centralises metrics tracking.
-- **Migration note (1.12 → 1.13)**: every `registry.sinkRegistry().X(...)` call site becomes
-  `registry.X(...)` (or `registry.XSink(...)` for the suffixed pairs above). `MessageSinkRegistry.JSON_LOGGING`
-  moved to `JsonFormat.JSON_LOGGING`. Per §16, no deprecation shim — callers migrated in the same PR
-  (`arch/registry-collapse`).
+Package ownership:
 
-### 8. Centralized Error Handling
+- `org.kpipe.metrics` → `kpipe-metrics`
+- `org.kpipe.producer.*` → `kpipe-producer`
+- `org.kpipe.sink.*` → `kpipe-producer`
+- `org.kpipe.consumer.*` → `kpipe-consumer`
+- `org.kpipe.consumer.metrics` → `kpipe-consumer` (reporters that depend on registry types)
+- `org.kpipe.consumer.sink.*` → `kpipe-consumer`
 
-- **Decision**: Standardize error suppression and logging logic in `RegistryFunctions`.
-- **Reasoning**: Consistent error handling prevents a single failing component from crashing the entire pipeline.
-- **Implementation**:
-    - `withOperatorErrorHandling`: Specifically for `UnaryOperator<T>`.
-    - `withConsumerErrorHandling`: Specifically for `MessageSink<T>`.
+## §10 OpenTelemetry metrics
 
-### 9. Modular Architecture and Split-Module Strategy
+`kpipe-metrics` ships interfaces against `opentelemetry-api` only — no SDK. Users bring their own SDK (Prometheus, OTLP,
+Jaeger). Both `ConsumerMetrics` / `ProducerMetrics` default to `OpenTelemetry.noop()` (zero cost when not configured)
+and wire via `.withMetrics(...)`.
 
-- **Decision**: Split the library into three submodules: `kpipe-metrics`, `kpipe-producer`, `kpipe-consumer`.
-- **Dependency chain**: `kpipe-metrics` ← `kpipe-producer` ← `kpipe-consumer`
-- **Reasoning**:
-    - **Reduced Surface Area**: Each module carries only the dependencies it needs.
-    - **JPMS Compliance**: Avoid split packages by clearly defining package ownership between modules.
-    - **No Aggregate Artifact**: Each module is published individually to Maven Central. `kpipe-consumer` transitively
-      includes `kpipe-producer` and `kpipe-metrics`, so users only need a single dependency.
-- **Publishing**: Each submodule applies `maven-publish` and `signing`. JReleaser (configured in `:lib`) deploys all
-  three staging directories to Maven Central in a single release.
-- **Package Convention**:
-    - `org.kpipe.metrics` — owned by `kpipe-metrics` (OTel instruments, `KPipeMetricsReporter`,
-      `ConsumerMetricsReporter`).
-    - `org.kpipe.producer.*` — owned by `kpipe-producer`.
-    - `org.kpipe.sink.*` — owned by `kpipe-producer`.
-    - `org.kpipe.consumer.*` — owned by `kpipe-consumer`.
-    - `org.kpipe.consumer.metrics` — owned by `kpipe-consumer` (reporters that depend on registry types).
-    - `org.kpipe.consumer.sink.*` — owned by `kpipe-consumer`.
-- **Split Package Rule**: No two modules may export the same Java package. When a class references types from another
-  module (e.g., `EntryMetricsReporter` referencing `MessageProcessorRegistry`), it stays in the module that owns
-  those types.
+| Component         | Instrument                           | Type      |
+| ----------------- | ------------------------------------ | --------- |
+| `ProducerMetrics` | `kpipe.producer.messages.sent`       | counter   |
+|                   | `kpipe.producer.messages.failed`     | counter   |
+|                   | `kpipe.producer.dlq.sent`            | counter   |
+| `ConsumerMetrics` | `kpipe.consumer.messages.received`   | counter   |
+|                   | `kpipe.consumer.messages.processed`  | counter   |
+|                   | `kpipe.consumer.messages.errors`     | counter   |
+|                   | `kpipe.consumer.processing.duration` | histogram |
+|                   | `kpipe.consumer.messages.inflight`   | gauge     |
+|                   | `kpipe.consumer.backpressure.pauses` | counter   |
+|                   | `kpipe.consumer.backpressure.time`   | counter   |
 
-### 10. OpenTelemetry Metrics Strategy
+Log-based fallback for users who don't run OTel: `ConsumerMetricsReporter` (consumer-wide snapshot) +
+`EntryMetricsReporter` (per-entry, namespace-aware via `forProcessors(...)` / `forSinks(...)`).
 
-- **Decision**: Provide first-class OTel support via `kpipe-metrics` using `opentelemetry-api` only (no SDK).
-- **Reasoning**: Libraries should instrument with the API; users bring their own SDK (Prometheus, OTLP, Jaeger, etc.).
-- **Implementation**:
-    - `ProducerMetrics` — counters: `kpipe.producer.messages.sent`, `kpipe.producer.messages.failed`,
-      `kpipe.producer.dlq.sent`.
-    - `ConsumerMetrics` — counters: `kpipe.consumer.messages.received`, `kpipe.consumer.messages.processed`,
-      `kpipe.consumer.messages.errors`; histogram: `kpipe.consumer.processing.duration`; gauge:
-      `kpipe.consumer.messages.inflight`; counters: `kpipe.consumer.backpressure.pauses`,
-      `kpipe.consumer.backpressure.time`.
-    - Both default to `OpenTelemetry.noop()` — zero cost when not configured.
-    - Wired via builder: `.withMetrics(new ConsumerMetrics(otel))` / `.withMetrics(new ProducerMetrics(otel))`.
-- **Log-based reporters**: `ConsumerMetricsReporter` (aggregate consumer-level snapshot — uptime,
-  per-second rates, backpressure totals) plus `EntryMetricsReporter` (per-entry, namespace-aware
-  via `forProcessors(...)` / `forSinks(...)`). 1.13.0 collapsed the prior `ProcessorMetricsReporter`
-  + `SinkMetricsReporter` (structurally identical) into the single `EntryMetricsReporter`. These
-  remain available as a lightweight fallback for users who do not use OTel.
+## §11 KPipeConsumer concurrency & safety patterns
 
-### 11. KPipeConsumer Concurrency and Safety Patterns
-
-- **State Machine**: All state transitions use single-read `compareAndSet` — read once into a local, decide, CAS. Never
-  use two sequential CAS calls (double-CAS window). Shared helper `transitionToClosing()` is used by `close()` and
+- **State machine.** All transitions use single-read `compareAndSet` — read once into a local, decide, CAS. Never two
+  sequential CAS calls (double-CAS window). Shared helper `transitionToClosing()` is used by `close()` and
   `uncaughtExceptionHandler`.
-- **Error Handler Safety**: Every `errorHandler.accept()` call site is wrapped in try-catch. A throwing user callback
+- **Error handler safety.** Every `errorHandler.accept()` call site is wrapped in try-catch. A throwing user callback
   must never crash the consumer thread, leak in-flight counts, or skip offset marking. `markOffsetProcessed()` is always
   called **before** `errorHandler.accept()`.
-- **Shutdown Guarantee**: `state.set(CLOSED)` lives in a nested `finally` inside the consumer thread's outer `finally`.
+- **Shutdown guarantee.** `state.set(CLOSED)` lives in a nested `finally` inside the consumer thread's outer `finally`.
   Even if `kafkaConsumer.close()` throws, the consumer always reaches terminal state.
-- **LockSupport Park/Unpark**: The consumer thread uses `LockSupport.park()` (not `Thread.sleep()`) when paused. This
-  avoids CPU waste and wakes instantly. Unpark sources:
-    - `internalResume()` — manual or backpressure resume.
-    - `close()` — shutdown path.
-    - `processRecord()` finally block — when `backpressurePaused` is true (in-flight drain triggers re-evaluation).
-      Commands are flushed via `processCommands()` **before** parking so `kafkaConsumer.pause()` executes immediately.
-- **Pipeline Null Handling**: Null record value and null deserialization throw specific `IllegalStateException` messages
-  (retryable via normal exception path). Null `process()` result is intentional filtering — mark offset processed, count
-  as success, no error.
-- **Metrics Immutability**: `getMetrics()` returns `Collections.unmodifiableMap()`. Callers cannot mutate the snapshot.
-- **Thread Safety Boundaries**: `processCommands()` is package-private — external callers cannot invoke
+- **LockSupport park/unpark.** Consumer thread uses `LockSupport.park()` (not `Thread.sleep()`) when paused. Unpark
+  sources: `internalResume()`, `close()`, and `processRecord()` finally block when `backpressurePaused` is true.
+  Commands are flushed via `processCommands()` **before** parking so `kafkaConsumer.pause()` executes immediately.
+- **Pipeline null handling.** Null record value and null deserialization throw specific `IllegalStateException` messages
+  (retryable). Null `process()` result is intentional filtering — mark offset processed, count as success, no error.
+- **Metrics immutability.** `getMetrics()` returns `Collections.unmodifiableMap()`.
+- **Thread-safety boundaries.** `processCommands()` is package-private — external callers can't invoke
   `kafkaConsumer.pause()`/`resume()`/`commitSync()` from arbitrary threads. `isRunning()` snapshots `state.get()` into a
-  local variable before comparing.
+  local before comparing.
 
-### 12. Explicit Pipeline Error Semantics — No Silent Failures
+## §12 Explicit pipeline error semantics — no silent failures
 
-- **Decision (1.9.0)**: `MessagePipeline.apply()` no longer overloads `null` as both "filtered" and "failed". Failures
-  throw; `null` means exactly one thing — intentional filtering by `process()`.
-- **Decision (1.13.0)**: `MessagePipeline.process()` returns a sealed `Result<T>` (`Passed | Filtered | Failed`). The
-  three outcomes are now distinct *types* enforced by the compiler — the §12 doctrine moved from "convention enforced
-  by discipline" to "guarantee enforced by exhaustive pattern matching". The byte-level entry points (`apply`,
-  `processToSink`, `processToValue`) preserve their pre-1.13 contracts by unwrapping the Result internally: `null` for
-  intentional filters, re-throwing the captured `Failed.cause` for failures. New code that wants typed handling calls
-  `process()` directly and switches on the result.
-- **Reasoning**: The pre-1.9.0 implementation caught all exceptions in `apply()` and returned `null`. The downstream
-  `KPipeConsumer.processTypedRecord` then treated `processed == null` as intentional filtering and incremented
-  `messagesProcessed` — masking deserialization errors as successes. The only signal something was wrong was a gauge
-  mismatch (`messagesProcessed` rising while `sinkInvocationCount` stayed at 0). 1.9 fixed the *behaviour*; 1.13
-  fixed the *type* so the bug is impossible at compile time.
-- **Real-world burn**: Discovered during the Grafana dashboard session — protobuf seed messages all failed
-  deserialization because `skipBytes(5)` was wrong, but the consumer reported them as processed. ~10 minutes wasted on
-  a bug that should have been a single error log. After 1.13.0 the same bug would surface as a `Result.Failed` at the
-  consumer's pattern-match site — no convention to remember, no discipline to maintain.
-- **Implementation invariants**:
-    - Null record value throws `IllegalStateException` with a specific message (retryable via the normal exception
-      path).
-    - Null deserialization result throws `IllegalStateException` (implementations must throw, not return null).
-    - `process()` returns `Result.Passed` (value flows on), `Result.Filtered` (offset committed, sink skipped), or
-      `Result.Failed(cause)` (retry/DLQ/error-handler routes the cause). The `Filtered` value is a shared singleton
-      via `Result.filtered()` to avoid per-record allocation; `Passed` and `Failed` each allocate one record per call.
-    - Operators (`UnaryOperator<T>`) still return `T` (or null for filter) — the Result wrapping lives at the
-      pipeline level, not at every operator. `TypedPipelineBuilder.build()` catches `RuntimeException` from operators
-      and converts to `Result.failed(...)`; null returns become `Result.filtered()`.
-- **Generalizable rule**: When composing `Function<T, R>` chains, never use `null`/`Optional.empty()` to signal both
-  "filtered" and "failed". If both states exist, model them as distinct types (sealed `Result<T>` or distinct
-  exceptions). Triage heuristic: when a "processed" counter rises but downstream invocations stay at 0, suspect
-  overloaded null semantics first.
+**Doctrine:** `MessagePipeline.process()` returns sealed `Result<T>` (`Passed | Filtered | Failed`). The three outcomes
+are distinct compiler-enforced types — the §12 rule moved from "convention" to "guarantee enforced by exhaustive pattern
+matching" in 1.13.0.
 
-### 13. KPipe Fluent Facade (1.10.0) — Layered API Strategy
+**Real-world burn:** before 1.9, `apply()` caught all exceptions and returned `null`. The downstream
+`KPipeConsumer.processTypedRecord` treated `processed == null` as intentional filtering and incremented
+`messagesProcessed` — masking deserialization errors as successes. Discovered during a Grafana session: protobuf seed
+messages all failed deserialization (`skipBytes(5)` was wrong) but were reported as processed. The only signal was
+`messagesProcessed` rising while `sinkInvocationCount` stayed at 0.
 
-- **Decision (1.10.0)**: ship a top-level `KPipe` fluent facade in a new `kpipe-api` module that delegates to the
-  existing `MessageProcessorRegistry` / `KPipeConsumer.Builder` stack. The facade is purely
-  additive — no public 1.x API was changed.
-- **Reasoning**: The 1.10.0 ergonomics pass smoothed surface friction (no-arg ctors, format helpers, DLQ bundle, etc.)
-  but left the typical "build a JSON consumer" path at ~10 lines of registry + builder + runner. The fluent facade
-  gets the common case to 5 lines without breaking anyone.
-- **Layered API rule**: the codebase now exposes TWO public surfaces:
-    1. **`org.kpipe.KPipe.json/avro/protobuf/bytes/custom(...)`** — fluent, immutable, returns `Stream<T>` →
-       `Sink<T>` → `Handle`. The 80% path. Discoverable via IDE auto-complete after the first `.`.
-    2. **`MessageProcessorRegistry` + `KPipeConsumer.Builder`** — explicit, multi-step,
-       supports custom registries, shared pipelines, programmatic runner config. The 20% path.
-- **Module placement (JPMS):** `Stream<T>`, `Sink<T>`, `Handle` interfaces live in `kpipe-api` (package
-  `org.kpipe`). Private impls (`DefaultStream`, `DefaultSink`, `DefaultHandle`) also in `org.kpipe`, package-private.
-  This keeps the user-facing import path clean (`import org.kpipe.KPipe;`) and avoids the `org.kpipe.facade` split-
-  package cost while still letting `kpipe-core` own the registry/sink/format types in `org.kpipe.registry` and
-  `org.kpipe.sink`.
-- **Immutability contract on `Stream<T>`**: `DefaultStream` is a Java record. Every fluent method returns a NEW
-  `DefaultStream` instance carrying the updated configuration. The original is never mutated. Branching from a
-  common root is safe — `s.pipe(a)` and `s.pipe(b)` produce independent streams. Operators are stored as an
-  immutable `List.copyOf(...)`. The record form keeps "adding a fluent setter is a one-place change" honest:
-  declare the component, add the `with*` method, reference it in `DefaultSink.buildPipeline` if it affects pipeline
-  construction.
-- **`Handle` is `AutoCloseable`** with a default `close()` that performs `shutdownGracefully(Duration.ofSeconds(5))`.
-  Use try-with-resources to guarantee cleanup. `metrics()` returns `Map<String, Long>` (typed), not `Map<String,
-  Object>`.
-- **`toConsole()` dispatch** uses a per-factory `Function<T, MessageSink<T>>` lambda baked into the `DefaultStream`
-  at construction time. No `instanceof MessageFormat` checks. Avro's factory throws `IllegalStateException` if no
-  default schema is registered.
-- **Test contract**: facade has both unit tests (composition + dispatch) and a Testcontainers end-to-end test that
-  spins up a real broker and verifies the entire chain through `start()` / `Handle.metrics()` / `shutdownGracefully()`.
+**Invariants:**
 
-### 14. Audit-Derived Concurrency Patterns
+- Null record value or null deserialization → throw `IllegalStateException` (retryable). Format implementations must
+  throw, not return null.
+- `process()` returns `Result.Passed` / `Result.Filtered` / `Result.Failed(cause)`. `Result.filtered()` is a **shared
+  singleton** to avoid per-record allocation; `Passed` and `Failed` allocate one record per call.
+- Operators (`UnaryOperator<T>`) still return `T` or null-for-filter — `Result` wrapping lives at the pipeline level.
+  `TypedPipelineBuilder.build()` catches `RuntimeException` from operators → `Result.failed(...)`; null returns →
+  `Result.filtered()`.
+- Byte-level entry points (`apply` / `processToSink` / `processToValue`) preserve pre-1.13 contracts by unwrapping the
+  Result internally: null for filters, re-throw `Failed.cause` for failures.
 
-These patterns came out of the deep internal audit work and should be preserved across the codebase:
+**Generalizable rule:** when composing `Function<T, R>` chains, never use `null`/`Optional.empty()` to signal both
+"filtered" and "failed." Model them as distinct types or distinct exceptions. **Triage heuristic:** when a "processed"
+counter rises but downstream invocations stay at 0, suspect overloaded null semantics first.
 
-- **Atomic remove-if-empty on `ConcurrentHashMap` of mutable collections**: NEVER do
-  `if (set.isEmpty()) map.remove(key)` after a separate `set.remove(value)` — the check-then-act is non-atomic and
-  a concurrent `computeIfAbsent` can repopulate the set between the check and the map removal. Always use
-  `map.computeIfPresent(key, (k, v) -> { v.remove(value); return v.isEmpty() ? null : v; })`. The bucket lock makes
-  the whole sequence atomic.
-- **`ConcurrentSkipListSet.first()` is a check-then-act trap**: pattern `if (!set.isEmpty()) set.first()` can throw
-  `NoSuchElementException` under contention. Wrap in a `safeFirst` helper that returns `null` on
-  `NoSuchElementException`. Apply the same pattern for `last()`.
-- **`(Properties) parent.clone()`, NOT `new Properties(parent)`**: `new Properties(parent)` makes the parent a
-  *fallback for `getProperty()`*, not a copy. `putIfAbsent` operates on the new instance only and silently shadows
-  parent entries. Always `clone()` when you intend to derive a copy.
-- **CAS-to-CAS happens-before doesn't extend to post-CAS field writes**: if `start()` does
-  `state.compareAndSet(...)` then assigns `scheduler = ...`, a concurrent `close()` that does its own
-  `state.compareAndSet(...)` is NOT guaranteed to see `scheduler` (the assignment is after the CAS in program order).
-  Mark such fields `volatile`, or move the assignment into the CAS-protected critical section.
-- **`Kafka.endOffsets(...)` without a `Duration`** uses the consumer's `default.api.timeout.ms` (60s default). On a
-  hot path (every consumer-loop iteration), a slow broker stalls the entire consumer. Always pass a bounded timeout.
-- **`catch (Exception) { return defaultValue; }` is a silent-failure trap**: never swallow without logging at
-  WARNING. If you catch `InterruptException` (Kafka) or `InterruptedException`, **always** call
-  `Thread.currentThread().interrupt()` to restore the flag for downstream code.
-- **Don't expose internal counters through public APIs**: if a method takes an `AtomicLong` parameter for
-  "optionally update this counter on success," it's leaking implementation detail. Return a `boolean` and let the
-  caller update its own counter.
+## §13 Fluent facade (1.10.0+)
 
-### 15. Multi-Topic Dispatch (1.11.0)
+**Layered API.** Two public surfaces:
 
-- **Decision**: One `KPipeConsumer` can host either one shared pipeline across N topics (homogeneous) or a
-  per-topic pipeline map (heterogeneous), but always through one Kafka consumer / one consumer-group / one
-  offset manager.
-- **Internal model**: `KPipeConsumer` stores `Map<String, MessagePipeline<?>> pipelines`. The homogeneous path
-  (`Builder.withPipeline(...)`) replicates the same pipeline reference across every subscribed topic at construction
-  time; the heterogeneous path (`Builder.withPipelines(Map)`) takes the map directly and derives the topic set from
-  its keys. `tryProcessRecord` does a single `pipelines.get(record.topic())` per record. The map is built via
-  `Map.copyOf(...)`, so for typical small route counts it's `Map1`/`MapN` (identity-fast `String#equals` lookup),
-  not `HashMap`.
-- **Unrouted-topic policy**: if a record arrives for a topic with no registered pipeline (rebalance race, config
-  error), **drop + log at WARNING + mark offset processed**. Never throw (would crash the consumer thread for a
-  config error) and never DLQ (we don't have a per-topic DLQ). The "mark processed" part is critical — without
-  it, the same record gets re-fetched forever.
-- **Facade split**: homogeneous via `KPipe.json/avro/protobuf/bytes/custom(Collection<String>, Properties)`;
-  heterogeneous via `KPipe.multi(props).json(topic, configurator).avro(...)...start()`. Single-string overloads
-  remain unchanged. Mixing `withTopic`/`withTopics` with `withPipelines` is rejected as a config error (silent
-  override would mask user mistakes).
-- **Metrics**: OTel `kpipe.consumer.*` instruments now carry both a `pipeline` attribute (consumer-wide) and a
-  `topic` attribute (per record). Per-topic `Attributes` are cached via `computeIfAbsent` so the per-record metric
-  path is allocation-free after each topic has been seen once.
+1. **`org.kpipe.KPipe.json/avro/protobuf/bytes/custom(...)`** — fluent, immutable, returns `Stream<T>` → `Sink<T>` →
+   `Handle`. The 80% path.
+2. **`MessageProcessorRegistry` + `KPipeConsumer.Builder`** — explicit, multi-step. The 20% path.
 
-### 16. No-Deprecation Policy
+**Immutability contract.** `DefaultStream` is a Java record; every fluent method returns a NEW instance carrying updated
+config. Operators are stored as `List.copyOf(...)`. Branching from a common root is safe: `s.pipe(a)` and `s.pipe(b)`
+produce independent streams. Adding a new fluent setter is a one-place change: declare the component, add the `with*`
+method, reference in `DefaultSink.buildPipeline` if it affects pipeline construction.
 
-- **Decision**: When a public API has to go, **delete it and migrate all callers**. Do not deprecate, do not add
-  `@Deprecated`, do not add `since = "..."` annotations.
-- **Reasoning**: Deprecation cycles bloat the surface, train users to ignore warnings, and rot in place when the
-  promised "removal in next major" never happens. The library is pre-1.x-stable enough that hard breaks with a
-  release-note migration are cleaner than carrying dead overloads. Tests and examples are migrated in the same PR
-  that deletes the method, so callers always have a working reference.
-- **Enforcement**: zero `@Deprecated` annotations and zero `@deprecated` Javadoc tags should ever land in the
-  codebase. If something needs to be removed, the PR description mentions the removal explicitly.
+`Handle` is `AutoCloseable` with a default `close()` that calls `shutdownGracefully(Duration.ofSeconds(5))`. `metrics()`
+returns `Map<String, Long>` (typed).
 
-### 17. Core ↔ Facade Capability Mapping
+## §14 Audit-derived concurrency patterns
 
-This table is the source of truth for which `kpipe-consumer` / `kpipe-core` / `kpipe-format-*` / `kpipe-metrics`
-capabilities are reachable through the **fluent facade** (`KPipe.json/avro/protobuf/bytes/custom(...)` →
-`Stream<T>` → `Sink<T>` → `Handle`, plus `KPipe.multi(props)` → `MultiBuilder`) versus only via the **explicit API**
-(`MessageProcessorRegistry` + `KPipeConsumer.Builder`).
+These came out of deep internal audit work — preserve across the codebase.
+
+- **Atomic remove-if-empty on `ConcurrentHashMap` of mutable collections.** Never do
+  `if (set.isEmpty()) map.remove(key)` after a separate `set.remove(value)` — non-atomic, a concurrent `computeIfAbsent`
+  can repopulate the set between the check and the map removal. Use
+  `map.computeIfPresent(key, (k, v) -> { v.remove(value); return v.isEmpty() ? null : v; })`. The bucket lock makes the
+  whole sequence atomic.
+- **`ConcurrentSkipListSet.first()` is a check-then-act trap.** `if (!set.isEmpty()) set.first()` can throw
+  `NoSuchElementException` under contention. Wrap in `safeFirst` returning `null` on `NoSuchElementException`. Same for
+  `last()`.
+- **`(Properties) parent.clone()`, NOT `new Properties(parent)`.** The latter makes parent a _fallback for
+  `getProperty()`_, not a copy. `putIfAbsent` operates on the new instance only and silently shadows parent entries.
+  Always `clone()` when deriving a copy.
+- **CAS-to-CAS happens-before doesn't extend to post-CAS field writes.** If `start()` does `state.compareAndSet(...)`
+  then assigns `scheduler = ...`, a concurrent `close()` doing its own CAS is NOT guaranteed to see `scheduler`. Mark
+  such fields `volatile`, or move the assignment inside the CAS-protected critical section.
+- **`Kafka.endOffsets(...)` without a `Duration`** uses `default.api.timeout.ms` (60s default). On a hot path, a slow
+  broker stalls the entire consumer. Always pass a bounded timeout.
+- **`catch (Exception) { return defaultValue; }` is a silent-failure trap.** Never swallow without logging at WARNING.
+  If you catch `InterruptException` (Kafka) or `InterruptedException`, **always** call
+  `Thread.currentThread().interrupt()` to restore the flag.
+- **Don't expose internal counters through public APIs.** A method taking `AtomicLong` for "optionally update this
+  counter on success" leaks implementation detail. Return `boolean` and let the caller update its own counter.
+
+## §15 Multi-topic dispatch (1.11.0)
+
+One `KPipeConsumer`, one Kafka consumer, one consumer-group, one offset manager. Either a single shared pipeline across
+N topics (homogeneous, `Builder.withPipeline(...)`) or a per-topic pipeline map (heterogeneous,
+`Builder.withPipelines(Map)`).
+
+**Unrouted-topic policy.** If a record arrives for a topic with no registered pipeline (rebalance race, config error):
+**drop + log at WARNING + mark offset processed.** Never throw (would crash the consumer thread for a config error) and
+never DLQ (no per-topic DLQ exists). The "mark processed" part is critical — without it, the same record gets re-fetched
+forever.
+
+**Config-error rejection.** Mixing `withTopic`/`withTopics` with `withPipelines` is rejected as a config error (silent
+override would mask user mistakes).
+
+## §16 No-deprecation policy
+
+When a public API has to go: **delete it and migrate all callers in the same PR.** No `@Deprecated`, no `@deprecated`
+Javadoc, no `since = "..."`.
+
+**Reasoning:** deprecation cycles bloat the surface, train users to ignore warnings, and rot in place when the promised
+"removal in next major" never happens. The PR description mentions the removal explicitly so callers always have a
+working reference.
+
+## §17 Core ↔ Facade capability mapping
+
+Source of truth for which capabilities are on the fluent facade (`KPipe.X(...)` → `Stream<T>` → `Sink<T>` → `Handle`,
+plus `KPipe.multi(props)` → `MultiBuilder`) versus only via the explicit API (`MessageProcessorRegistry` +
+`KPipeConsumer.Builder`).
 
 When adding a new consumer/builder feature: decide whether it belongs on the 80% path (add to `Stream<T>` and
-`MultiBuilder`) or whether it stays as an escape hatch (explicit-only). Update this table in the same PR.
+`MultiBuilder`) or stays as an escape hatch (explicit-only). Update this table in the same PR. Rows in **bold** are
+deliberately escape-hatch-only.
 
-| Capability                                  | Source module          | Facade path                                                              | Explicit-API path                                                                                    | Notes                                                                                                                                                                                 |
-|---------------------------------------------|------------------------|--------------------------------------------------------------------------|------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| Format selection                            | `kpipe-format-*`       | `KPipe.json/avro/protobuf/bytes/custom(...)`                             | `new MessageProcessorRegistry(format)`                                                               | Custom format: pass any `MessageFormat<T>` to `KPipe.custom`.                                                                                                                         |
-| Topic subscription (homogeneous)            | `kpipe-consumer`       | `KPipe.X(topic, props)`                                                  | `Builder.withTopic(s) / withTopics(...)`                                                             | One topic-set, one shared pipeline.                                                                                                                                                   |
-| Topic subscription (heterogeneous)          | `kpipe-consumer`       | `KPipe.multi(props).json(...).avro(...)...start()`                       | `Builder.withPipelines(Map<String, MessagePipeline<?>>)`                                             | Per-topic dispatch (§15).                                                                                                                                                             |
-| Operator chain (`pipe/filter/peek/when`)    | `kpipe-core`           | `Stream.pipe / filter / peek / when`                                     | `MessageProcessorRegistry.pipeline(format).add(...)`                                                 | Identical operator semantics.                                                                                                                                                         |
-| Custom terminal sink                        | `kpipe-core`           | `Stream.toCustom(MessageSink<T>)`                                        | `registry.register(key, sink)`                                                                   | Any `MessageSink<T>`; facade also offers `.toConsole()`.                                                                                                                              |
-| Multi-sink fanout                           | `kpipe-core`           | `Stream.toMulti(sinks...)`                                               | `new CompositeMessageSink<>(...)`                                                                    | Best-effort delivery; per-sink errors logged + suppressed.                                                                                                                            |
-| Batch sink (size + age flush)               | `kpipe-core`           | `Stream.toBatch(BatchSink<T>, BatchPolicy)`                              | `Builder.withBatchPipeline(topic, pipeline, sink, policy)` (multi-call for heterogeneous batch)      | `BatchSink<T>` returns `BatchResult` for per-record DLQ; `BatchSink.ofVoid(consumer)` wraps void-style sinks (whole-batch DLQ on throw). Both sequential and parallel modes. See §18. |
-| Batch sink (multi-topic via `MultiBuilder`) | `kpipe-api`            | `KPipe.multi(props).json(topic, s -> s.toBatch(sink, policy))...start()` | `Builder.withBatchPipeline(...)` × N                                                                 | One consumer-group, mixed batch + non-batch routes.                                                                                                                                   |
-| Skip wire-format prefix                     | `kpipe-core`           | `Stream.skipBytes(int)`                                                  | `TypedPipelineBuilder.skipBytes(int)`                                                                | Confluent envelope: 5 (Avro) / 6 (Proto single-msg).                                                                                                                                  |
-| Retry policy                                | `kpipe-consumer`       | `Stream.withRetry(int, Duration)`                                        | `Builder.withRetry(int, Duration)`                                                                   |                                                                                                                                                                                       |
-| Backpressure (default watermarks)           | `kpipe-consumer`       | `Stream.withBackpressure()`                                              | `Builder.withBackpressure(BackpressureController)`                                                   | Defaults: pause 10k, resume 7k.                                                                                                                                                       |
-| Backpressure (custom watermarks)            | `kpipe-consumer`       | `Stream.withBackpressure(high, low)`                                     | `Builder.withBackpressure(BackpressureController)`                                                   | High/low strategy auto-derived from `sequentialProcessing`.                                                                                                                           |
-| Sequential processing                       | `kpipe-consumer`       | `Stream.withSequentialProcessing(boolean)`                               | `Builder.withSequentialProcessing(boolean)`                                                          | Switches backpressure to lag-based (§5).                                                                                                                                              |
-| OTel/custom metrics                         | `kpipe-metrics(-otel)` | `Stream.withMetrics(ConsumerMetrics)` / `MultiBuilder.withMetrics(...)`  | `Builder.withMetrics(ConsumerMetrics)`                                                               | Single-format and multi-topic both supported.                                                                                                                                         |
-| Custom error handler                        | `kpipe-consumer`       | `Stream.withErrorHandler(Consumer<ProcessingError<byte[]>>)`             | `Builder.withErrorHandler(ErrorHandler<K>)`                                                          | Default logs at WARNING (§11).                                                                                                                                                        |
-| Dead-letter topic                           | `kpipe-consumer`       | `Stream.withDeadLetterTopic(String)`                                     | `Builder.withDeadLetterTopic(String)` / `withDeadLetterBundle(...)`                                  | Bundle form pairs DLQ + producer for advanced wiring.                                                                                                                                 |
-| Poll timeout                                | `kpipe-consumer`       | `Stream.withPollTimeout(Duration)`                                       | `Builder.withPollTimeout(Duration)`                                                                  | Default 100ms.                                                                                                                                                                        |
-| Lifecycle handle                            | `kpipe-api`            | `Handle.isHealthy / metrics / awaitShutdown / close`                     | `KPipeConsumer.start / awaitShutdown / shutdownGracefully / waitForInFlightDrain`                    | `Handle` is `AutoCloseable` (5s graceful default). Since 1.13: consumer hosts the lifecycle directly — no separate `KPipeRunner`.                                                    |
-| **Custom `OffsetManager`**                  | `kpipe-consumer`       | — (escape hatch only)                                                    | `Builder.withOffsetManager(...)` / `withOffsetManager(Provider)`                                     | E.g. Postgres/Redis-backed manager.                                                                                                                                                   |
-| **Custom Kafka `Consumer` factory**         | `kpipe-consumer`       | —                                                                        | `Builder.withConsumerProvider(Supplier<Consumer<K,byte[]>>)`                                         | Test seam / SSL configurators.                                                                                                                                                        |
-| **Custom DLQ `KafkaProducer`**              | `kpipe-producer`       | —                                                                        | `Builder.withKafkaProducer(...)` / `withDeadLetterBundle(...)`                                       | Override default producer for the DLQ.                                                                                                                                                |
-| **Rebalance listener**                      | `kpipe-consumer`       | —                                                                        | `Builder.withRebalanceListener(ConsumerRebalanceListener)`                                           | External offset commit hooks, log routing.                                                                                                                                            |
-| **Custom command queue**                    | `kpipe-consumer`       | —                                                                        | `Builder.withCommandQueue(Queue<ConsumerCommand>)`                                                   | Test seam (rarely needed).                                                                                                                                                            |
-| **Thread/executor termination**             | `kpipe-consumer`       | —                                                                        | `Builder.withThreadTerminationTimeout / withExecutorTerminationTimeout / withWaitForMessagesTimeout` | Shutdown tuning.                                                                                                                                                                      |
-| **Periodic metrics reporting + shutdown hook**  | `kpipe-consumer`   | —                                                                        | `Builder.withMetricsReporters(...) / withMetricsInterval(...) / withShutdownHook(true)`              | Folded into `KPipeConsumer.Builder` in 1.13. Reporter thread runs while consumer is alive; daemon thread, doesn't keep the JVM up.                                                    |
-| **Health endpoint**                         | `kpipe-consumer`       | —                                                                        | `HttpHealthServer.fromEnv(...)`                                                                      | Run alongside `Handle` in the host process.                                                                                                                                           |
-| **In-flight drain**                         | `kpipe-consumer`       | `Handle.shutdownGracefully(Duration)`                                    | `KPipeConsumer.waitForInFlightDrain(Duration) / shutdownGracefully(Duration)`                        | Replaces the deleted `MessageTracker` class. Uses the live in-flight counter (includes buffered batch records), not metric-derived.                                                  |
-| **Custom `MessageProcessorRegistry`**       | `kpipe-core`           | —                                                                        | `new MessageProcessorRegistry(...)` + manual wiring                                                  | Pre-shared pipelines across consumers, multi-format orchestrators.                                                                                                                    |
+| Capability                                     | Source module                                           | Facade path                                                              | Explicit-API path                                                                                    | Notes                                                                                                                                                                                 |
+| ---------------------------------------------- | ------------------------------------------------------- | ------------------------------------------------------------------------ | ---------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Format selection                               | `kpipe-format-*`                                        | `KPipe.json/avro/protobuf/bytes/custom(...)`                             | `new MessageProcessorRegistry(format)`                                                               | Custom format: pass any `MessageFormat<T>` to `KPipe.custom`.                                                                                                                         |
+| Topic subscription (homogeneous)               | `kpipe-consumer`                                        | `KPipe.X(topic, props)`                                                  | `Builder.withTopic(s) / withTopics(...)`                                                             | One topic-set, one shared pipeline.                                                                                                                                                   |
+| Topic subscription (heterogeneous)             | `kpipe-consumer`                                        | `KPipe.multi(props).json(...).avro(...)...start()`                       | `Builder.withPipelines(Map<String, MessagePipeline<?>>)`                                             | Per-topic dispatch (§15).                                                                                                                                                             |
+| Operator chain (`pipe/filter/peek/when`)       | `kpipe-core`                                            | `Stream.pipe / filter / peek / when`                                     | `MessageProcessorRegistry.pipeline(format).add(...)`                                                 | Identical operator semantics.                                                                                                                                                         |
+| Custom terminal sink                           | `kpipe-core`                                            | `Stream.toCustom(MessageSink<T>)`                                        | `registry.registerSink(key, sink)`                                                                   | Any `MessageSink<T>`; facade also offers `.toConsole()`.                                                                                                                              |
+| Multi-sink fanout                              | `kpipe-core`                                            | `Stream.toMulti(sinks...)`                                               | `new CompositeMessageSink<>(...)`                                                                    | Best-effort delivery; per-sink errors logged + suppressed.                                                                                                                            |
+| Batch sink (size + age flush)                  | `kpipe-core`                                            | `Stream.toBatch(BatchSink<T>, BatchPolicy)`                              | `Builder.withBatchPipeline(topic, pipeline, sink, policy)` (multi-call for heterogeneous batch)      | `BatchSink<T>` returns `BatchResult` for per-record DLQ; `BatchSink.ofVoid(consumer)` wraps void-style sinks (whole-batch DLQ on throw). Both sequential and parallel modes. See §18. |
+| Batch sink (multi-topic via `MultiBuilder`)    | `kpipe-api`                                             | `KPipe.multi(props).json(topic, s -> s.toBatch(sink, policy))...start()` | `Builder.withBatchPipeline(...)` × N                                                                 | One consumer-group, mixed batch + non-batch routes.                                                                                                                                   |
+| Skip wire-format prefix                        | `kpipe-core`                                            | `Stream.skipBytes(int)`                                                  | `TypedPipelineBuilder.skipBytes(int)`                                                                | Confluent envelope: 5 (Avro) / 6 (Proto single-msg).                                                                                                                                  |
+| Confluent SR per-record auto-lookup            | `kpipe-format-avro` + `kpipe-schema-registry-confluent` | `Stream.withSchemaRegistry(SchemaResolver)`                              | `AvroFormat.withRegistry(SchemaResolver)`                                                            | Reads wire envelope, caches schemas by ID (immutable in SR; no TTL). Avro-only — Protobuf needs runtime `.proto` compilation. See §19.                                                |
+| Pipeline outcome counters (OTel)               | `kpipe-metrics-otel`                                    | `Stream.peekResult(PipelineMetricsObserver)`                             | hand a `Consumer<Result<T>>` to `peekResult`                                                         | Emits `kpipe.pipeline.passed/filtered/failed` counters. Observer-only — doesn't suppress or reroute (see §11 observer-wrap layer).                                                    |
+| Retry policy                                   | `kpipe-consumer`                                        | `Stream.withRetry(int, Duration)`                                        | `Builder.withRetry(int, Duration)`                                                                   |                                                                                                                                                                                       |
+| Backpressure (default watermarks)              | `kpipe-consumer`                                        | `Stream.withBackpressure()`                                              | `Builder.withBackpressure(BackpressureController)`                                                   | Defaults: pause 10k, resume 7k.                                                                                                                                                       |
+| Backpressure (custom watermarks)               | `kpipe-consumer`                                        | `Stream.withBackpressure(high, low)`                                     | `Builder.withBackpressure(BackpressureController)`                                                   | High/low strategy auto-derived from `sequentialProcessing`.                                                                                                                           |
+| Sequential processing                          | `kpipe-consumer`                                        | `Stream.withSequentialProcessing(boolean)`                               | `Builder.withSequentialProcessing(boolean)`                                                          | Switches backpressure to lag-based (§5).                                                                                                                                              |
+| OTel/custom metrics                            | `kpipe-metrics(-otel)`                                  | `Stream.withMetrics(ConsumerMetrics)` / `MultiBuilder.withMetrics(...)`  | `Builder.withMetrics(ConsumerMetrics)`                                                               | Single-format and multi-topic both supported.                                                                                                                                         |
+| Custom error handler                           | `kpipe-consumer`                                        | `Stream.withErrorHandler(Consumer<ProcessingError<byte[]>>)`             | `Builder.withErrorHandler(ErrorHandler<K>)`                                                          | Default logs at WARNING (§11).                                                                                                                                                        |
+| Dead-letter topic                              | `kpipe-consumer`                                        | `Stream.withDeadLetterTopic(String)`                                     | `Builder.withDeadLetterTopic(String)` / `withDeadLetterBundle(...)`                                  | Bundle form pairs DLQ + producer for advanced wiring.                                                                                                                                 |
+| Poll timeout                                   | `kpipe-consumer`                                        | `Stream.withPollTimeout(Duration)`                                       | `Builder.withPollTimeout(Duration)`                                                                  | Default 100ms.                                                                                                                                                                        |
+| Lifecycle handle                               | `kpipe-api`                                             | `Handle.isHealthy / metrics / awaitShutdown / close`                     | `KPipeConsumer.start / awaitShutdown / shutdownGracefully / waitForInFlightDrain`                    | `Handle` is `AutoCloseable` (5s graceful default). Since 1.13: consumer hosts the lifecycle directly — no separate `KPipeRunner`.                                                     |
+| **Custom `OffsetManager`**                     | `kpipe-consumer`                                        | — (escape hatch only)                                                    | `Builder.withOffsetManager(...)` / `withOffsetManager(Provider)`                                     | E.g. Postgres/Redis-backed manager.                                                                                                                                                   |
+| **Custom Kafka `Consumer` factory**            | `kpipe-consumer`                                        | —                                                                        | `Builder.withConsumerProvider(Supplier<Consumer<K,byte[]>>)`                                         | Test seam / SSL configurators.                                                                                                                                                        |
+| **Custom DLQ `KafkaProducer`**                 | `kpipe-producer`                                        | —                                                                        | `Builder.withKafkaProducer(...)` / `withDeadLetterBundle(...)`                                       | Override default producer for the DLQ.                                                                                                                                                |
+| **Rebalance listener**                         | `kpipe-consumer`                                        | —                                                                        | `Builder.withRebalanceListener(ConsumerRebalanceListener)`                                           | External offset commit hooks, log routing.                                                                                                                                            |
+| **Custom command queue**                       | `kpipe-consumer`                                        | —                                                                        | `Builder.withCommandQueue(Queue<ConsumerCommand>)`                                                   | Test seam (rarely needed).                                                                                                                                                            |
+| **Thread/executor termination**                | `kpipe-consumer`                                        | —                                                                        | `Builder.withThreadTerminationTimeout / withExecutorTerminationTimeout / withWaitForMessagesTimeout` | Shutdown tuning.                                                                                                                                                                      |
+| **Periodic metrics reporting + shutdown hook** | `kpipe-consumer`                                        | —                                                                        | `Builder.withMetricsReporters(...) / withMetricsInterval(...) / withShutdownHook(true)`              | Folded into `KPipeConsumer.Builder` in 1.13. Reporter thread is daemon, doesn't keep the JVM up.                                                                                      |
+| **Health endpoint**                            | `kpipe-consumer`                                        | —                                                                        | `HttpHealthServer.fromEnv(...)`                                                                      | Run alongside `Handle` in the host process.                                                                                                                                           |
+| **In-flight drain**                            | `kpipe-consumer`                                        | `Handle.shutdownGracefully(Duration)`                                    | `KPipeConsumer.waitForInFlightDrain(Duration) / shutdownGracefully(Duration)`                        | Replaces the deleted `MessageTracker` class. Uses the live in-flight counter (includes buffered batch records), not metric-derived.                                                   |
+| **Custom `MessageProcessorRegistry`**          | `kpipe-core`                                            | —                                                                        | `new MessageProcessorRegistry(...)` + manual wiring                                                  | Pre-shared pipelines across consumers, multi-format orchestrators.                                                                                                                    |
 
-**Reading the table:** rows in **bold** are deliberately escape-hatch-only. The 80%-path features (everything not in
-bold) are discoverable via the facade's IDE auto-complete after the first `.`. If a user reaches for an explicit-API
-escape hatch, they're either operating an advanced topology or building a backend that should live in its own module
-(e.g. a Postgres `OffsetManager`).
+## §18 Batch sink architecture (1.12.0)
 
-### 18. Batch Sink Architecture (1.12.0)
+- **One `BatchSink<T> extends Function<List<T>, BatchResult>`.** Implementations that report per-record outcomes return
+  `BatchResult` directly; void-style consumers wrap with `BatchSink.ofVoid(consumer::accept)` — normal return →
+  `BatchResult.allSucceeded(size)`, throw → `BatchResult.allFailed(size, e)`. **No separate `PartialBatchSink`** — the
+  void shape is just a special case (collapsed in 1.12.0).
+- **Coverage contract enforced.** A `BatchResult` whose `succeededIndexes` ∪ `failedByIndex.keys()` doesn't cover every
+  `[0, batchSize)` is a contract violation. `BatchPipelineWrapper` flags missing indexes with a synthetic
+  `IllegalStateException` and routes them to the DLQ rather than silently marking them processed (§12). Out-of-range
+  indexes are logged at WARNING; a `null` `BatchResult` is treated as whole-batch failure.
+- **`BatchPipelineWrapper` owns buffer + lock + gauge + age-tick.** One wrapper per topic; `ReentrantLock` protects
+  `enqueue` / `tick` / `close` / `flushLocked` so parallel-mode workers can enqueue concurrently while a flush is
+  mid-flight. Constructed in the consumer ctor, started in `start()`, drained in `close()`.
+- **Backpressure participation in parallel mode.** `inFlightCount` is decremented as soon as `processRecord` returns —
+  for batch paths that's "the record was buffered," which would make buffered records invisible to the in-flight
+  watermark. The wrapper's `bufferedCount()` is added to `KPipeConsumer.totalInFlight()` to close that gap.
+- **Offset commits use `OffsetManager` directly, not the command queue.** The command queue serializes Kafka-consumer
+  calls (pause/resume/commitSync) on the consumer thread; `OffsetManager.markOffsetProcessed` is already thread-safe.
+  Bypassing the queue means shutdown drain works even after the consumer thread has exited.
+- **Whole-batch shutdown drain happens BEFORE `offsetManager.close()`.** Order in `close()`: pause + Close-command +
+  wait-for-in-flight + join consumer thread + shutdown executor → drain all batch wrappers → close offset manager →
+  close producer → state = CLOSED.
+- **Multi-topic batching is heterogeneous-only via `MultiBuilder`.** A consumer can host any mix of regular and batch
+  routes, but a single topic can only appear in one or the other — the disjoint-set check fires in `Builder.build()`.
+- **Bench harness** lives in `benchmarks/`. `BatchSinkLatencyBenchmark` drives the public facade through `MockConsumer`
+  so `BatchPipelineWrapper` stays package-private.
 
-- **One sink interface, two usage shapes.** `BatchSink<T> extends Function<List<T>, BatchResult>` is
-  the single batch terminal. Implementations that report per-record outcomes return `BatchResult`
-  directly; void-style consumers (transactional commits, fire-and-forget HTTP POSTs) wrap with
-  `BatchSink.ofVoid(consumer::accept)` — `consumer.accept` returning normally maps to
-  `BatchResult.allSucceeded(size)`, throwing maps to `BatchResult.allFailed(size, e)`. There is
-  **no separate `PartialBatchSink` interface** — that was collapsed in 1.12.0 because the void
-  shape is just a special case of the partial one (and the duplication cost two interfaces, two
-  facade records, two builder methods, and a nullable-mutual-exclusion invariant in `BatchSpec`).
-- **Coverage contract is enforced.** A `BatchResult` whose `succeededIndexes` ∪
-  `failedByIndex.keys()` does not cover every position `[0, batchSize)` is a contract violation.
-  `BatchPipelineWrapper` flags missing indexes with a synthetic `IllegalStateException` and
-  routes them to the DLQ rather than silently marking them processed (§12 "no silent failures").
-  Out-of-range indexes are logged at WARNING; a `null` `BatchResult` is treated as whole-batch
-  failure with a clear log line.
-- **Buffering lives in `BatchPipelineWrapper`** — one wrapper per topic, owns its own buffer +
-  `ReentrantLock` + `bufferedCount` gauge + age-tick `ScheduledFuture`. The lock protects
-  `enqueue` / `tick` / `close` / `flushLocked` so parallel-mode workers can `enqueue` concurrently
-  while a flush is mid-flight. Constructed once per `BatchSpec` in the consumer constructor;
-  started in `KPipeConsumer.start()` (registers the tick); drained in `close()` (one final flush
-  before the offset manager closes).
-- **Backpressure participation in parallel mode.** `inFlightCount` is decremented the moment
-  `processRecord` returns — for a batch path, that's "the record was buffered," which would make
-  buffered records invisible to the in-flight watermark. The wrapper's `bufferedCount()` is
-  added to `KPipeConsumer.totalInFlight()` to close that gap. `enqueue` increments it before
-  releasing the lock; `flushLocked` decrements it in `finally` by the snapshot size so the gauge
-  stays correct even if the user sink throws.
-- **Offset commits use the `OffsetManager` directly, not the command queue.** The command queue
-  exists to serialize Kafka-consumer calls (pause/resume/commitSync) on the consumer thread;
-  `OffsetManager.markOffsetProcessed` is already thread-safe (`ConcurrentHashMap` +
-  `ConcurrentSkipListSet`). Bypassing the queue from the wrapper's flush callback means the
-  shutdown drain works even after the consumer thread has exited — the alternative would have
-  the queue accumulating commands that never get processed.
-- **Whole-batch shutdown drain happens BEFORE `offsetManager.close()`.** Order in
-  `KPipeConsumer.close()`: pause + Close-command + wait-for-in-flight + join consumer thread +
-  shutdown executor → drain all batch wrappers → close offset manager → close producer → state =
-  CLOSED. The drain runs while the offset manager is still alive so the freshly marked offsets
-  are part of the final commit.
-- **Sequential vs parallel choice is on the user.** Default is parallel (matches the rest of the
-  consumer); `Stream.withSequentialProcessing(true)` switches to per-partition ordering. Batch
-  works in both modes — sequential is simpler reasoning but loses Loom's free parallelism;
-  parallel needs the `bufferedCount` machinery above.
-- **Multi-topic batching is heterogeneous-only via `MultiBuilder`.** A consumer may host any mix
-  of regular pipelines (`withPipeline` / `withPipelines`) and batch routes (`withBatchPipeline`
-  multi-call), but a single topic can only appear in one or the other — the disjoint-set check
-  fires in `Builder.build()`. The facade composes naturally: each `KPipe.multi(...).json(topic,
-  s -> s.toBatch(...))` route is a single-topic `DefaultBatchSink` that the multi-builder
-  collects and wires through `withBatchPipeline` at start time.
-- **Bench harness** lives in the existing `benchmarks/` module (NOT a new `lib/kpipe-bench`
-  module). `BatchSinkLatencyBenchmark` parameterises over `batchSize × sinkLatencyMicros` and
-  drives the public facade through `MockConsumer` so `BatchPipelineWrapper` stays
-  package-private.
+## §19 Confluent SR auto-lookup (1.14.0)
+
+**Two modes, one format class.** `AvroFormat` now operates in either static mode (`new AvroFormat(schema)` — single
+schema for the lifetime of the codec) or registry mode (`AvroFormat.withRegistry(SchemaResolver)` — per-record envelope
+read + schema lookup). The mode is decided at construction and never changes. Registry mode rejects `serialize` with
+`UnsupportedOperationException` — KPipe is consumer-first; if you need writer-side SR, construct the format in static
+mode with the writer schema you want.
+
+**Why per-record lookup matters even with FORWARD-compatible evolution.** A static-fetch-at-startup codec reads the
+schema once and treats it as both writer and reader. When the producer rolls v2, v2 bytes hit the consumer and the
+static reader decodes them against v1 — silently corrupting the output (extra v2 fields read as part of the next field,
+or v1 fields offset wrong if a field was removed). FORWARD compatibility at the SR level allows non-append evolution
+(field removal with defaults, type promotion, union reordering) which the static path can't decode safely. Per-record
+auto-lookup uses the actual writer schema for each record, then projects to the reader schema via
+`GenericDatumReader(writerSchema, readerSchema)` — Avro's schema-resolution rules handle the evolution.
+
+**Cache design.** `CachedSchemaResolver` in `kpipe-schema-registry-confluent` wraps any `SchemaResolver` with a
+`ConcurrentHashMap<Integer, String>` cache. No TTL, no LRU eviction — Confluent SR schema IDs are immutable, so
+cache-by-ID is trivially correct and cardinality is naturally bounded (typically tens of distinct schemas across the
+lifetime of a topic). `computeIfAbsent` atomicizes load+store so concurrent misses on the same ID collapse to one HTTP
+call. The format itself caches _parsed_ `Schema` instances by ID on top of the resolver — two-level cache, both correct
+because IDs never reassign.
+
+**No `skipBytes(5)` when registry-backed.** The format reads the 5-byte envelope itself. Combining
+`.withSchemaRegistry(...)` with `.skipBytes(5)` would strip the envelope before the format sees it, leaving the schema
+ID unreadable. Users who set both get a decode error; documented in `Stream.skipBytes` Javadoc.
+
+**Protobuf is deferred.** Confluent Protobuf SR returns `.proto` source text (not a binary descriptor), so runtime
+auto-lookup needs `.proto` compilation — out of scope for 1.14. The static `new ProtobufFormat(descriptor)` +
+`.skipBytes(6)` path remains for the single-top-level-message case.
+
+**Generalizable rule:** when SR returns by-ID, cache forever in-process — the immutability of the key removes every
+cache-coherence concern that would otherwise need TTLs or invalidation protocols.

--- a/.claude/PLAN.md
+++ b/.claude/PLAN.md
@@ -1,19 +1,26 @@
 # KPipe — Roadmap & State of the Library
 
-**Last updated:** 2026-05-16
-**Current released line:** 1.12.0 (Maven Central) — batch sinks, Confluent SR, W3C tracing, circuit breaker, JUnit 6,
-`enableMetrics` removal
-**Queued for release:** 1.13.0 on `main` — three breaking changes (`Result<T>` sealed type, Avro/Protobuf codec /
-catalog split, `ConsumerHealthController` facade collapsing `PauseCoordinator` + `CircuitBreakerStats`) plus Codecov
-test-results upload and CI/release wiring for `kpipe-schema-registry-confluent` + `kpipe-tracing-otel`.
-**Active branch:** main (clean)
+- **Last updated:** 2026-05-19
+- **Current released line:** 1.13.0 (Maven Central) — `Result<T>` sealed pipeline outcomes, Avro/Protobuf codec /
+  catalog split, `ConsumerHealthController` facade unifying pause / backpressure / circuit-breaker, Codecov test-results
+  upload, CI/release wiring for `kpipe-schema-registry-confluent` + `kpipe-tracing-otel`.
+- **Next line (1.14, in flight):** registry rename (`registerOperator` / `registerSink`, `withOperatorErrorHandling` /
+  `withSinkErrorHandling`); `PipelineDiagnostics` with Confluent magic-byte hint; `Stream.onFiltered` / `onFailed` /
+  `peekResult` observers; `docs/escape-hatches.md` page; **Confluent SR per-record auto-lookup**
+  (`AvroFormat.withRegistry(...)` + `CachedSchemaResolver` + `Stream.withSchemaRegistry(...)`);
+  **`PipelineMetricsObserver`** in `kpipe-metrics-otel` with optional SR cache-counter binding; README rewrite leading
+  with multi-topic + DLQ.
+- **Active branch:** main (clean)
+- **Recent infra work (not a P-item but worth recording):** competitive bench harness — 4 runtimes (KPipe, Confluent PC,
+  Reactor Kafka 1.3.25, Raw `KafkaConsumer` + VT), Testcontainers-backed Kafka 4.2.0, `workMicros` parameterised
+  workload, JMH JSON + SVG + blog post published.
 
 ---
 
 ## Public API self-assessment (current)
 
 | Dimension                              | Score       |
-|----------------------------------------|-------------|
+| -------------------------------------- | ----------- |
 | Common-path ergonomics                 | 9/10        |
 | Customization / escape hatches         | 9/10        |
 | Discovery (does the API teach itself?) | 8.5/10      |
@@ -25,41 +32,79 @@ test-results upload and CI/release wiring for `kpipe-schema-registry-confluent` 
 | Aggregate                              | **~8.7/10** |
 
 API quality is solid; the 1.13 cycle closed three breaking-change items that had been deferred to a future major
-(Result<T>, INSTANCE singleton removal, pause/CB/backpressure consolidation) and brought README + Javadoc back in
-sync with the 1.12 + 1.13 surface. The remaining gap is **productivity tooling for adopters** (`kpipe-test`) — the
-backlog now leads with that.
+(Result<T>, INSTANCE singleton removal, pause/CB/backpressure consolidation) and brought README + Javadoc back in sync
+with the 1.12 + 1.13 surface. The remaining gap is **productivity tooling for adopters** (`kpipe-test`) — the backlog
+now leads with that.
 
 ---
 
 ## Prioritized backlog
 
-| # | Priority                   | Item                                                                                                                                                                                                                                                                                                | Type     | Effort    |
-|---|----------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------|-----------|
-| 1 | **P2 — Productivity**      | Testing primitives (`kpipe-test`) — `TestStream<T>` analogue of `TopologyTestDriver`, no Testcontainers required                                                                                                                                                                                    | Feature  | ~3–4 days |
-| 2 | **P3 — User-visible**      | `AppConfig` slimdown / split — example infra; decide whether to split or move into `examples/`                                                                                                                                                                                                      | Refactor | ~1 hr     |
-| 3 | **P3 — User-visible**      | `HttpHealthServer` placement — lib contract or sample → `examples/`?                                                                                                                                                                                                                                | Refactor | ~30 min   |
-| 4 | **P3 — User-visible**      | Residual build/test config cleanup (consumer parallelism, fork tuning)                                                                                                                                                                                                                              | Refactor | ~30 min   |
-| 5 | **P3 — Audience**          | Spring Boot starter — opt-in module, `@KPipeListener`, auto-wires from `application.yml`. **Only build if a Spring-shop user asks.**                                                                                                                                                                | Feature  | ~1 week   |
-| 6 | ~~**P3 — User-visible**~~  | ~~`Format.INSTANCE` hardening — JVM-global mutable singleton~~ — shipped in 1.13.0. `AvroFormat` / `ProtobufFormat` are now stateless codecs constructed with `new AvroFormat(schema)` / `new ProtobufFormat(descriptor)`; keyed lookup moves to `AvroSchemaCatalog` / `ProtobufDescriptorCatalog`. | Breaking | shipped   |
-| 7 | ~~**P5 — 2.0 candidate**~~ | ~~`MessageTracker` collapse — add `KPipeConsumer.waitForInFlightDrain(Duration)`~~ — shipped in 1.12.0; `MessageTracker` was deleted, the public method lives on `KPipeConsumer`. (Already marked in §17 / capability table.)                                                                       | Breaking | shipped   |
-| 8 | ~~**P5 — 2.0 candidate**~~ | ~~`Result<T>` sealed type for pipeline outcomes~~ — shipped in 1.13.0. `MessagePipeline.process()` returns `Result<T>` with `Passed \| Filtered \| Failed`; byte-level entry points (`apply` / `processToSink` / `processToValue`) preserve their pre-1.13 contracts by unwrapping internally.      | Breaking | shipped   |
-| 9 | **P5 — Speculative**       | Format serialization caches re-wire — only with JMH evidence of allocation/GC pressure                                                                                                                                                                                                              | Perf     | ~1–2 days |
+| #   | Priority              | Item                                                                                                                                 | Type     | Effort    |
+| --- | --------------------- | ------------------------------------------------------------------------------------------------------------------------------------ | -------- | --------- |
+| 1   | **P2 — Productivity** | Testing primitives (`kpipe-test`) — `TestStream<T>` analogue of `TopologyTestDriver`, no Testcontainers required                     | Feature  | ~3–4 days |
+| 2   | **P3 — User-visible** | `AppConfig` slimdown / split — example infra; decide whether to split or move into `examples/`                                       | Refactor | ~1 hr     |
+| 3   | **P3 — User-visible** | `HttpHealthServer` placement — lib contract or sample → `examples/`?                                                                 | Refactor | ~30 min   |
+| 4   | **P3 — User-visible** | Residual build/test config cleanup (consumer parallelism, fork tuning)                                                               | Refactor | ~30 min   |
+| 5   | **P3 — Audience**     | Spring Boot starter — opt-in module, `@KPipeListener`, auto-wires from `application.yml`. **Only build if a Spring-shop user asks.** | Feature  | ~1 week   |
+| 6   | **P5 — Speculative**  | Format serialization caches re-wire — only with JMH evidence of allocation/GC pressure                                               | Perf     | ~1–2 days |
+
+### Developer-ergonomics — 1.14 in flight (2026-05-19)
+
+The "top 5 ergonomics improvements" brainstorm bundled four items into a single 1.14 PR. The fifth (`kpipe-test`) is the
+same as backlog item #1 and stays on the priority table.
+
+**Shipped in the 1.14 PR (single squash):**
+
+1. **`MessageProcessorRegistry` rename.** `register` → `registerOperator` / `registerSink`; `withErrorHandling` →
+   `withOperatorErrorHandling` / `withSinkErrorHandling`. Per §16, deleted the old names in the same PR. Kills the
+   overload-ambiguity cast footgun on `x -> x`.
+2. **`PipelineDiagnostics` magic-byte hint.** On a deserialization failure, hex-dumps the leading bytes and — when
+   `skipBytes(...)` wasn't set and the payload starts with `0x00` — suggests `skipBytes(5)` for Avro / `skipBytes(6)`
+   for Proto. Closes the §12 Grafana-burn loop with a message a human can act on.
+3. **`Stream` Result observers.** `onFiltered(Runnable)`, `onFailed(Consumer<Throwable>)`,
+   `peekResult(Consumer<Result<T>>)` on the fluent facade. Pure side-effects; do not suppress or reroute. Surfaces §12
+   outcomes without making users drop to the explicit API.
+4. **`docs/escape-hatches.md`.** Ported the §17 capability table to a user-facing doc and linked it from the README's
+   "Two API surfaces" block.
+5. **Confluent SR per-record auto-lookup (Avro).** `AvroFormat.withRegistry(SchemaResolver)` reads the wire envelope on
+   every record, looks up the writer schema by ID through a `CachedSchemaResolver` (`ConcurrentHashMap`, no TTL — SR IDs
+   are immutable), and decodes against it. Fluent shorthand `Stream.withSchemaRegistry(resolver)`. Closes the
+   schema-evolution-correctness hole that the static `lookupBySubjectVersion("latest")` path left open. Doctrine in §19.
+6. **`PipelineMetricsObserver` in `kpipe-metrics-otel`.** Per-Result-variant counters
+   (`kpipe.pipeline.passed/filtered/failed`) emitted via OTel; optional `bindSchemaRegistryCache(hits, misses, size)`
+   binds the SR cache counters into the same observer. Hand to `Stream.peekResult(observer)`.
+7. **README rewrite.** Promotes DLQ + retry into a "Production wiring — ten lines" snippet right after the §2 hello.
+   Adds Observability + updated Confluent SR sections. Closes the "docs don't keep up with the surface area" gap flagged
+   in the outside critique.
+
+**Deliberately deferred (not in 1.14):**
+
+- `Stream.strict()` / `.lenient()` toggle for malformed-record routing. Conflates two API decisions; revisit standalone.
+- `KPipe.from(props).json().topic(...)` short-form. Current `KPipe.json("topic", props)` is already one call.
+- Spring Boot starter (still P3, gated on real user ask — see backlog #5).
+- **Protobuf SR auto-lookup.** Needs runtime `.proto` text compilation (protoc-jar) — out of scope; documented in §19
+  and on `Stream.withSchemaRegistry` Javadoc.
+- `just new-format <name>` scaffold — cheap unlock, but slot it in standalone outside the 1.14 bundle.
+
+**Honorable mentions (still candidates, not committed):** fold `HttpHealthServer.fromEnv(...)` into `Handle` (overlaps
+with backlog #3).
 
 **Why this ordering:**
 
-- **kpipe-test first.** Docs caught up in 1.13 (README + Javadoc audit landed alongside the breaking changes);
-  the next leverage point is letting adopters write unit tests without Testcontainers. Productivity multiplier for
-  every existing and future user, and CI-environment-friendly for shops without Docker.
+- **kpipe-test first.** Docs caught up in 1.13 (README + Javadoc audit landed alongside the breaking changes); the next
+  leverage point is letting adopters write unit tests without Testcontainers. Productivity multiplier for every existing
+  and future user, and CI-environment-friendly for shops without Docker.
 - **P3 refactors next.** Cheap (~2 hours total) but worth doing before they accumulate.
-- **Spring starter held until asked.** ~1 week of work for an audience that already has Spring
-  Kafka. Build it when a Spring-shop user actively asks, not speculatively.
+- **Spring starter held until asked.** ~1 week of work for an audience that already has Spring Kafka. Build it when a
+  Spring-shop user actively asks, not speculatively.
 
 ---
 
 ## P2 — kpipe-test module detail
 
-**Today:** writing a unit test for a KPipe pipeline means either Testcontainers (10s+ per test,
-Docker-dependent) or hand-rolling a `MockConsumer` harness. The JMH bench has the second; users don't.
+**Today:** writing a unit test for a KPipe pipeline means either Testcontainers (10s+ per test, Docker-dependent) or
+hand-rolling a `MockConsumer` harness. The JMH bench has the second; users don't.
 
 **Target ergonomics:**
 
@@ -78,20 +123,19 @@ assertEquals(List.of(...), captured.captured());
 
 **Surface decisions (open):**
 
-1. **Drive model.** Option (a) Kafka-free pipeline-direct invocation; option (b) MockConsumer-backed
-   `KPipeConsumer` on a synchronous executor. Recommendation: **(b)** — exercises real code paths,
-   stays in sync as the consumer evolves. Cost is ~5–20ms/test vs ~1ms.
+1. **Drive model.** Option (a) Kafka-free pipeline-direct invocation; option (b) MockConsumer-backed `KPipeConsumer` on
+   a synchronous executor. Recommendation: **(b)** — exercises real code paths, stays in sync as the consumer evolves.
+   Cost is ~5–20ms/test vs ~1ms.
 2. **JUnit integration.** v1 plain API only; `@KPipeTest` extension is a follow-up.
-3. **Assertion API.** Just `captured()` returning `List<T>` — let users use AssertJ / Hamcrest /
-   plain `assertEquals`. Don't invent a DSL.
+3. **Assertion API.** Just `captured()` returning `List<T>` — let users use AssertJ / Hamcrest / plain `assertEquals`.
+   Don't invent a DSL.
 4. **Multi-topic.** Single-topic v1, multi-topic follow-up.
-5. **Batch helpers.** Size-flush + shutdown-flush v1; virtual-clock age-flush is a follow-up
-   (interaction with `ScheduledFuture` needs care).
-6. **Module type.** Full `compile` artifact (not `test`-classifier) — it's a runtime tool for users'
-   test suites.
+5. **Batch helpers.** Size-flush + shutdown-flush v1; virtual-clock age-flush is a follow-up (interaction with
+   `ScheduledFuture` needs care).
+6. **Module type.** Full `compile` artifact (not `test`-classifier) — it's a runtime tool for users' test suites.
 
-**Why P2 productivity:** every existing and future user benefits. Cuts test feedback loops 100×.
-Removes the Docker-required friction for CI environments without Docker.
+**Why P2 productivity:** every existing and future user benefits. Cuts test feedback loops 100×. Removes the
+Docker-required friction for CI environments without Docker.
 
 ---
 
@@ -109,7 +153,7 @@ kpipe-bom                                                    (BOM — pins versi
 ```
 
 | Module                            | What's in it                                                                                                                                                                                                 |
-|-----------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| --------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | `kpipe-bom`                       | Maven BOM — pins all `kpipe-*` artifacts to matching versions                                                                                                                                                |
 | `kpipe-core`                      | Format-agnostic pipeline machinery: `MessageProcessorRegistry`, `MessageFormat`, `MessageSink`, `Operators`, `MessagePipeline` (returns `Result<T>` — `Passed \| Filtered \| Failed`), `SchemaResolver` SPI  |
 | `kpipe-metrics`                   | Metrics interfaces (`ConsumerMetrics`, `ProducerMetrics`) + log-based reporters; **no OTel API** on classpath                                                                                                |
@@ -126,7 +170,7 @@ kpipe-bom                                                    (BOM — pins versi
 **Still planned:**
 
 | Module                      | What's in it                                                                                           |
-|-----------------------------|--------------------------------------------------------------------------------------------------------|
+| --------------------------- | ------------------------------------------------------------------------------------------------------ |
 | `kpipe-test`                | `TestStream<T>` for unit-testing pipelines without Testcontainers; `.send(record).flush()` ergonomics. |
 | `kpipe-spring-boot-starter` | Auto-wiring of `KPipeConsumer` from `application.yml`. Opt-in; no Spring on `kpipe-core`'s classpath.  |
 
@@ -140,8 +184,8 @@ Real example infra; likely belongs in `examples/` rather than crossing module bo
 
 ### `HttpHealthServer` placement
 
-Currently in `kpipe-consumer`. Decide: lib contract (document and own) or sample (move to
-`examples/`). ~30 minutes either way once the call is made.
+Currently in `kpipe-consumer`. Decide: lib contract (document and own) or sample (move to `examples/`). ~30 minutes
+either way once the call is made.
 
 ### Build/test config cleanup
 
@@ -149,13 +193,13 @@ Residual fork tuning, consumer parallelism settings. Cleanup pass; no functional
 
 ### Spring Boot starter
 
-Audience-multiplier feature. Auto-wire `KPipeConsumer` from `application.yml`, expose
-`@KPipeListener` or similar declarative entry point, hook health probes to Spring Boot Actuator.
-The starter is the opt-in; no Spring on `kpipe-core`'s classpath. ~1 week — non-trivial because
-Spring's lifecycle and config-binding semantics are their own learning curve.
+Audience-multiplier feature. Auto-wire `KPipeConsumer` from `application.yml`, expose `@KPipeListener` or similar
+declarative entry point, hook health probes to Spring Boot Actuator. The starter is the opt-in; no Spring on
+`kpipe-core`'s classpath. ~1 week — non-trivial because Spring's lifecycle and config-binding semantics are their own
+learning curve.
 
-**Why P3:** higher effort than the P2 items, audience overlap is real but not 100% (Spring Boot
-Kafka users already have Spring Kafka). Promote to P2 if a Spring-shop user explicitly asks.
+**Why P3:** higher effort than the P2 items, audience overlap is real but not 100% (Spring Boot Kafka users already have
+Spring Kafka). Promote to P2 if a Spring-shop user explicitly asks.
 
 ---
 
@@ -168,16 +212,15 @@ Only revisit when allocation rate or GC pressure shows up in profiling.
 To resurrect as a real optimization:
 
 1. Move the `inScopedCaches` boundary from per-format-call to per-poll-batch (consumer wraps the record loop).
-2. Have each format's serialize / deserialize read `OUTPUT_STREAM_CACHE.get()` (with `.reset()` for buffer reuse)
-   and pass the cached encoder / decoder to `EncoderFactory.binaryEncoder(out, prev)` for stateful reuse.
-3. Handle the multi-schema corner case carefully — `BinaryEncoder` and `Schema.Parser` carry state that doesn't
-   transfer cleanly across schemas. With multi-topic Phase 2 (per-topic dispatch, heterogeneous schemas) this
-   becomes a per-schema lookup, not a single ScopedValue.
+2. Have each format's serialize / deserialize read `OUTPUT_STREAM_CACHE.get()` (with `.reset()` for buffer reuse) and
+   pass the cached encoder / decoder to `EncoderFactory.binaryEncoder(out, prev)` for stateful reuse.
+3. Handle the multi-schema corner case carefully — `BinaryEncoder` and `Schema.Parser` carry state that doesn't transfer
+   cleanly across schemas. With multi-topic Phase 2 (per-topic dispatch, heterogeneous schemas) this becomes a
+   per-schema lookup, not a single ScopedValue.
 4. Land **only with JMH evidence** that the cache reuse exceeds `ScopedValue` lookup overhead.
 
-**Format-specific note:** Protobuf does not benefit — `Message` is immutable (must allocate per
-record), `CodedOutputStream` / `CodedInputStream` are thin wrappers. Scope any caching work to Avro
-and JSON only.
+**Format-specific note:** Protobuf does not benefit — `Message` is immutable (must allocate per record),
+`CodedOutputStream` / `CodedInputStream` are thin wrappers. Scope any caching work to Avro and JSON only.
 
 ---
 
@@ -207,15 +250,10 @@ Don't regress these in any future refactor:
 
 ## Open questions
 
-1. **`kpipe-test` test runner integration** — JUnit 5/6 first-class (`@KPipeTest` extension), or
-   plain `TestStream` and let users wire it themselves? Recommendation: plain v1, extension follow-up.
-2. **Tracing default-on or opt-in?** — `kpipe-tracing-otel` is opt-in by module choice. Should the
-   facade auto-enable trace propagation when the module is on the classpath, or stay explicit
+1. **`kpipe-test` test runner integration** — plain `TestStream` v1, `@KPipeTest` extension as follow-up.
+2. **Tracing default-on or opt-in?** — auto-enable when `kpipe-tracing-otel` is on the classpath, or stay explicit
    (`.withTracer(...)`)?
-3. **Confluent SR scope beyond v1** — TTL cache for `lookupById` (hot-path) and wire-envelope
-   auto-lookup in `AvroFormat` / `ProtobufFormat` decode — both still deferred. With the 1.13
-   codec/catalog split, wire-envelope auto-lookup now has a clean place to live (the catalog can
-   own a `SchemaResolver`-backed loader). Schedule for 1.14?
-4. **Spring starter audience confirmation** — has a Spring-shop user actually asked, or is this
-   speculative? Promote to P2 if real demand exists.
-5. **Are there 1.x users in production?** Affects whether 2.0 ships a compat shim package or hard-breaks.
+3. **Confluent SR scope beyond v1** — TTL cache for `lookupById` (hot-path) and wire-envelope auto-lookup in
+   `AvroFormat` / `ProtobufFormat` decode. With the 1.13 codec/catalog split, wire-envelope auto-lookup now has a clean
+   place to live (catalog owns a `SchemaResolver`-backed loader). Schedule for 1.14?
+4. **Spring starter demand check** — promote to P2 only on real user ask.

--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ What it does:
 - Composable `UnaryOperator<T>` pipelines that deserialize once and serialize once
 - At-least-once delivery via lowest-pending-offset commits, even with parallel processing
 - In-flight or lag-based backpressure with hysteresis
+- Dead-letter routing, retries, and a circuit breaker — one fluent setter each
+- Multi-topic dispatch (homogeneous or heterogeneous-format) through a single consumer / consumer-group
 - Minimal framework code on the hot path
 
 The target audience is anyone running Kafka consumers that transform, enrich, or route — and would rather not glue their
@@ -32,7 +34,9 @@ There are two public entry points; pick whichever matches the shape of your prob
 | **`KPipe` fluent facade** (`kpipe-api`)                | 5-line `KPipe.json("topic", props).pipe(...).toConsole().start()`. Returns a `Stream<T>` → `Sink<T>` → `Handle` chain. Immutable, IDE-discoverable.                                 | The common path — most users start here.                                       |
 | **Registry + Builder explicit API** (`kpipe-consumer`) | `MessageProcessorRegistry` + `KPipeConsumer.Builder`. Multi-step, supports custom registries, shared pipelines, custom offset managers, periodic metrics reporting via the builder. | Custom offset managers, multi-pipeline-per-consumer, advanced lifecycle hooks. |
 
-The facade is a thin layer on top of the explicit API, so dropping down when you outgrow it doesn't cost anything.
+The facade is a thin layer on top of the explicit API, so dropping down when you outgrow it doesn't cost anything. See
+[`docs/escape-hatches.md`](docs/escape-hatches.md) for the full capability map and worked examples of the explicit-only
+features (custom `OffsetManager`, rebalance listeners, pre-shared registries, etc.).
 
 ---
 
@@ -71,20 +75,20 @@ There's also a `kpipe-bom` so you only pin one version across modules — use it
 <details>
 <summary>Module catalog & other build tools</summary>
 
-| Module                            | What it gives you                                                                                                                                          |
-| --------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `kpipe-api`                       | High-level fluent entry point: `KPipe`, `Stream<T>`, `Sink<T>`, `Handle`                                                                                   |
-| `kpipe-bom`                       | Maven BOM — pins all `kpipe-*` artifacts to matching versions                                                                                              |
-| `kpipe-core`                      | Low-level building blocks: registries, `MessageFormat`, `MessageSink`, operators, `BatchSink`                                                              |
-| `kpipe-metrics`                   | Metrics interfaces (`ConsumerMetrics`, `ProducerMetrics`) + log-based reporters                                                                            |
-| `kpipe-metrics-otel`              | OpenTelemetry-backed implementation (opt-in)                                                                                                               |
-| `kpipe-tracing-otel`              | W3C trace context propagation through Kafka headers (opt-in)                                                                                               |
-| `kpipe-schema-registry-confluent` | Confluent Schema Registry client — `lookupById` + `lookupBySubjectVersion` (opt-in)                                                                        |
-| `kpipe-producer`                  | Kafka producer wrapper, `KafkaMessageSink`, `Tracer` SPI                                                                                                   |
+| Module                            | What it gives you                                                                                                                                           |
+| --------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `kpipe-api`                       | High-level fluent entry point: `KPipe`, `Stream<T>`, `Sink<T>`, `Handle`                                                                                    |
+| `kpipe-bom`                       | Maven BOM — pins all `kpipe-*` artifacts to matching versions                                                                                               |
+| `kpipe-core`                      | Low-level building blocks: registries, `MessageFormat`, `MessageSink`, operators, `BatchSink`                                                               |
+| `kpipe-metrics`                   | Metrics interfaces (`ConsumerMetrics`, `ProducerMetrics`) + log-based reporters                                                                             |
+| `kpipe-metrics-otel`              | OpenTelemetry-backed implementation (opt-in)                                                                                                                |
+| `kpipe-tracing-otel`              | W3C trace context propagation through Kafka headers (opt-in)                                                                                                |
+| `kpipe-schema-registry-confluent` | Confluent Schema Registry client — `lookupById` + `lookupBySubjectVersion` (opt-in)                                                                         |
+| `kpipe-producer`                  | Kafka producer wrapper, `KafkaMessageSink`, `Tracer` SPI                                                                                                    |
 | `kpipe-consumer`                  | `KPipeConsumer` (hosts lifecycle, metrics-reporter thread, shutdown hook), `BackpressureController`, `CircuitBreakerController`, `ConsumerHealthController` |
-| `kpipe-format-json`               | `JsonFormat`, `JsonConsoleSink`                                                                                                                            |
-| `kpipe-format-avro`               | `AvroFormat`, `AvroConsoleSink`                                                                                                                            |
-| `kpipe-format-protobuf`           | `ProtobufFormat`, `ProtobufConsoleSink`                                                                                                                    |
+| `kpipe-format-json`               | `JsonFormat`, `JsonConsoleSink`                                                                                                                             |
+| `kpipe-format-avro`               | `AvroFormat`, `AvroConsoleSink`                                                                                                                             |
+| `kpipe-format-protobuf`           | `ProtobufFormat`, `ProtobufConsoleSink`                                                                                                                     |
 
 **Gradle (Kotlin) with BOM**
 
@@ -155,6 +159,30 @@ KPipe.json("events", kafkaProps)
 
 A working JSON Kafka consumer that strips the `password` field, stamps a timestamp, and logs to console. Behind the
 scenes the chain assembles a `MessageProcessorRegistry` and a `KPipeConsumer` — you don't have to touch either of them.
+
+### 2b. Production wiring — ten lines
+
+The same shape with the operational stack turned on: retry, backpressure with default watermarks, a dead-letter topic,
+and a custom sink instead of the console. Everything below is one-liner toggle on top of the §2 chain.
+
+```java
+try (var handle = KPipe.json("orders", kafkaProps)
+    .pipe(enrich)
+    .filter(order -> order.total() > 0)
+    .withRetry(3, Duration.ofMillis(100))
+    .withBackpressure()                            // pause at 10k in-flight, resume at 7k
+    .withDeadLetterTopic("orders.dlq")             // bad records flow here after retries exhaust
+    .onFailed(cause -> log.warn("processing failed", cause))   // observer, not a handler — log only
+    .toCustom(WarehouseSink.create())
+    .start()) {
+  handle.awaitShutdown();
+}
+```
+
+`Handle` is `AutoCloseable` and `close()` calls `shutdownGracefully(Duration.ofSeconds(5))` by default. The DLQ wires a
+`KafkaProducer` from the same properties; provide your own via `.withDeadLetterBundle(...)` if you need a different
+configuration. See [`docs/escape-hatches.md`](docs/escape-hatches.md) for the full set of explicit-only options (custom
+`OffsetManager`, rebalance listeners, multi-topic heterogeneous dispatch).
 
 ### 3. The full fluent surface
 
@@ -386,8 +414,8 @@ KPipe runs on Java virtual threads (Project Loom) for concurrency.
 - Thread-per-record. Each message gets its own virtual thread, so I/O-bound enrichment scales without explicit pool
   sizing.
 - No `ThreadLocal` on the hot path. `ThreadLocal` doesn't compose with thread-per-record — every record would get a
-  fresh map, defeating any caching intent. If a future need for thread-local-like state turns up (tenant context,
-  span propagation), we'll reach for `ScopedValue`; the codebase currently has neither.
+  fresh map, defeating any caching intent. If a future need for thread-local-like state turns up (tenant context, span
+  propagation), we'll reach for `ScopedValue`; the codebase currently has neither.
 
 ### 4. At-least-once delivery via lowest pending offset
 
@@ -460,9 +488,9 @@ Error handling is layered:
   ```
 - Custom error handler: `.withErrorHandler(...)` to route failures somewhere other than a Kafka topic — an external DB,
   alerting system, whatever.
-- Per-processor and per-sink wrapping: `MessageProcessorRegistry.withErrorHandling()` and
-  `MessageProcessorRegistry.withErrorHandling()` (overloaded for both operators and sinks) swallow failures at the
-  boundary so one bad processor doesn't take down the pipeline.
+- Per-processor and per-sink wrapping: `MessageProcessorRegistry.withOperatorErrorHandling()` and
+  `MessageProcessorRegistry.withSinkErrorHandling()` swallow failures at the boundary so one bad processor doesn't take
+  down the pipeline.
 
 ### 8. Backpressure
 
@@ -648,13 +676,13 @@ import org.kpipe.registry.RegistryKey;
 final var registry = new MessageProcessorRegistry("myApp");
 
 final var stampKey = RegistryKey.json("addTimestamp");
-registry.register(stampKey, addField("processedAt", System.currentTimeMillis()));
+registry.registerOperator(stampKey, addField("processedAt", System.currentTimeMillis()));
 
 final var sanitizeKey = RegistryKey.json("sanitize");
-registry.register(sanitizeKey, removeFields("password", "ssn"));
+registry.registerOperator(sanitizeKey, removeFields("password", "ssn"));
 
 final var lowerEmailKey = RegistryKey.json("lowerEmail");
-registry.register(lowerEmailKey, transformField("email", v -> ((String) v).toLowerCase()));
+registry.registerOperator(lowerEmailKey, transformField("email", v -> ((String) v).toLowerCase()));
 
 // Single deserialization → many transformations → single serialization
 final var pipeline = registry.pipeline(JsonFormat.INSTANCE)
@@ -686,7 +714,7 @@ final var format = AvroFormat.of("""
 // Avro records are schema-bound: use inline lambdas with the native Avro API for value transforms.
 // `Operators.filter`, `tap`, `compose` etc. work for any payload type, including GenericRecord.
 final var lowerNameKey = AvroRegistryKey.of("lowerName");
-registry.register(lowerNameKey, record -> {
+registry.registerOperator(lowerNameKey, record -> {
   if (record.get("name") != null) record.put("name", record.get("name").toString().toLowerCase());
   return record;
 });
@@ -699,10 +727,12 @@ final var confluentPipeline = registry.pipeline(format).skipBytes(5).add(lowerNa
 
 #### Confluent Schema Registry
 
-For Confluent-style deployments where schemas live in a Schema Registry rather than on the classpath, the
-`kpipe-schema-registry-confluent` module ships an HTTP client that resolves schemas by ID or by subject-version. It
-exposes the `SchemaResolver` SPI from `kpipe-core` so future versions can wire wire-envelope auto-lookup directly into
-`AvroFormat` / `ProtobufFormat` — for now you fetch the schema at startup and construct an `AvroFormat` from it.
+For Confluent-style deployments where schemas live in a registry rather than on the classpath, the
+`kpipe-schema-registry-confluent` module ships an HTTP client and an in-process cache. Per-record auto-lookup is wired
+into `AvroFormat`: the format reads the wire envelope (1-byte magic + 4-byte schema ID) off each record, resolves the
+writer's schema, caches it by ID, and decodes the remaining bytes against it. This is the schema-evolution-correct path
+— every record decodes against its actual writer schema, so producer evolution doesn't silently corrupt consumer output
+the way a static-fetch-at-startup pattern would.
 
 Add the dependency:
 
@@ -710,31 +740,53 @@ Add the dependency:
 implementation("io.github.eschizoid:kpipe-schema-registry-confluent:1.12.0")
 ```
 
-Resolve a schema at startup:
+Wire the fluent facade with the SR-shorthand factory:
 
 ```java
 import java.time.Duration;
-import org.kpipe.format.avro.AvroFormat;
+import org.kpipe.KPipe;
+import org.kpipe.schemaregistry.confluent.CachedSchemaResolver;
 import org.kpipe.schemaregistry.confluent.ConfluentSchemaResolver;
 
-try (final var resolver = new ConfluentSchemaResolver("http://schema-registry:8081", Duration.ofSeconds(10))) {
-  // Fetch by subject-version (config-time) and build a format directly:
-  final String schemaJson = resolver.lookupBySubjectVersion("user-value", "latest");
-  final var format = AvroFormat.of(schemaJson);
-
-  // Fetch by ID (runtime, e.g. from a wire-envelope decode loop):
-  final String byId = resolver.lookupById(42);
+// One resolver for the process; CachedSchemaResolver caches by ID with no TTL (Confluent SR IDs
+// are immutable, so cache-by-ID is trivially correct).
+try (final var resolver = new CachedSchemaResolver(
+        new ConfluentSchemaResolver("http://schema-registry:8081", Duration.ofSeconds(10)));
+     final var handle = KPipe.avro("orders", kafkaProps, resolver)   // ← one-line SR consumer
+         .pipe(record -> enrich(record))
+         .toCustom(WarehouseSink.create())
+         .start()) {
+  handle.awaitShutdown();
 }
 ```
 
-The single-arg constructor `new ConfluentSchemaResolver(baseUrl)` defaults the request timeout to 10s; an internal
-`HttpClient` is built from the timeout. The module has no Jackson dependency (the SR envelope is unwrapped by a
-hand-rolled parser scoped to the response shape) and is opt-in: `kpipe-format-avro`'s built-in `http://` schema fetcher
-was removed in 1.12, calling it now throws with a migration message pointing here.
+The factory above is equivalent to `KPipe.avro(AvroFormat.withRegistry(resolver), "orders", props)`. The format reads
+the envelope per record. Do **not** combine `withSchemaRegistry(...)` with `skipBytes(5)` — the format already consumes
+the envelope. The static-mode path is still supported for shops with strict append-only evolution who fetch the schema
+once at startup:
 
-**v1 scope and what's deferred:** read-only lookups. No schema publishing (Confluent's own producer client handles
-that). No caching — every call is a fresh HTTP request; acceptable for startup-time `lookupBySubjectVersion`, you'll
-want an external cache before wiring `lookupById` into a hot path. No compatibility checks.
+```java
+try (final var resolver = new ConfluentSchemaResolver("http://schema-registry:8081")) {
+  final var schemaJson = resolver.lookupBySubjectVersion("orders-value", "latest");
+  final var format = AvroFormat.of(schemaJson);
+  // Pass `format` to KPipe.avro(topic, props, format) and pair with .skipBytes(5).
+}
+```
+
+The explicit `lookupById(int)` and `lookupBySubjectVersion(subject, version)` calls remain available on
+`ConfluentSchemaResolver` for users who want to manage their own caching or fetch a known schema at startup.
+
+**Cache semantics.** `CachedSchemaResolver` uses a `ConcurrentHashMap` with no TTL and no LRU eviction. Confluent SR
+schema IDs are immutable — ID 42 today means the same schema tomorrow — so cache-by-ID is trivially correct and cache
+cardinality is naturally bounded (typically tens of distinct schemas across the lifetime of a topic, even with active
+evolution). The first record carrying a new schema ID costs one HTTP round trip; every subsequent record with that ID is
+a hit. Hit / miss / size counters are exposed via the resolver's accessors and can be bound to OTel via
+`PipelineMetricsObserver.bindSchemaRegistryCache(...)` (see [Observability](#observability) below).
+
+**Scope.** Avro only for now. Protobuf SR auto-lookup needs runtime `.proto` text compilation and has not shipped — use
+`kpipe-format-protobuf` with a compiled descriptor and `skipBytes(6)` for the single-top-level-message case. No schema
+publishing (Confluent's own producer client handles that). No compatibility checks at the consumer — those run at
+registration time inside SR.
 
 ### Protobuf
 
@@ -752,14 +804,14 @@ final var format = new ProtobufFormat(CustomerProto.Customer.getDescriptor());
 final var registry = new MessageProcessorRegistry("myApp", format);
 
 final var clearEmailKey = ProtobufRegistryKey.of("clearEmail");
-registry.register(clearEmailKey, msg -> {
+registry.registerOperator(clearEmailKey, msg -> {
   final var emailField = msg.getDescriptorForType().findFieldByName("email");
   return msg.toBuilder().clearField(emailField).build();
 });
 
 // Register the protobuf console sink yourself (defaults are no longer auto-registered)
 final var protoLoggingKey = ProtobufRegistryKey.of("protobufLogging");
-registry.register(protoLoggingKey, new org.kpipe.format.protobuf.ProtobufConsoleSink<>());
+registry.registerSink(protoLoggingKey, new org.kpipe.format.protobuf.ProtobufConsoleSink<>());
 
 final var pipeline = registry
   .pipeline(format)
@@ -794,7 +846,7 @@ final var avroConsoleSink = new AvroConsoleSink<GenericRecord>(schema);
 final var protobufConsoleSink = new ProtobufConsoleSink<Message>();
 
 // Register and use via the pipeline builder
-registry.register(JsonFormat.JSON_LOGGING, jsonConsoleSink);
+registry.registerSink(JsonFormat.JSON_LOGGING, jsonConsoleSink);
 
 final var pipeline = registry
   .pipeline(JsonFormat.INSTANCE)
@@ -814,16 +866,16 @@ final MessageSink<Map<String, Object>> databaseSink = (processedMap) -> {
 ### Registering sinks
 
 `MessageProcessorRegistry` holds operators and sinks in two namespaces under the same key shape.
-`register(key, operator)` and `register(key, sink)` are overloads of one method; lookups use `getOperator(key)` and
+`registerOperator(key, op)` and `registerSink(key, sink)` are the entry points; lookups use `getOperator(key)` and
 `getSink(key)`. Per-namespace utilities (`getAllSinks`, `getSinkMetrics`, `unregisterSink`, `clearSinks`,
 `compositeSink`) keep the surfaces separate without forcing users through a sub-object.
 
 ```java
 final var registry = new MessageProcessorRegistry();
 
-// Register a sink — `register` is overloaded; Java picks the MessageSink variant
+// Register a sink under a typed key
 final var dbKey = RegistryKey.of("database", Map.class);
-registry.register(dbKey, databaseSink);
+registry.registerSink(dbKey, databaseSink);
 
 // Use it in a pipeline
 final var pipeline = registry.pipeline(JsonFormat.INSTANCE).add(RegistryKey.json("enrich")).toSink(dbKey).build();
@@ -833,10 +885,10 @@ final var pipeline = registry.pipeline(JsonFormat.INSTANCE).add(RegistryKey.json
 
 ```java
 // Wrap a sink or operator with error handling (suppresses exceptions, logs errors)
-final var safeSink = MessageProcessorRegistry.withErrorHandling(riskySink);
-final var safeOperator = MessageProcessorRegistry.withErrorHandling(riskyOperator);
+final var safeSink = MessageProcessorRegistry.withSinkErrorHandling(riskySink);
+final var safeOperator = MessageProcessorRegistry.withOperatorErrorHandling(riskyOperator);
 
-registry.register(RegistryKey.json("safeDatabase"), safeSink);
+registry.registerSink(RegistryKey.json("safeDatabase"), safeSink);
 ```
 
 ### Kafka producer sink
@@ -1223,7 +1275,7 @@ Return `null` from an operator to skip a record. KPipe stops processing it — n
 offset is still committed (the record is treated as intentionally filtered, not failed).
 
 ```java
-registry.register(RegistryKey.json("filter"), map -> {
+registry.registerOperator(RegistryKey.json("filter"), map -> {
   if ("internal".equals(map.get("type"))) return null; // Skip this message
   return map;
 });
@@ -1264,6 +1316,55 @@ guarantees per-partition ordering. Use that:
 - KPipe commits per-partition lowest-pending-offset, so as long as related events share a key, they land on one
   partition and KPipe processes them in order without skipping.
 - For strict per-partition serial processing (one record at a time), turn on `.withSequentialProcessing(true)`.
+
+---
+
+## Observability
+
+Two OTel pieces ship in `kpipe-metrics-otel`:
+
+- **`OtelConsumerMetrics`** — implements `ConsumerMetrics`. Wire on the consumer builder / `Stream.withMetrics(...)` and
+  get the standard `kpipe.consumer.*` counters and histograms (received, processed, errors, processing duration,
+  in-flight gauge, backpressure pauses, circuit-breaker state changes).
+- **`PipelineMetricsObserver`** — implements `Consumer<Result<?>>`. Hand to `Stream.peekResult(observer)` and every
+  `Passed` / `Filtered` / `Failed` outcome increments the matching `kpipe.pipeline.*` counter. This is how you make the
+  §12 "processed counter rises but sink stays at 0" condition visible at the metrics layer instead of having to scrape
+  logs.
+
+```java
+import io.opentelemetry.api.GlobalOpenTelemetry;
+import org.kpipe.metrics.otel.OtelConsumerMetrics;
+import org.kpipe.metrics.otel.PipelineMetricsObserver;
+
+final var otel = GlobalOpenTelemetry.get();
+final var consumerMetrics = new OtelConsumerMetrics(otel, "orders-consumer");
+final var observer = new PipelineMetricsObserver(otel, "orders");
+
+try (var handle = KPipe.json("orders", kafkaProps)
+    .pipe(enrich)
+    .withMetrics(consumerMetrics)             // standard kpipe.consumer.* metrics
+    .peekResult(observer)                     // per-Result-variant counters
+    .toCustom(WarehouseSink.create())
+    .start()) {
+  handle.awaitShutdown();
+}
+```
+
+If you're using Confluent SR auto-lookup, bind the cache counters too so cache hit rate is visible alongside the
+pipeline outcomes:
+
+```java
+final var resolver = new CachedSchemaResolver(new ConfluentSchemaResolver("http://schema-registry:8081"));
+
+final var observer = new PipelineMetricsObserver(otel, "orders").bindSchemaRegistryCache(
+  resolver::hitCount,
+  resolver::missCount,
+  () -> (long) resolver.size()
+);
+```
+
+The observer takes `LongSupplier`s rather than the resolver itself so `kpipe-metrics-otel` doesn't acquire a transitive
+dependency on `kpipe-schema-registry-confluent`. Wire whichever cache you actually use; the suppliers don't care.
 
 ---
 

--- a/benchmarks/METHODOLOGY.md
+++ b/benchmarks/METHODOLOGY.md
@@ -1,46 +1,45 @@
 # KPipe Benchmark Methodology
 
-This document is how to read the numbers in `benchmarks/results/` and how to reproduce them. If
-you're tempted to quote a single number from a single run, read this first.
+This document is how to read the numbers in `benchmarks/results/` and how to reproduce them. If you're tempted to quote
+a single number from a single run, read this first.
 
 ## What the suite measures
 
 | Bench                                | Question it answers                                                                                                                            |
-|--------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------|
+| ------------------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------- |
 | `JsonPipelineBenchmark`              | What does KPipe's single-SerDe-cycle save vs naive byte-to-byte chaining? (Design validation, not competitive.)                                |
 | `AvroPipelineBenchmark`              | What does zero-copy magic-byte handling save vs `Arrays.copyOfRange`? (Design validation.)                                                     |
 | `ParallelProcessingBenchmark`        | How does **throughput** compare across KPipe, Confluent Parallel Consumer, Reactor Kafka, and a hand-rolled `KafkaConsumer + virtual threads`? |
 | `ParallelProcessingLatencyBenchmark` | How do those four runtimes compare on **per-batch latency** (p50, p95, p99)?                                                                   |
 | `BatchSinkLatencyBenchmark`          | What does `Stream.toBatch(...)` save when the destination has nontrivial per-call cost?                                                        |
 
-The first two are KPipe-vs-straw-man. They show the design choices paid off but are not
-competitive claims. Use them in design docs, not in pitches.
+The first two are KPipe-vs-straw-man. They show the design choices paid off but are not competitive claims. Use them in
+design docs, not in pitches.
 
-The next two are the competitive suite. **These are the ones to quote** when comparing KPipe to
-the alternatives a JVM team would actually pick.
+The next two are the competitive suite. **These are the ones to quote** when comparing KPipe to the alternatives a JVM
+team would actually pick.
 
 The last one is KPipe alone, parameterised across batch size and sink latency.
 
 ## What the four parallel runtimes look like
 
 | Runtime                                   | Concurrency primitive                                                                 | Configured concurrency                                                                |
-|-------------------------------------------|---------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------|
+| ----------------------------------------- | ------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------- |
 | **KPipe**                                 | Virtual thread per record (Loom)                                                      | Unbounded (virtual-thread-per-record); the consumer's in-flight watermark caps memory |
 | **Confluent Parallel Consumer**           | Platform-thread worker pool, `ProcessingOrder.UNORDERED`                              | `maxConcurrency=100`                                                                  |
 | **Reactor Kafka**                         | Reactor `parallel` scheduler via `Flux.parallel(N)`                                   | `parallel(100)` to match Confluent's pool size                                        |
 | **Raw `KafkaConsumer` + virtual threads** | `Executors.newVirtualThreadPerTaskExecutor()` driven from a platform-thread poll loop | Unbounded virtual threads                                                             |
 
-Two of the four (KPipe, raw) lean on Loom. The other two (Confluent, Reactor) lean on platform
-threads. That's the interesting axis. At `workMicros=0` the comparison is essentially "framework
-overhead"; at `workMicros=1000` it's "how does each runtime schedule blocking work?". Those two
-questions often have different winners.
+Two of the four (KPipe, raw) lean on Loom. The other two (Confluent, Reactor) lean on platform threads. That's the
+interesting axis. At `workMicros=0` the comparison is essentially "framework overhead"; at `workMicros=1000` it's "how
+does each runtime schedule blocking work?". Those two questions often have different winners.
 
 ## JMH configuration
 
 The Gradle JMH plugin is configured in `benchmarks/build.gradle.kts`. Defaults:
 
 | Parameter              | Default              | Override                   |
-|------------------------|----------------------|----------------------------|
+| ---------------------- | -------------------- | -------------------------- |
 | Warmup iterations      | 3                    | `-Pjmh.warmupIterations=N` |
 | Measurement iterations | 5                    | `-Pjmh.iterations=N`       |
 | Forks                  | 1                    | `-Pjmh.fork=N`             |
@@ -52,8 +51,8 @@ The Gradle JMH plugin is configured in `benchmarks/build.gradle.kts`. Defaults:
 
 Per-benchmark overrides:
 
-- `ParallelProcessingLatencyBenchmark` sets `Mode.SampleTime + Mode.AverageTime` and
-  `OutputTimeUnit.MILLISECONDS` to publish percentile histograms.
+- `ParallelProcessingLatencyBenchmark` sets `Mode.SampleTime + Mode.AverageTime` and `OutputTimeUnit.MILLISECONDS` to
+  publish percentile histograms.
 - `BatchSinkLatencyBenchmark` parameterises over `batchSize × sinkLatencyMicros`.
 - `ParallelProcessingBenchmark` parameterises over `workMicros` (`0 / 100 / 1000`).
 
@@ -69,9 +68,8 @@ Per-benchmark overrides:
   -Pjmh.resultFormat=JSON
 ```
 
-Two forks instead of one cuts the cross-fork noise on the latency percentiles. The `gc` profiler
-adds allocation rate and GC count per benchmark — required input to the "throughput vs
-allocation-cost" trade-off.
+Two forks instead of one cuts the cross-fork noise on the latency percentiles. The `gc` profiler adds allocation rate
+and GC count per benchmark — required input to the "throughput vs allocation-cost" trade-off.
 
 ### Quick smoke run (for local sanity-check)
 
@@ -83,80 +81,73 @@ allocation-cost" trade-off.
   -Pjmh.fork=1
 ```
 
-One iteration, one warmup, one fork, only the KPipe / 0-µs cell. Useful for verifying the
-harness didn't break after changes; meaningless as a measurement.
+One iteration, one warmup, one fork, only the KPipe / 0-µs cell. Useful for verifying the harness didn't break after
+changes; meaningless as a measurement.
 
 ## What to write down with every published number
 
 A bench number without context is unverifiable. Each entry in `results/` should record:
 
 1. **Date** — when the run completed.
-2. **Hardware** — CPU model, core count, RAM. (Apple Silicon M2 Pro 10c/16GB, AWS m7i.4xlarge,
-   GitHub Actions Linux runner spec, etc.)
+2. **Hardware** — CPU model, core count, RAM. (Apple Silicon M2 Pro 10c/16GB, AWS m7i.4xlarge, GitHub Actions Linux
+   runner spec, etc.)
 3. **OS + kernel** — affects scheduler behaviour, especially for Loom.
 4. **JDK build** — `java -version`. Loom semantics changed across 21 → 25.
 5. **JMH config** — iterations / warmup / forks / profilers actually used.
 6. **Benchmark scope** — which classes and which `@Param` cells.
-7. **Result file** — the raw `results.json` or `results.text` from the run, committed alongside
-   the summary.
+7. **Result file** — the raw `results.json` or `results.text` from the run, committed alongside the summary.
 
 ## Reading the numbers
 
 ### Throughput mode (`ops/s`)
 
-The `ParallelProcessingBenchmark` uses `@OperationsPerInvocation(TARGET_MESSAGES)` where
-`TARGET_MESSAGES = 100_000`. So the JMH "ops/s" number is **records processed per second**.
+The `ParallelProcessingBenchmark` uses `@OperationsPerInvocation(TARGET_MESSAGES)` where `TARGET_MESSAGES = 100_000`. So
+the JMH "ops/s" number is **records processed per second**.
 
-Don't multiply by `TARGET_MESSAGES`. The `@OperationsPerInvocation` annotation already
-normalises.
+Don't multiply by `TARGET_MESSAGES`. The `@OperationsPerInvocation` annotation already normalises.
 
 ### Sample-time mode (latency percentiles)
 
-`ParallelProcessingLatencyBenchmark` reports per-op time in milliseconds. Same
-`@OperationsPerInvocation` so an "op" is one record, but the published number is "median time to
-process one record at this position in the run". Look at the histogram, not the mean:
+`ParallelProcessingLatencyBenchmark` reports per-op time in milliseconds. Same `@OperationsPerInvocation` so an "op" is
+one record, but the published number is "median time to process one record at this position in the run". Look at the
+histogram, not the mean:
 
 - **p50** — typical record. Lower is better.
 - **p95 / p99** — tail. This is what matters when SLA-bound consumers are involved.
 - **p100** — the worst observation in the run. Highly noisy; don't quote.
 
-A runtime can win on average throughput while losing on p99 — `Flux.parallel(N)` schedules
-records in a fan-out / fan-in pattern that produces good average throughput but occasional
-stragglers.
+A runtime can win on average throughput while losing on p99 — `Flux.parallel(N)` schedules records in a fan-out / fan-in
+pattern that produces good average throughput but occasional stragglers.
 
 ### Within-iteration vs cross-fork variance
 
-The default `forks=1` means all iterations share the same JVM process. Cross-fork variance (JIT
-warmup differences, GC profile differences across forks) doesn't get exposed. For published
-numbers run with `forks=2` minimum.
+The default `forks=1` means all iterations share the same JVM process. Cross-fork variance (JIT warmup differences, GC
+profile differences across forks) doesn't get exposed. For published numbers run with `forks=2` minimum.
 
 ## Caveats
 
 A few things to keep in mind whenever you quote a number from this suite:
 
-- **Broker runs in Docker (Testcontainers Kafka 4.2.0), not in-process.** That's the right call
-  for a competitive bench — the broker isn't fighting consumers for cores — but it also means
-  network IO is real (loopback to a container) and absolute numbers are still **lower than a
-  production setup with a network broker on dedicated hardware**. The headline *ordering*
-  between runtimes is what's meaningful; absolute records-per-second is a function of how much
-  of the host's cores Docker / the container runtime is giving the broker.
-- **Single-broker, single-container.** No replication, no leader election, no rebalance under
-  load. The broker container runs replication factor 1 and `min.insync.replicas=1`. Real
-  failure modes won't show up.
-- **Single payload size.** The seed payload is small JSON (~50 bytes). Reactor Kafka's
-  `flatMap` strategy can behave differently under 10KB payloads.
-- **Macros vs micros.** This suite measures consumer-side throughput. End-to-end latency
-  (produce → consume → process → ack) needs a separate harness.
-- **Docker overhead is real.** The first iteration of every trial pays the container-startup
-  cost. JMH's warmup phase absorbs most of that; if you're spot-checking with `-wi 0`, expect
-  the first measurement iteration to look slow.
+- **Broker runs in Docker (Testcontainers Kafka 4.2.0), not in-process.** That's the right call for a competitive bench
+  — the broker isn't fighting consumers for cores — but it also means network IO is real (loopback to a container) and
+  absolute numbers are still **lower than a production setup with a network broker on dedicated hardware**. The headline
+  _ordering_ between runtimes is what's meaningful; absolute records-per-second is a function of how much of the host's
+  cores Docker / the container runtime is giving the broker.
+- **Single-broker, single-container.** No replication, no leader election, no rebalance under load. The broker container
+  runs replication factor 1 and `min.insync.replicas=1`. Real failure modes won't show up.
+- **Single payload size.** The seed payload is small JSON (~50 bytes). Reactor Kafka's `flatMap` strategy can behave
+  differently under 10KB payloads.
+- **Macros vs micros.** This suite measures consumer-side throughput. End-to-end latency (produce → consume → process →
+  ack) needs a separate harness.
+- **Docker overhead is real.** The first iteration of every trial pays the container-startup cost. JMH's warmup phase
+  absorbs most of that; if you're spot-checking with `-wi 0`, expect the first measurement iteration to look slow.
 
 ## When the numbers should change
 
 Re-publish the results file when **any** of these change:
 
-- A new runtime is added or an existing one is upgraded (Confluent PC version bump, Reactor
-  Kafka version bump, Kafka client version bump).
+- A new runtime is added or an existing one is upgraded (Confluent PC version bump, Reactor Kafka version bump, Kafka
+  client version bump).
 - KPipe's hot-path code changes (offset manager, pipeline builder, consumer thread loop).
 - The JMH config changes (different iteration count, different fork count).
 - The hardware changes.

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -25,26 +25,24 @@ Measures the efficiency of KPipe's magic byte offset handling vs. traditional by
 
 ### 3. Parallel Processing — Competitive Suite (`ParallelProcessingBenchmark`)
 
-Four parallel-consumer runtimes drink from the same seeded topic on a **Testcontainers-managed
-Kafka 4.2.0 broker** (Docker; broker runs in its own JVM on its own cores so it isn't fighting the
-consumer under test for CPU):
+Four parallel-consumer runtimes drink from the same seeded topic on a **Testcontainers-managed Kafka 4.2.0 broker**
+(Docker; broker runs in its own JVM on its own cores so it isn't fighting the consumer under test for CPU):
 
 - **KPipe** — virtual-thread-per-record on Loom; no pool, no queue.
-- **Confluent Parallel Consumer** — `ProcessingOrder.UNORDERED` with a 100-worker pool. The de-facto industry
-  baseline.
+- **Confluent Parallel Consumer** — `ProcessingOrder.UNORDERED` with a 100-worker pool. The de-facto industry baseline.
 - **Reactor Kafka** — `Flux<ReceiverRecord>` on the Reactor `parallel` scheduler with a matching concurrency limit.
 - **Raw `KafkaConsumer` + `newVirtualThreadPerTaskExecutor`** — the hand-rolled baseline. No framework, no offset
   manager. Establishes the floor of "what if I just wrote the loop myself?"
 
-A `workMicros` `@Param` (`0`, `100`, `1000`) injects per-record work via `LockSupport.parkNanos` so the bench
-covers three workload regimes: pure framework overhead (0 µs), local enrichment (100 µs), and blocking I/O round
-trip (1000 µs). At `workMicros=0` the comparison is "who has the lowest per-record overhead?"; at
-`workMicros=1000` it's "who schedules blocking work best?" — those two questions usually have different winners.
+A `workMicros` `@Param` (`0`, `100`, `1000`) injects per-record work via `LockSupport.parkNanos` so the bench covers
+three workload regimes: pure framework overhead (0 µs), local enrichment (100 µs), and blocking I/O round trip (1000
+µs). At `workMicros=0` the comparison is "who has the lowest per-record overhead?"; at `workMicros=1000` it's "who
+schedules blocking work best?" — those two questions usually have different winners.
 
-Each invocation processes **25,000 records** across **8 partitions**. Because the broker is in its own container
-(not in-process), pushing the record count higher actually scales the consumer workload instead of bottlenecking on
-broker contention. **Docker must be running** before invoking the bench; Testcontainers will pull
-`apache/kafka:4.2.0` and start the container at trial setup.
+Each invocation processes **25,000 records** across **8 partitions**. Because the broker is in its own container (not
+in-process), pushing the record count higher actually scales the consumer workload instead of bottlenecking on broker
+contention. **Docker must be running** before invoking the bench; Testcontainers will pull `apache/kafka:4.2.0` and
+start the container at trial setup.
 
 ### 4. Batch Sink Throughput (`BatchSinkLatencyBenchmark`)
 

--- a/benchmarks/results/2026-05-16.md
+++ b/benchmarks/results/2026-05-16.md
@@ -1,34 +1,33 @@
 # Benchmark snapshot — 2026-05-16
 
-Full four-runtime publishing run from the Testcontainers-backed harness. All four runtimes
-produced clean JMH scores across the full `workMicros` sweep — including Reactor Kafka, which
-was unblocked by the upstream 1.3.25 release.
+Full four-runtime publishing run from the Testcontainers-backed harness. All four runtimes produced clean JMH scores
+across the full `workMicros` sweep — including Reactor Kafka, which was unblocked by the upstream 1.3.25 release.
 
 ## Environment
 
-| Field | Value |
-|---|---|
-| Date | 2026-05-16 (run); doc refreshed 2026-05-17 |
-| Hardware | Apple Silicon laptop, 10 cores |
-| OS | macOS 14.x |
-| JDK | OpenJDK 25.0.2 (25.0.2+10-69) |
-| Broker | `apache/kafka:4.2.0` via Testcontainers (Docker) |
-| KPipe | branch `bench/results-2026-05-16` |
-| Confluent Parallel Consumer | 0.5.3.0 |
-| Reactor Kafka | 1.3.25 (the `kafka-clients` 4.x fix shipped 2025-11-06) |
+| Field                       | Value                                                   |
+| --------------------------- | ------------------------------------------------------- |
+| Date                        | 2026-05-16 (run); doc refreshed 2026-05-17              |
+| Hardware                    | Apple Silicon laptop, 10 cores                          |
+| OS                          | macOS 14.x                                              |
+| JDK                         | OpenJDK 25.0.2 (25.0.2+10-69)                           |
+| Broker                      | `apache/kafka:4.2.0` via Testcontainers (Docker)        |
+| KPipe                       | branch `bench/results-2026-05-16`                       |
+| Confluent Parallel Consumer | 0.5.3.0                                                 |
+| Reactor Kafka               | 1.3.25 (the `kafka-clients` 4.x fix shipped 2025-11-06) |
 
 ## JMH configuration
 
-| Parameter | Value |
-|---|---|
-| Warmup iterations | 3 |
-| Measurement iterations | 5 |
-| Forks | 2 |
-| Profilers | `gc` |
-| Result format | JSON (`2026-05-16.json` alongside this file) |
-| `TARGET_MESSAGES` | 25,000 |
-| `TOPIC_PARTITIONS` | 8 |
-| Total wall-clock | 36 min 22 s |
+| Parameter              | Value                                        |
+| ---------------------- | -------------------------------------------- |
+| Warmup iterations      | 3                                            |
+| Measurement iterations | 5                                            |
+| Forks                  | 2                                            |
+| Profilers              | `gc`                                         |
+| Result format          | JSON (`2026-05-16.json` alongside this file) |
+| `TARGET_MESSAGES`      | 25,000                                       |
+| `TOPIC_PARTITIONS`     | 8                                            |
+| Total wall-clock       | 36 min 22 s                                  |
 
 ## Scope
 
@@ -38,78 +37,70 @@ just bench
 
 ## Throughput — `ParallelProcessingBenchmark`
 
-Records / second, higher is better. Each cell is `Score ± error` from `Cnt=10` (5 iterations × 2
-forks).
+Records / second, higher is better. Each cell is `Score ± error` from `Cnt=10` (5 iterations × 2 forks).
 
-| Runtime | `workMicros=0` | `workMicros=100` | `workMicros=1000` |
-|---|---:|---:|---:|
-| **Raw `KafkaConsumer` + VT** | 542,859 ± 34,077 | 500,231 ± 40,168 | 482,639 ± 50,406 |
-| **KPipe** | **473,491 ± 79,218** | **461,273 ± 55,179** | **430,526 ± 117,613** |
-| **Reactor Kafka** | 256,648 ± 25,508 | 77,542 ± 1,054 | **8,979 ± 34** |
-| **Confluent Parallel Consumer** | 100,106 ± 19,160 | 108,194 ± 6,652 | 64,715 ± 3,091 |
+| Runtime                         |       `workMicros=0` |     `workMicros=100` |     `workMicros=1000` |
+| ------------------------------- | -------------------: | -------------------: | --------------------: |
+| **Raw `KafkaConsumer` + VT**    |     542,859 ± 34,077 |     500,231 ± 40,168 |      482,639 ± 50,406 |
+| **KPipe**                       | **473,491 ± 79,218** | **461,273 ± 55,179** | **430,526 ± 117,613** |
+| **Reactor Kafka**               |     256,648 ± 25,508 |       77,542 ± 1,054 |        **8,979 ± 34** |
+| **Confluent Parallel Consumer** |     100,106 ± 19,160 |      108,194 ± 6,652 |        64,715 ± 3,091 |
 
 ### Observations
 
-- **The Reactor cliff is the headline finding of this run.** At `workMicros=0` Reactor is in
-  the middle of the pack (256k, ~2.5× Confluent but ~half KPipe). At `workMicros=100` it
-  drops *below* Confluent. At `workMicros=1000` it does **8,979 ops/sec** — 7× slower than
-  Confluent and 48× slower than KPipe at the same workload. The error band of ±34 on 8,979
-  says it's consistently terrible, not noise. `Flux.parallel(100)` does not deliver 100
-  parallel rails when records block on `LockSupport.parkNanos`.
+- **The Reactor cliff is the headline finding of this run.** At `workMicros=0` Reactor is in the middle of the pack
+  (256k, ~2.5× Confluent but ~half KPipe). At `workMicros=100` it drops _below_ Confluent. At `workMicros=1000` it does
+  **8,979 ops/sec** — 7× slower than Confluent and 48× slower than KPipe at the same workload. The error band of ±34 on
+  8,979 says it's consistently terrible, not noise. `Flux.parallel(100)` does not deliver 100 parallel rails when
+  records block on `LockSupport.parkNanos`.
 
-- **KPipe degrades gracefully** across the workload sweep (473k → 461k → 430k). Virtual
-  threads scale beyond the partition count; each blocked record costs kilobytes of stack and
-  the carrier-thread continues serving other work.
+- **KPipe degrades gracefully** across the workload sweep (473k → 461k → 430k). Virtual threads scale beyond the
+  partition count; each blocked record costs kilobytes of stack and the carrier-thread continues serving other work.
 
-- **Raw `KafkaConsumer + VT` narrowly beats KPipe** across the board, by 5–15%. The earlier
-  smoke-test claim of "KPipe ≈ raw within error" was too strong with this run's tighter error
-  bands. KPipe still wraps the consumer loop very cleanly, but there is a small measurable
-  framework cost.
+- **Raw `KafkaConsumer + VT` narrowly beats KPipe** across the board, by 5–15%. The earlier smoke-test claim of "KPipe ≈
+  raw within error" was too strong with this run's tighter error bands. KPipe still wraps the consumer loop very
+  cleanly, but there is a small measurable framework cost.
 
-- **Confluent's flat 0→100 curve makes sense.** Pool of 100 workers, 100µs of work per record
-  → pool exactly saturated, no queuing. At 1000µs (workers can't drain fast enough) it falls
-  to 64k.
+- **Confluent's flat 0→100 curve makes sense.** Pool of 100 workers, 100µs of work per record → pool exactly saturated,
+  no queuing. At 1000µs (workers can't drain fast enough) it falls to 64k.
 
 ## Allocation profile (`gc.alloc.rate.norm`, B / op)
 
 Lower is better. JMH's GC profiler reports allocation per benchmark operation (= per record).
 
-| Runtime | `workMicros=0` | `workMicros=100` | `workMicros=1000` |
-|---|---:|---:|---:|
-| Confluent Parallel Consumer | 34 | 34 | 35 |
-| Raw `KafkaConsumer` + VT | 55 | 431 | 455 |
-| Reactor Kafka | 175 | 83 | 193 |
-| KPipe | 924 | 1,513 | 1,436 |
+| Runtime                     | `workMicros=0` | `workMicros=100` | `workMicros=1000` |
+| --------------------------- | -------------: | ---------------: | ----------------: |
+| Confluent Parallel Consumer |             34 |               34 |                35 |
+| Raw `KafkaConsumer` + VT    |             55 |              431 |               455 |
+| Reactor Kafka               |            175 |               83 |               193 |
+| KPipe                       |            924 |            1,513 |             1,436 |
 
 ### Observations
 
-- **Confluent allocates least** (~34 B/op) and is consistent across the workload sweep — its
-  pool of long-lived worker threads doesn't allocate much per record.
-- **Raw** is second-leanest at `workMicros=0` (55 B/op). The big jump at 100/1000µs is the
-  virtual-thread Runnable lambdas piling up while blocked.
-- **Reactor** allocates moderately (83–193 B/op) — surprising given its throughput collapse,
-  but the `Flux` machinery is not as allocation-heavy as you'd expect; the problem is
-  scheduling, not bytes.
-- **KPipe allocates most** (924–1,513 B/op) because of `Result<T>` wrappers, per-record
-  builder hand-off, and a fresh virtual thread per record. **At the throughput shown above
-  this allocation rate did not depress ops/sec** — the JVM's young gen absorbed it. On a
-  tight heap or a workload sensitive to GC tail latency, watch this number.
+- **Confluent allocates least** (~34 B/op) and is consistent across the workload sweep — its pool of long-lived worker
+  threads doesn't allocate much per record.
+- **Raw** is second-leanest at `workMicros=0` (55 B/op). The big jump at 100/1000µs is the virtual-thread Runnable
+  lambdas piling up while blocked.
+- **Reactor** allocates moderately (83–193 B/op) — surprising given its throughput collapse, but the `Flux` machinery is
+  not as allocation-heavy as you'd expect; the problem is scheduling, not bytes.
+- **KPipe allocates most** (924–1,513 B/op) because of `Result<T>` wrappers, per-record builder hand-off, and a fresh
+  virtual thread per record. **At the throughput shown above this allocation rate did not depress ops/sec** — the JVM's
+  young gen absorbed it. On a tight heap or a workload sensitive to GC tail latency, watch this number.
 
 ## GC behavior
 
 `gc.count` (events) and `gc.time` (total ms across measurement iterations).
 
-| Runtime | `workMicros=0` count / ms | `workMicros=100` count / ms | `workMicros=1000` count / ms |
-|---|---|---|---|
-| Raw `KafkaConsumer` + VT | 93 / 112 | 130 / 196 | 126 / 330 |
-| KPipe | 98 / 166 | 123 / 251 | 126 / 523 |
-| Confluent Parallel Consumer | 192 / 515 | 270 / 455 | 352 / 535 |
-| Reactor Kafka | 272 / 732 | 157 / 704 | 33 / 98 |
+| Runtime                     | `workMicros=0` count / ms | `workMicros=100` count / ms | `workMicros=1000` count / ms |
+| --------------------------- | ------------------------- | --------------------------- | ---------------------------- |
+| Raw `KafkaConsumer` + VT    | 93 / 112                  | 130 / 196                   | 126 / 330                    |
+| KPipe                       | 98 / 166                  | 123 / 251                   | 126 / 523                    |
+| Confluent Parallel Consumer | 192 / 515                 | 270 / 455                   | 352 / 535                    |
+| Reactor Kafka               | 272 / 732                 | 157 / 704                   | 33 / 98                      |
 
-The Reactor GC numbers at `workMicros=1000` look low (33 events / 98 ms) because the
-benchmark is barely running — at ~9 records/sec processing, very little allocation pressure
-gets generated. Don't read that as Reactor being well-behaved; the throughput tells the real
-story.
+The Reactor GC numbers at `workMicros=1000` look low (33 events / 98 ms) because the benchmark is barely running — at ~9
+records/sec processing, very little allocation pressure gets generated. Don't read that as Reactor being well-behaved;
+the throughput tells the real story.
 
 ## Raw output
 

--- a/benchmarks/results/TEMPLATE.md
+++ b/benchmarks/results/TEMPLATE.md
@@ -1,12 +1,12 @@
 # Benchmark snapshot — YYYY-MM-DD
 
-Copy this file when publishing a fresh benchmark run. Fill in every section. If a section
-doesn't apply (e.g., no `perfnorm` data because the run was on macOS), say so explicitly.
+Copy this file when publishing a fresh benchmark run. Fill in every section. If a section doesn't apply (e.g., no
+`perfnorm` data because the run was on macOS), say so explicitly.
 
 ## Environment
 
 | Field                       | Value                                          |
-|-----------------------------|------------------------------------------------|
+| --------------------------- | ---------------------------------------------- |
 | Date (UTC)                  | `YYYY-MM-DD HH:MM`                             |
 | Hardware                    | e.g., `Apple Silicon M2 Pro, 10 cores, 16 GB`  |
 | OS / Kernel                 | e.g., `macOS 14.5 (Darwin 24.6.0)`             |
@@ -19,7 +19,7 @@ doesn't apply (e.g., no `perfnorm` data because the run was on macOS), say so ex
 ## JMH configuration
 
 | Parameter              | Value                                                 |
-|------------------------|-------------------------------------------------------|
+| ---------------------- | ----------------------------------------------------- |
 | Warmup iterations      | 3 (default)                                           |
 | Measurement iterations | 5 (default)                                           |
 | Forks                  | 2 (recommended for publishing)                        |
@@ -38,11 +38,10 @@ doesn't apply (e.g., no `perfnorm` data because the run was on macOS), say so ex
 
 ## Throughput — ParallelProcessingBenchmark
 
-Records / second, higher is better. `workMicros` is per-record simulated work via
-`LockSupport.parkNanos`.
+Records / second, higher is better. `workMicros` is per-record simulated work via `LockSupport.parkNanos`.
 
 | Runtime                     | workMicros=0 | workMicros=100 | workMicros=1000 |
-|-----------------------------|-------------:|---------------:|----------------:|
+| --------------------------- | -----------: | -------------: | --------------: |
 | KPipe                       |    TBD ± TBD |      TBD ± TBD |       TBD ± TBD |
 | Confluent Parallel Consumer |    TBD ± TBD |      TBD ± TBD |       TBD ± TBD |
 | Reactor Kafka               |    TBD ± TBD |      TBD ± TBD |       TBD ± TBD |
@@ -59,7 +58,7 @@ Records / second, higher is better. `workMicros` is per-record simulated work vi
 Per-record time (ms), lower is better. Reported at `workMicros=100` (typical local enrichment).
 
 | Runtime                     | p50 | p95 | p99 |
-|-----------------------------|----:|----:|----:|
+| --------------------------- | --: | --: | --: |
 | KPipe                       | TBD | TBD | TBD |
 | Confluent Parallel Consumer | TBD | TBD | TBD |
 | Reactor Kafka               | TBD | TBD | TBD |
@@ -75,7 +74,7 @@ Per-record time (ms), lower is better. Reported at `workMicros=100` (typical loc
 `gc.alloc.rate.norm` (B / op, lower is better) at `workMicros=100`.
 
 | Runtime                     | B/op |
-|-----------------------------|-----:|
+| --------------------------- | ---: |
 | KPipe                       |  TBD |
 | Confluent Parallel Consumer |  TBD |
 | Reactor Kafka               |  TBD |
@@ -86,7 +85,7 @@ Per-record time (ms), lower is better. Reported at `workMicros=100` (typical loc
 See `BatchSinkLatencyBenchmark` — single-runtime, separate sweep. Headline:
 
 | batchSize | sinkLatencyMicros | Throughput (ops/s) |
-|----------:|------------------:|-------------------:|
+| --------: | ----------------: | -----------------: |
 |         1 |                10 |                TBD |
 |         1 |              1000 |                TBD |
 |       100 |                10 |                TBD |
@@ -94,8 +93,8 @@ See `BatchSinkLatencyBenchmark` — single-runtime, separate sweep. Headline:
 
 ## Raw output
 
-The full JMH JSON output is attached as `results-YYYY-MM-DD.json`. The `gc` profiler section in
-that file is the source of truth for allocation rates.
+The full JMH JSON output is attached as `results-YYYY-MM-DD.json`. The `gc` profiler section in that file is the source
+of truth for allocation rates.
 
 ## Pitfalls in this run
 

--- a/benchmarks/src/jmh/java/org/kpipe/benchmarks/AvroPipelineBenchmark.java
+++ b/benchmarks/src/jmh/java/org/kpipe/benchmarks/AvroPipelineBenchmark.java
@@ -103,8 +103,8 @@ public class AvroPipelineBenchmark {
       return r;
     };
 
-    registry.register(op1, setProcessed);
-    registry.register(op2, renameProcessed);
+    registry.registerOperator(op1, setProcessed);
+    registry.registerOperator(op2, renameProcessed);
 
     kpipePipeline = registry.pipeline(format).add(op1, op2).build();
     kpipeMagicPipeline = registry.pipeline(format).skipBytes(5).add(op1, op2).build();

--- a/benchmarks/src/jmh/java/org/kpipe/benchmarks/JsonPipelineBenchmark.java
+++ b/benchmarks/src/jmh/java/org/kpipe/benchmarks/JsonPipelineBenchmark.java
@@ -57,15 +57,15 @@ public class JsonPipelineBenchmark {
     final var op2 = RegistryKey.json("op2");
     final var op3 = RegistryKey.json("op3");
 
-    registry.register(op1, map -> {
+    registry.registerOperator(op1, map -> {
       map.put("processed_by", "kpipe");
       return map;
     });
-    registry.register(op2, map -> {
+    registry.registerOperator(op2, map -> {
       map.put("timestamp", BENCHMARK_TIMESTAMP);
       return map;
     });
-    registry.register(op3, map -> {
+    registry.registerOperator(op3, map -> {
       map.remove("email");
       return map;
     });

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -77,22 +77,26 @@ allprojects {
       trimTrailingWhitespace()
       endWithNewline()
     }
-    format("markdown") {
-      target("*.md")
-      prettier(
-        mapOf(
-          "prettier" to "3.8.1",
-          "prettier-plugin-java" to "2.8.1",
-        ),
-      ).config(
-        mapOf(
-          "plugins" to listOf("prettier-plugin-java"),
-          "printWidth" to 120,
-          "proseWrap" to "always",
-          "tabWidth" to 2,
-        ),
-      )
-    }
+  }
+}
+
+spotless {
+  format("markdown") {
+    target("**/*.md")
+    targetExclude("**/build/**", "**/.gradle/**", "**/node_modules/**")
+    prettier(
+      mapOf(
+        "prettier" to "3.8.1",
+        "prettier-plugin-java" to "2.8.1",
+      ),
+    ).config(
+      mapOf(
+        "plugins" to listOf("prettier-plugin-java"),
+        "printWidth" to 120,
+        "proseWrap" to "always",
+        "tabWidth" to 2,
+      ),
+    )
   }
 }
 

--- a/docs/escape-hatches.md
+++ b/docs/escape-hatches.md
@@ -1,0 +1,143 @@
+# Escape hatches — when the fluent facade isn't enough
+
+The [`KPipe` fluent facade](../README.md#the-fluent-facade) covers the 80% path:
+
+```java
+try (var handle = KPipe.json("orders", props)
+    .pipe(order -> enrich(order))
+    .filter(order -> order.total() > 0)
+    .withRetry(3, Duration.ofMillis(100))
+    .withBackpressure()
+    .withDeadLetterTopic("orders.dlq")
+    .toCustom(WarehouseSink.create())
+    .start()) {
+  handle.awaitShutdown();
+}
+```
+
+Some advanced use cases need the explicit `MessageProcessorRegistry` + `KPipeConsumer.Builder` surface. This page is the
+index — for each capability, it tells you whether it's on the fluent path, on the explicit path, or both, and how to
+wire it up.
+
+Rows in **bold** are deliberately escape-hatch-only (no fluent equivalent planned).
+
+## Capability map
+
+| Capability                                          | Facade path                                                              | Explicit-API path                                                                                    | Notes                                                                                                                                                                            |
+| --------------------------------------------------- | ------------------------------------------------------------------------ | ---------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Format selection                                    | `KPipe.json/avro/protobuf/bytes/custom(...)`                             | `new MessageProcessorRegistry(format)`                                                               | Custom format: pass any `MessageFormat<T>` to `KPipe.custom`.                                                                                                                    |
+| Topic subscription (homogeneous)                    | `KPipe.X(topic, props)`                                                  | `Builder.withTopic(s) / withTopics(...)`                                                             | One topic-set, one shared pipeline.                                                                                                                                              |
+| Topic subscription (heterogeneous)                  | `KPipe.multi(props).json(...).avro(...)...start()`                       | `Builder.withPipelines(Map<String, MessagePipeline<?>>)`                                             | Per-topic dispatch.                                                                                                                                                              |
+| Operator chain (`pipe/filter/peek/when`)            | `Stream.pipe / filter / peek / when`                                     | `MessageProcessorRegistry.pipeline(format).add(...)`                                                 | Identical operator semantics.                                                                                                                                                    |
+| Result observers (`onFiltered/onFailed/peekResult`) | `Stream.onFiltered / onFailed / peekResult`                              | — (the fluent facade is the entry point; explicit API users pattern-match `Result<T>` directly)      | Observers fire after the pipeline returns `Result.Passed/Filtered/Failed`. Side-effect only; they do not suppress or reroute.                                                    |
+| Custom terminal sink                                | `Stream.toCustom(MessageSink<T>)`                                        | `registry.registerSink(key, sink)`                                                                   | Any `MessageSink<T>`; facade also offers `.toConsole()`.                                                                                                                         |
+| Multi-sink fanout                                   | `Stream.toMulti(sinks...)`                                               | `new CompositeMessageSink<>(...)`                                                                    | Best-effort delivery; per-sink errors logged + suppressed.                                                                                                                       |
+| Batch sink (size + age flush)                       | `Stream.toBatch(BatchSink<T>, BatchPolicy)`                              | `Builder.withBatchPipeline(topic, pipeline, sink, policy)`                                           | `BatchSink<T>` returns `BatchResult` for per-record DLQ; `BatchSink.ofVoid(consumer)` wraps void-style sinks (whole-batch DLQ on throw). Sequential + parallel modes both work.  |
+| Batch sink (multi-topic)                            | `KPipe.multi(props).json(topic, s -> s.toBatch(sink, policy))...start()` | `Builder.withBatchPipeline(...)` × N                                                                 | One consumer-group, mixed batch + non-batch routes.                                                                                                                              |
+| Skip wire-format prefix                             | `Stream.skipBytes(int)`                                                  | `TypedPipelineBuilder.skipBytes(int)`                                                                | Confluent envelope: 5 (Avro) / 6 (Proto single-msg). Don't combine with `withSchemaRegistry(...)`.                                                                               |
+| Confluent SR per-record auto-lookup (Avro)          | `Stream.withSchemaRegistry(SchemaResolver)`                              | `AvroFormat.withRegistry(SchemaResolver)`                                                            | Cached by ID, no TTL (SR IDs are immutable). Avro only — Protobuf needs runtime `.proto` compilation. Replaces the static `lookupBySubjectVersion("latest")` startup-fetch path. |
+| Pipeline outcome counters (OTel)                    | `Stream.peekResult(PipelineMetricsObserver)`                             | hand any `Consumer<Result<T>>` to `peekResult`                                                       | `PipelineMetricsObserver` in `kpipe-metrics-otel` emits `kpipe.pipeline.passed/filtered/failed`. Optional `bindSchemaRegistryCache(...)` adds the SR cache counters.             |
+| Retry policy                                        | `Stream.withRetry(int, Duration)`                                        | `Builder.withRetry(int, Duration)`                                                                   |                                                                                                                                                                                  |
+| Backpressure (default watermarks)                   | `Stream.withBackpressure()`                                              | `Builder.withBackpressure(BackpressureController)`                                                   | Defaults: pause 10k, resume 7k.                                                                                                                                                  |
+| Backpressure (custom watermarks)                    | `Stream.withBackpressure(high, low)`                                     | `Builder.withBackpressure(BackpressureController)`                                                   | High/low strategy auto-derived from `sequentialProcessing`.                                                                                                                      |
+| Sequential processing                               | `Stream.withSequentialProcessing(boolean)`                               | `Builder.withSequentialProcessing(boolean)`                                                          | Switches backpressure to lag-based.                                                                                                                                              |
+| OTel/custom metrics                                 | `Stream.withMetrics(ConsumerMetrics)` / `MultiBuilder.withMetrics(...)`  | `Builder.withMetrics(ConsumerMetrics)`                                                               | Single-format and multi-topic both supported.                                                                                                                                    |
+| Custom error handler                                | `Stream.withErrorHandler(Consumer<ProcessingError<byte[]>>)`             | `Builder.withErrorHandler(ErrorHandler<K>)`                                                          | Default logs at WARNING.                                                                                                                                                         |
+| Dead-letter topic                                   | `Stream.withDeadLetterTopic(String)`                                     | `Builder.withDeadLetterTopic(String)` / `withDeadLetterBundle(...)`                                  | Bundle form pairs DLQ + producer for advanced wiring.                                                                                                                            |
+| Poll timeout                                        | `Stream.withPollTimeout(Duration)`                                       | `Builder.withPollTimeout(Duration)`                                                                  | Default 100ms.                                                                                                                                                                   |
+| Lifecycle handle                                    | `Handle.isHealthy / metrics / awaitShutdown / close`                     | `KPipeConsumer.start / awaitShutdown / shutdownGracefully / waitForInFlightDrain`                    | `Handle` is `AutoCloseable` (5s graceful default). Since 1.13: consumer hosts the lifecycle directly — no separate `KPipeRunner`.                                                |
+| **Custom `OffsetManager`**                          | — (escape hatch only)                                                    | `Builder.withOffsetManager(...)` / `withOffsetManager(Provider)`                                     | E.g. Postgres/Redis-backed manager.                                                                                                                                              |
+| **Custom Kafka `Consumer` factory**                 | —                                                                        | `Builder.withConsumerProvider(Supplier<Consumer<K,byte[]>>)`                                         | Test seam / SSL configurators.                                                                                                                                                   |
+| **Custom DLQ `KafkaProducer`**                      | —                                                                        | `Builder.withKafkaProducer(...)` / `withDeadLetterBundle(...)`                                       | Override default producer for the DLQ.                                                                                                                                           |
+| **Rebalance listener**                              | —                                                                        | `Builder.withRebalanceListener(ConsumerRebalanceListener)`                                           | External offset commit hooks, log routing.                                                                                                                                       |
+| **Custom command queue**                            | —                                                                        | `Builder.withCommandQueue(Queue<ConsumerCommand>)`                                                   | Test seam (rarely needed).                                                                                                                                                       |
+| **Thread/executor termination tuning**              | —                                                                        | `Builder.withThreadTerminationTimeout / withExecutorTerminationTimeout / withWaitForMessagesTimeout` | Shutdown tuning.                                                                                                                                                                 |
+| **Periodic metrics reporting + shutdown hook**      | —                                                                        | `Builder.withMetricsReporters(...) / withMetricsInterval(...) / withShutdownHook(true)`              | Folded into `KPipeConsumer.Builder` in 1.13. Reporter thread is daemon, doesn't keep the JVM up.                                                                                 |
+| **Health endpoint**                                 | —                                                                        | `HttpHealthServer.fromEnv(...)`                                                                      | Run alongside `Handle` in the host process.                                                                                                                                      |
+| **In-flight drain**                                 | `Handle.shutdownGracefully(Duration)`                                    | `KPipeConsumer.waitForInFlightDrain(Duration) / shutdownGracefully(Duration)`                        | Uses the live in-flight counter (includes buffered batch records), not metric-derived.                                                                                           |
+| **Custom `MessageProcessorRegistry`**               | —                                                                        | `new MessageProcessorRegistry(...)` + manual wiring                                                  | Pre-shared pipelines across consumers, multi-format orchestrators.                                                                                                               |
+
+## Worked examples
+
+### A custom OffsetManager
+
+Use case: persist offsets in Postgres alongside business writes, so commit is atomic with the record's downstream
+side-effect.
+
+```java
+final var offsetManager = new PostgresOffsetManager(dataSource);
+
+final var consumer = KPipeConsumer.<byte[]>builder()
+  .withProperties(kafkaProps)
+  .withTopic("orders")
+  .withPipeline(pipeline)
+  .withOffsetManager(offsetManager)
+  .build();
+```
+
+`OffsetManager` is a thin SPI — implement `markOffsetProcessed`, `getOffsetsToCommit`, and `close`. The consumer threads
+call into it concurrently; implementations must be thread-safe.
+
+### A custom rebalance listener
+
+Use case: flush an external buffer before partitions are revoked.
+
+```java
+final var consumer = KPipeConsumer.<byte[]>builder()
+  .withProperties(kafkaProps)
+  .withTopic("orders")
+  .withPipeline(pipeline)
+  .withRebalanceListener(
+    new ConsumerRebalanceListener() {
+      @Override
+      public void onPartitionsRevoked(final Collection<TopicPartition> partitions) {
+        externalBuffer.flush(partitions);
+      }
+
+      @Override
+      public void onPartitionsAssigned(final Collection<TopicPartition> partitions) {
+        // no-op
+      }
+    }
+  )
+  .build();
+```
+
+### Pre-shared registries across consumers
+
+Use case: a single pipeline definition reused across consumer groups for A/B traffic split.
+
+```java
+final var registry = new MessageProcessorRegistry(JsonFormat.INSTANCE);
+registry.registerOperator(RegistryKey.json("enrich"), enrichOp);
+registry.registerSink(RegistryKey.json("warehouse"), warehouseSink);
+
+final var pipeline = registry.pipeline(JsonFormat.INSTANCE)
+    .add(RegistryKey.<Map<String, Object>>json("enrich"))
+    .toSink(RegistryKey.<Map<String, Object>>json("warehouse"))
+    .build();
+
+final var groupA = KPipeConsumer.<byte[]>builder()
+    .withProperties(propsForGroup("group-a"))
+    .withTopic("orders")
+    .withPipeline(pipeline)
+    .build();
+
+final var groupB = KPipeConsumer.<byte[]>builder()
+    .withProperties(propsForGroup("group-b"))
+    .withTopic("orders")
+    .withPipeline(pipeline)
+    .build();
+```
+
+Both consumers share the same pipeline instance — operators and sinks are thread-safe.
+
+## Dropping back to the explicit API mid-stream
+
+You don't have to commit to one surface. The fluent facade's `Handle` exposes the underlying `KPipeConsumer` via
+`metrics()` and lifecycle methods; for richer access, build with the explicit API directly. The two surfaces are
+interchangeable: anything you can write with the facade can be written with the builder, and the facade itself is just a
+thin layer over the builder.
+
+If you find yourself reaching for an escape hatch that isn't in the table above, open an issue — either it's missing
+from this doc, or it's a real gap in the API.

--- a/examples/schema-registry/src/main/java/org/kpipe/App.java
+++ b/examples/schema-registry/src/main/java/org/kpipe/App.java
@@ -5,20 +5,20 @@ import java.lang.System.Logger.Level;
 import java.time.Duration;
 import org.kpipe.consumer.config.AppConfig;
 import org.kpipe.consumer.config.KafkaConsumerConfig;
-import org.kpipe.format.avro.AvroFormat;
+import org.kpipe.schemaregistry.confluent.CachedSchemaResolver;
 import org.kpipe.schemaregistry.confluent.ConfluentSchemaResolver;
 
-/// Avro consumer that fetches its schema from Confluent Schema Registry at startup, builds an
-/// [AvroFormat] from it, and then runs a normal `KPipe.avro(...)` pipeline.
+/// Avro consumer that resolves the writer's schema from Confluent Schema Registry per record.
+/// The format reads the 5-byte wire envelope itself (1 magic byte + 4-byte schema id), looks up
+/// the schema through the cached resolver, and decodes the remaining bytes against it. This is
+/// the schema-evolution-correct path — producer evolution can't silently corrupt the consumer
+/// the way the older "fetch once at startup, treat as fixed" pattern could.
 ///
 /// Environment variables (in addition to the standard `AppConfig`):
 ///
 /// - `SCHEMA_REGISTRY_URL` — base URL of the Schema Registry (e.g. `http://schema-registry:8081`).
-/// - `SCHEMA_SUBJECT` — the SR subject name (commonly `<topic>-value`).
-/// - `SCHEMA_VERSION` — version identifier (`"latest"` or a numeric version). Defaults to `latest`.
 ///
-/// Confluent producers wrap each record in a 5-byte wire envelope (1 magic byte + 4-byte schema
-/// id). The pipeline uses `.skipBytes(5)` to drop that prefix before deserialization.
+/// Do NOT add `.skipBytes(5)` here — `withSchemaRegistry(...)` consumes the envelope itself.
 public final class App {
 
   private static final Logger LOGGER = System.getLogger(App.class.getName());
@@ -30,21 +30,13 @@ public final class App {
     final var props = KafkaConsumerConfig.createConsumerConfig(config.bootstrapServers(), config.consumerGroup());
 
     final var srUrl = requireEnv("SCHEMA_REGISTRY_URL");
-    final var subject = requireEnv("SCHEMA_SUBJECT");
-    final var version = System.getenv().getOrDefault("SCHEMA_VERSION", "latest");
-
-    final AvroFormat format;
-    try (final var resolver = new ConfluentSchemaResolver(srUrl, Duration.ofSeconds(10))) {
-      final var schemaJson = resolver.lookupBySubjectVersion(subject, version);
-      format = AvroFormat.of(schemaJson);
-      LOGGER.log(Level.INFO, "Resolved schema (subject={0}, version={1})", subject, version);
-    }
+    LOGGER.log(Level.INFO, "Wiring per-record SR auto-lookup against {0}", srUrl);
 
     try (
-      final var handle = KPipe.avro(format, config.topic(), props)
-        .skipBytes(5)
+      final var resolver = new CachedSchemaResolver(new ConfluentSchemaResolver(srUrl, Duration.ofSeconds(10)));
+      final var handle = KPipe.avro(config.topic(), props, resolver)
         .peek(rec -> LOGGER.log(Level.INFO, "received {0}", rec))
-        .toConsole()
+        .toCustom(rec -> LOGGER.log(Level.INFO, "decoded {0}", rec))
         .start()
     ) {
       LOGGER.log(Level.INFO, "Schema Registry Avro consumer started for topic {0}", config.topic());

--- a/lib/kpipe-api/src/main/java/org/kpipe/DefaultSink.java
+++ b/lib/kpipe-api/src/main/java/org/kpipe/DefaultSink.java
@@ -1,9 +1,13 @@
 package org.kpipe;
 
+import java.lang.System.Logger;
+import java.lang.System.Logger.Level;
 import java.util.Objects;
+import java.util.function.Consumer;
 import org.kpipe.consumer.KPipeConsumer;
 import org.kpipe.registry.MessagePipeline;
 import org.kpipe.registry.MessageProcessorRegistry;
+import org.kpipe.registry.Result;
 import org.kpipe.sink.MessageSink;
 
 /// Package-private [Sink] impl. Holds the configured [DefaultStream] plus the chosen terminal
@@ -12,6 +16,8 @@ import org.kpipe.sink.MessageSink;
 ///
 /// @param <T> the deserialized message type
 record DefaultSink<T>(DefaultStream<T> stream, MessageSink<T> terminalSink) implements Sink<T> {
+  private static final Logger LOGGER = System.getLogger(DefaultSink.class.getName());
+
   DefaultSink(final DefaultStream<T> stream, final MessageSink<T> terminalSink) {
     this.stream = Objects.requireNonNull(stream, "stream cannot be null");
     this.terminalSink = Objects.requireNonNull(terminalSink, "terminalSink cannot be null");
@@ -41,12 +47,70 @@ record DefaultSink<T>(DefaultStream<T> stream, MessageSink<T> terminalSink) impl
   }
 
   /// Builds the [MessagePipeline] for this sink's stream + terminal sink. Reused by
-  /// [MultiBuilder] when assembling a per-topic pipeline map.
+  /// [MultiBuilder] when assembling a per-topic pipeline map. Wraps the built pipeline with
+  /// observer dispatch when any of `onFiltered` / `onFailed` / `peekResult` is configured.
   MessagePipeline<?> buildPipeline() {
     final var registry = new MessageProcessorRegistry(stream.format());
     final var pipelineBuilder = registry.pipeline(stream.format()).skipBytes(stream.skipBytes());
     for (final var op : stream.operators()) pipelineBuilder.add(op);
-    return pipelineBuilder.toSink(terminalSink).build();
+    final var base = pipelineBuilder.toSink(terminalSink).build();
+    return wrapWithObservers(base);
+  }
+
+  private MessagePipeline<T> wrapWithObservers(final MessagePipeline<T> base) {
+    final var onFiltered = stream.onFilteredObserver();
+    final var onFailed = stream.onFailedObserver();
+    final var peek = stream.peekResultObserver();
+    if (onFiltered == null && onFailed == null && peek == null) return base;
+    return new MessagePipeline<T>() {
+      @Override
+      public T deserialize(final byte[] data) {
+        return base.deserialize(data);
+      }
+
+      @Override
+      public byte[] serialize(final T data) {
+        return base.serialize(data);
+      }
+
+      @Override
+      public Result<T> process(final T data) {
+        final var result = base.process(data);
+        if (peek != null) safeAccept(peek, result, "peekResult");
+        switch (result) {
+          case Result.Passed<T> __ -> {
+          }
+          case Result.Filtered<T> __ -> {
+            if (onFiltered != null) safeRun(onFiltered);
+          }
+          case Result.Failed<T> failed -> {
+            if (onFailed != null) safeAccept(onFailed, failed.cause(), "onFailed");
+          }
+        }
+        return result;
+      }
+
+      @Override
+      public MessageSink<T> getSink() {
+        return base.getSink();
+      }
+    };
+  }
+
+  private static void safeRun(final Runnable observer) {
+    try {
+      observer.run();
+    } catch (final RuntimeException e) {
+      LOGGER.log(Level.WARNING, "onFiltered observer threw; swallowing to keep the pipeline running", e);
+    }
+  }
+
+  private static <A> void safeAccept(final Consumer<A> observer, final A arg, final String name) {
+    try {
+      observer.accept(arg);
+    } catch (final RuntimeException e) {
+      LOGGER.log(Level.WARNING, name + " observer threw; swallowing to keep the pipeline running", e);
+    }
   }
 
   /// Exposes the configured stream for test inspection of composition.

--- a/lib/kpipe-api/src/main/java/org/kpipe/DefaultStream.java
+++ b/lib/kpipe-api/src/main/java/org/kpipe/DefaultStream.java
@@ -13,10 +13,13 @@ import java.util.function.Supplier;
 import java.util.function.UnaryOperator;
 import org.kpipe.consumer.CircuitBreakerController;
 import org.kpipe.consumer.KPipeConsumer;
+import org.kpipe.format.avro.AvroFormat;
 import org.kpipe.metrics.ConsumerMetrics;
 import org.kpipe.producer.tracing.Tracer;
 import org.kpipe.registry.MessageFormat;
 import org.kpipe.registry.Operators;
+import org.kpipe.registry.Result;
+import org.kpipe.registry.SchemaResolver;
 import org.kpipe.sink.BatchPolicy;
 import org.kpipe.sink.BatchSink;
 import org.kpipe.sink.CompositeMessageSink;
@@ -50,7 +53,10 @@ record DefaultStream<T>(
   String deadLetterTopic,
   Duration pollTimeout,
   Tracer tracer,
-  CircuitBreakerController circuitBreaker
+  CircuitBreakerController circuitBreaker,
+  Runnable onFilteredObserver,
+  Consumer<Throwable> onFailedObserver,
+  Consumer<Result<T>> peekResultObserver
 ) implements Stream<T> {
   /// Public constructor used by [KPipe] factories — single topic, empty pipeline, default
   /// retry / backpressure settings.
@@ -84,6 +90,9 @@ record DefaultStream<T>(
       null,
       false,
       0,
+      null,
+      null,
+      null,
       null,
       null,
       null,
@@ -165,6 +174,26 @@ record DefaultStream<T>(
   }
 
   @Override
+  public Stream<T> withSchemaRegistry(final SchemaResolver resolver) {
+    Objects.requireNonNull(resolver, "resolver cannot be null");
+    @SuppressWarnings("unchecked")
+    final var newFormat = (MessageFormat<T>) registryBackedFormat(format, resolver);
+    return mutate(m -> m.format = newFormat);
+  }
+
+  /// Returns a registry-backed variant of `format` for any format type that supports it. Today
+  /// this is Avro only — Protobuf SR auto-lookup needs runtime `.proto` text compilation and
+  /// has not shipped.
+  private static MessageFormat<?> registryBackedFormat(final MessageFormat<?> format, final SchemaResolver resolver) {
+    if (format instanceof AvroFormat) return AvroFormat.withRegistry(resolver);
+    throw new UnsupportedOperationException(
+      "withSchemaRegistry is not supported for format " +
+        format.getClass().getSimpleName() +
+        " — currently only Avro is wired for per-record schema lookup. Protobuf SR auto-lookup is on the roadmap."
+    );
+  }
+
+  @Override
   public Stream<T> withMetrics(final ConsumerMetrics metrics) {
     Objects.requireNonNull(metrics, "metrics cannot be null");
     return mutate(m -> m.consumerMetrics = metrics);
@@ -207,6 +236,24 @@ record DefaultStream<T>(
   public Stream<T> withCircuitBreaker(final CircuitBreakerController controller) {
     Objects.requireNonNull(controller, "controller cannot be null");
     return mutate(m -> m.circuitBreaker = controller);
+  }
+
+  @Override
+  public Stream<T> onFiltered(final Runnable observer) {
+    Objects.requireNonNull(observer, "observer cannot be null");
+    return mutate(m -> m.onFilteredObserver = observer);
+  }
+
+  @Override
+  public Stream<T> onFailed(final Consumer<Throwable> observer) {
+    Objects.requireNonNull(observer, "observer cannot be null");
+    return mutate(m -> m.onFailedObserver = observer);
+  }
+
+  @Override
+  public Stream<T> peekResult(final Consumer<Result<T>> observer) {
+    Objects.requireNonNull(observer, "observer cannot be null");
+    return mutate(m -> m.peekResultObserver = observer);
   }
 
   @Override
@@ -274,6 +321,9 @@ record DefaultStream<T>(
     Duration pollTimeout;
     Tracer tracer;
     CircuitBreakerController circuitBreaker;
+    Runnable onFilteredObserver;
+    Consumer<Throwable> onFailedObserver;
+    Consumer<Result<T>> peekResultObserver;
 
     static <T> Mut<T> from(final DefaultStream<T> s) {
       final var m = new Mut<T>();
@@ -294,6 +344,9 @@ record DefaultStream<T>(
       m.pollTimeout = s.pollTimeout;
       m.tracer = s.tracer;
       m.circuitBreaker = s.circuitBreaker;
+      m.onFilteredObserver = s.onFilteredObserver;
+      m.onFailedObserver = s.onFailedObserver;
+      m.peekResultObserver = s.peekResultObserver;
       return m;
     }
 
@@ -315,7 +368,10 @@ record DefaultStream<T>(
         deadLetterTopic,
         pollTimeout,
         tracer,
-        circuitBreaker
+        circuitBreaker,
+        onFilteredObserver,
+        onFailedObserver,
+        peekResultObserver
       );
     }
   }

--- a/lib/kpipe-api/src/main/java/org/kpipe/KPipe.java
+++ b/lib/kpipe-api/src/main/java/org/kpipe/KPipe.java
@@ -13,6 +13,7 @@ import org.kpipe.format.avro.AvroFormat;
 import org.kpipe.format.json.JsonFormat;
 import org.kpipe.format.protobuf.ProtobufFormat;
 import org.kpipe.registry.MessageFormat;
+import org.kpipe.registry.SchemaResolver;
 import org.kpipe.sink.MessageSink;
 
 /// Top-level fluent facade for KPipe. Provides static factories for the supported message
@@ -80,6 +81,35 @@ public final class KPipe {
     final Properties kafkaProps
   ) {
     return new DefaultStream<>(topics, kafkaProps, format, format::consoleSink);
+  }
+
+  /// Avro-typed stream wired for per-record Confluent Schema Registry lookup. The wire envelope
+  /// is consumed by the format itself; do NOT pair this overload with `.skipBytes(5)`.
+  ///
+  /// Equivalent to `avro(AvroFormat.withRegistry(resolver), topic, kafkaProps)`. Provided so the
+  /// "Confluent Avro topic in one line" pitch is genuinely one line. Wrap the underlying SR
+  /// resolver with `CachedSchemaResolver` for the cache; that bookkeeping is your responsibility
+  /// since the resolver typically outlives a single stream.
+  ///
+  /// @param topic the Kafka topic to consume
+  /// @param kafkaProps the Kafka consumer properties
+  /// @param resolver the schema resolver (must be non-null; typically a `CachedSchemaResolver`)
+  /// @return a fluent [Stream] configured for Avro with per-record schema lookup
+  public static Stream<GenericRecord> avro(
+    final String topic,
+    final Properties kafkaProps,
+    final SchemaResolver resolver
+  ) {
+    final var format = AvroFormat.withRegistry(resolver);
+    return new DefaultStream<>(topic, kafkaProps, format, KPipe::registryModeConsoleSinkUnsupported);
+  }
+
+  private static MessageSink<GenericRecord> registryModeConsoleSinkUnsupported() {
+    throw new IllegalStateException(
+      "toConsole() requires a fixed schema; an AvroFormat in Schema-Registry mode has none. " +
+        "Use .toCustom(...) with your own sink, or construct the stream via " +
+        "KPipe.avro(new AvroFormat(schema), topic, props) to keep the console-sink path."
+    );
   }
 
   /// Protobuf-typed stream consuming from `topic` using `format` for SerDe. Construct the format

--- a/lib/kpipe-api/src/main/java/org/kpipe/Stream.java
+++ b/lib/kpipe-api/src/main/java/org/kpipe/Stream.java
@@ -8,6 +8,8 @@ import org.kpipe.consumer.CircuitBreakerController;
 import org.kpipe.consumer.KPipeConsumer;
 import org.kpipe.metrics.ConsumerMetrics;
 import org.kpipe.producer.tracing.Tracer;
+import org.kpipe.registry.Result;
+import org.kpipe.registry.SchemaResolver;
 import org.kpipe.sink.BatchPolicy;
 import org.kpipe.sink.BatchSink;
 import org.kpipe.sink.MessageSink;
@@ -164,6 +166,52 @@ public interface Stream<T> {
   /// @throws NullPointerException if `controller` is null
   Stream<T> withCircuitBreaker(final CircuitBreakerController controller);
 
+  /// Returns a new stream that invokes `observer` whenever a record is intentionally filtered
+  /// (an operator returned `null`). The observer is for visibility — it does **not** affect
+  /// pipeline flow, suppress the filter, or reroute the record. Use [#withErrorHandler] or
+  /// [#withDeadLetterTopic] for real failure routing; this is purely a hook for logging and
+  /// metrics.
+  ///
+  /// Runs on the consumer thread immediately after the pipeline returns `Filtered`. If the
+  /// observer throws, the exception is logged at WARNING and swallowed so observer bugs cannot
+  /// crash the pipeline. Calling this method more than once replaces the previous observer —
+  /// for fan-out, compose externally.
+  ///
+  /// @param observer a side-effect invoked when a record is filtered (must not be null)
+  /// @return a new stream with the observer attached
+  /// @throws NullPointerException if `observer` is null
+  Stream<T> onFiltered(final Runnable observer);
+
+  /// Returns a new stream that invokes `observer` with the captured cause whenever the pipeline
+  /// returns `Failed`. The observer is for visibility — it does **not** suppress the failure or
+  /// stop the failure from reaching retry / DLQ / `withErrorHandler` logic.
+  ///
+  /// Runs on the consumer thread immediately after the pipeline returns `Failed`. If the
+  /// observer throws, the exception is logged at WARNING and swallowed. Calling this method more
+  /// than once replaces the previous observer.
+  ///
+  /// **Use this for the §12 visibility burn.** When `messagesProcessed` rises but the sink stays
+  /// at 0, attach `onFailed(cause -> log.warn("pipeline failed", cause))` to surface what's
+  /// actually being lost.
+  ///
+  /// @param observer a side-effect invoked with the failure cause (must not be null)
+  /// @return a new stream with the observer attached
+  /// @throws NullPointerException if `observer` is null
+  Stream<T> onFailed(final Consumer<Throwable> observer);
+
+  /// Returns a new stream that invokes `observer` with every [Result] the pipeline produces —
+  /// `Passed`, `Filtered`, or `Failed`. The lowest-level observer hook; use this for full
+  /// pattern-matching diagnostic taps. Does **not** affect pipeline flow.
+  ///
+  /// Runs on the consumer thread before any downstream sink invocation. If the observer throws,
+  /// the exception is logged at WARNING and swallowed. Calling this method more than once
+  /// replaces the previous observer.
+  ///
+  /// @param observer a side-effect invoked with every pipeline outcome (must not be null)
+  /// @return a new stream with the observer attached
+  /// @throws NullPointerException if `observer` is null
+  Stream<T> peekResult(final Consumer<Result<T>> observer);
+
   /// Returns a new stream with a custom error handler. The handler is invoked after retries are
   /// exhausted (or immediately when `maxRetries == 0`) with the failing record, the exception,
   /// and the retry count. The default handler logs at WARNING.
@@ -196,10 +244,36 @@ public interface Stream<T> {
   /// (1 magic + 4 schema id) for Avro, or 6-byte envelope (5 + 1 message-index varint) for the
   /// single-top-level-message Protobuf case.
   ///
+  /// Prefer [#withSchemaRegistry(SchemaResolver)] for Avro on Confluent SR — it consumes the
+  /// envelope and resolves the correct writer schema per record, which is also what makes
+  /// schema-evolution-correct decoding work. `skipBytes(5)` only strips the prefix; it does not
+  /// fix the static-reader-schema correctness hole described in the project README.
+  ///
   /// @param n the number of leading bytes to skip (must be ≥ 0)
   /// @return a new stream with the skip configured
   /// @throws IllegalArgumentException if `n` is negative
   Stream<T> skipBytes(final int n);
+
+  /// Switches the stream's format into Schema-Registry mode. Only supported when the originating
+  /// format honours the [SchemaResolver] SPI — at the time of writing, [Avro
+  /// (`kpipe-format-avro`)](https://github.com/eschizoid/kpipe). Each record's Confluent wire
+  /// envelope (1-byte magic + 4-byte schema ID) is consumed inside the format, the writer schema
+  /// is resolved via `resolver` (cache it with `CachedSchemaResolver` from
+  /// `kpipe-schema-registry-confluent`), and the remaining bytes are decoded against that
+  /// schema. Do NOT combine with `skipBytes(5)` — the format already strips the envelope.
+  ///
+  /// **Protobuf is not yet supported** through this entry point. Protobuf SR auto-lookup
+  /// requires runtime `.proto` text compilation (protoc-jar) which is out of scope for the
+  /// current release; use `kpipe-format-protobuf` with `skipBytes(6)` and a single descriptor
+  /// for now.
+  ///
+  /// @param resolver the schema resolver (typically a `CachedSchemaResolver` wrapping a
+  ///                 `ConfluentSchemaResolver`)
+  /// @return a new stream with the registry-backed format wired in
+  /// @throws NullPointerException if `resolver` is null
+  /// @throws UnsupportedOperationException if the underlying format does not support
+  ///         registry-backed mode
+  Stream<T> withSchemaRegistry(final SchemaResolver resolver);
 
   /// Terminates the stream with a format-appropriate console sink and returns a [Sink] ready
   /// to start. For Avro streams this requires that a default schema has been registered; see

--- a/lib/kpipe-api/src/test/java/org/kpipe/StreamResultObserversTest.java
+++ b/lib/kpipe-api/src/test/java/org/kpipe/StreamResultObserversTest.java
@@ -1,0 +1,214 @@
+package org.kpipe;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.util.Map;
+import java.util.Properties;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+import org.junit.jupiter.api.Test;
+import org.kpipe.registry.Result;
+import org.kpipe.sink.MessageSink;
+
+/// Exercises the [Stream] fluent facade's `onFiltered` / `onFailed` / `peekResult` observer
+/// hooks. The pipeline is built via the public facade and driven through `processToSink` so we
+/// exercise the same wrapping path the live consumer takes — no Kafka required.
+class StreamResultObserversTest {
+
+  private static Properties props() {
+    final var p = new Properties();
+    p.setProperty("bootstrap.servers", "localhost:9092");
+    p.setProperty("group.id", "test-group");
+    return p;
+  }
+
+  private static DefaultSink<Map<String, Object>> sinkWith(final MessageSink<Map<String, Object>> terminal) {
+    return (DefaultSink<Map<String, Object>>) KPipe.json("topic", props()).toCustom(terminal);
+  }
+
+  @Test
+  void onFilteredFiresWhenAnOperatorReturnsNull() {
+    final var fired = new AtomicInteger();
+    @SuppressWarnings("unchecked")
+    final var sink = (DefaultSink<Map<String, Object>>) KPipe.json("topic", props())
+      .filter(m -> false)
+      .onFiltered(fired::incrementAndGet)
+      .toCustom(m -> {});
+
+    @SuppressWarnings("unchecked")
+    final var pipeline = (org.kpipe.registry.MessagePipeline<Map<String, Object>>) sink.buildPipeline();
+    pipeline.processToSink("{}".getBytes());
+
+    assertEquals(1, fired.get());
+  }
+
+  @Test
+  void onFilteredDoesNotFireForPassedRecords() {
+    final var fired = new AtomicInteger();
+    @SuppressWarnings("unchecked")
+    final var sink = (DefaultSink<Map<String, Object>>) KPipe.json("topic", props())
+      .onFiltered(fired::incrementAndGet)
+      .toCustom(m -> {});
+
+    @SuppressWarnings("unchecked")
+    final var pipeline = (org.kpipe.registry.MessagePipeline<Map<String, Object>>) sink.buildPipeline();
+    pipeline.processToSink("{\"k\":\"v\"}".getBytes());
+
+    assertEquals(0, fired.get());
+  }
+
+  @Test
+  void onFailedReceivesTheCauseAndPipelineStillThrows() {
+    final var capturedCause = new AtomicReference<Throwable>();
+    final var boom = new RuntimeException("boom");
+    @SuppressWarnings("unchecked")
+    final var sink = (DefaultSink<Map<String, Object>>) KPipe.json("topic", props())
+      .pipe(m -> {
+        throw boom;
+      })
+      .onFailed(capturedCause::set)
+      .toCustom(m -> {});
+
+    @SuppressWarnings("unchecked")
+    final var pipeline = (org.kpipe.registry.MessagePipeline<Map<String, Object>>) sink.buildPipeline();
+    final var thrown = assertThrows(RuntimeException.class, () -> pipeline.processToSink("{}".getBytes()));
+
+    assertSame(boom, thrown);
+    assertSame(boom, capturedCause.get());
+  }
+
+  @Test
+  void peekResultFiresOnEveryOutcome() {
+    final var passed = new AtomicInteger();
+    final var filtered = new AtomicInteger();
+    final var failed = new AtomicInteger();
+    @SuppressWarnings("unchecked")
+    final var sink = (DefaultSink<Map<String, Object>>) KPipe.json("topic", props())
+      .filter(m -> m.containsKey("keep"))
+      .pipe(m -> {
+        if (m.containsKey("explode")) throw new RuntimeException("nope");
+        return m;
+      })
+      .peekResult(result -> {
+        switch (result) {
+          case Result.Passed<Map<String, Object>> __ -> passed.incrementAndGet();
+          case Result.Filtered<Map<String, Object>> __ -> filtered.incrementAndGet();
+          case Result.Failed<Map<String, Object>> __ -> failed.incrementAndGet();
+        }
+      })
+      .toCustom(m -> {});
+
+    @SuppressWarnings("unchecked")
+    final var pipeline = (org.kpipe.registry.MessagePipeline<Map<String, Object>>) sink.buildPipeline();
+    pipeline.processToSink("{\"keep\":\"yes\"}".getBytes());
+    pipeline.processToSink("{\"drop\":\"me\"}".getBytes());
+    assertThrows(RuntimeException.class, () -> pipeline.processToSink("{\"keep\":\"yes\",\"explode\":1}".getBytes()));
+
+    assertEquals(1, passed.get());
+    assertEquals(1, filtered.get());
+    assertEquals(1, failed.get());
+  }
+
+  @Test
+  void observerExceptionsAreSwallowedSoPipelineStaysAlive() {
+    @SuppressWarnings("unchecked")
+    final var sink = (DefaultSink<Map<String, Object>>) KPipe.json("topic", props())
+      .filter(m -> false)
+      .onFiltered(() -> {
+        throw new RuntimeException("observer bug");
+      })
+      .toCustom(m -> {});
+
+    @SuppressWarnings("unchecked")
+    final var pipeline = (org.kpipe.registry.MessagePipeline<Map<String, Object>>) sink.buildPipeline();
+    pipeline.processToSink("{}".getBytes()); // must not throw despite observer bug
+  }
+
+  @Test
+  void noObserverConfiguredMeansNoWrapper() {
+    @SuppressWarnings("unchecked")
+    final var sink = (DefaultSink<Map<String, Object>>) KPipe.json("topic", props())
+      .pipe(m -> {
+        m.put("x", 1);
+        return m;
+      })
+      .toCustom(m -> {});
+
+    // We can't easily assert "is not the wrapper class" because the wrapper is anonymous, but
+    // we can confirm the pipeline still works without observers configured.
+    final var pipeline = sink.buildPipeline();
+    assertNotNull(pipeline);
+  }
+
+  @Test
+  void observersDoNotAffectFilterReturnValue() {
+    final var seenAtSink = new AtomicReference<Map<String, Object>>();
+    @SuppressWarnings("unchecked")
+    final var sink = (DefaultSink<Map<String, Object>>) KPipe.json("topic", props())
+      .filter(m -> false)
+      .onFiltered(() -> {
+        // observer is a side-effect — must not suppress the filter
+      })
+      .toCustom((Map<String, Object> v) -> seenAtSink.set(v));
+
+    @SuppressWarnings("unchecked")
+    final var pipeline = (org.kpipe.registry.MessagePipeline<Map<String, Object>>) sink.buildPipeline();
+    pipeline.processToSink("{\"any\":\"value\"}".getBytes());
+
+    assertNull(seenAtSink.get(), "filtered records must not reach the sink");
+  }
+
+  @Test
+  void nullObserversAreRejected() {
+    final var stream = KPipe.json("topic", props());
+    assertThrows(NullPointerException.class, () -> stream.onFiltered(null));
+    assertThrows(NullPointerException.class, () -> stream.onFailed(null));
+    assertThrows(NullPointerException.class, () -> stream.peekResult(null));
+  }
+
+  @Test
+  void lastWriteWinsForRepeatedObserverCalls() {
+    final var first = new AtomicInteger();
+    final var second = new AtomicInteger();
+    @SuppressWarnings("unchecked")
+    final var sink = (DefaultSink<Map<String, Object>>) KPipe.json("topic", props())
+      .filter(m -> false)
+      .onFiltered(first::incrementAndGet)
+      .onFiltered(second::incrementAndGet)
+      .toCustom(m -> {});
+
+    @SuppressWarnings("unchecked")
+    final var pipeline = (org.kpipe.registry.MessagePipeline<Map<String, Object>>) sink.buildPipeline();
+    pipeline.processToSink("{}".getBytes());
+
+    assertEquals(0, first.get(), "first observer must be replaced by the second call");
+    assertEquals(1, second.get());
+  }
+
+  @Test
+  void onFailedDoesNotFireOnFilteredOrPassed() {
+    final var failedFired = new AtomicInteger();
+    @SuppressWarnings("unchecked")
+    final var sink = (DefaultSink<Map<String, Object>>) KPipe.json("topic", props())
+      .filter(m -> m.containsKey("keep"))
+      .onFailed(_ -> failedFired.incrementAndGet())
+      .toCustom(m -> {});
+
+    @SuppressWarnings("unchecked")
+    final var pipeline = (org.kpipe.registry.MessagePipeline<Map<String, Object>>) sink.buildPipeline();
+    pipeline.processToSink("{\"keep\":\"yes\"}".getBytes());
+    pipeline.processToSink("{\"drop\":\"me\"}".getBytes());
+
+    assertEquals(0, failedFired.get());
+  }
+
+  // Suppresses the unused-variable warning on sinkWith — kept for readability of test setups.
+  @SuppressWarnings("unused")
+  private static void useSinkWith(final MessageSink<Map<String, Object>> s) {
+    sinkWith(s);
+  }
+}

--- a/lib/kpipe-core/src/main/java/org/kpipe/registry/MessageProcessorRegistry.java
+++ b/lib/kpipe-core/src/main/java/org/kpipe/registry/MessageProcessorRegistry.java
@@ -24,11 +24,11 @@ import org.kpipe.sink.MessageSink;
 /// final var registry = new MessageProcessorRegistry(JsonFormat.INSTANCE);
 ///
 /// // Operator side
-/// registry.register(RegistryKey.json("addTimestamp"),
-///                   m -> { m.put("ts", System.currentTimeMillis()); return m; });
+/// registry.registerOperator(RegistryKey.json("addTimestamp"),
+///                           m -> { m.put("ts", System.currentTimeMillis()); return m; });
 ///
-/// // Sink side — same `register`, just a different functional interface
-/// registry.register(RegistryKey.json("dbSink"), record -> database.insert(record));
+/// // Sink side
+/// registry.registerSink(RegistryKey.json("dbSink"), record -> database.insert(record));
 ///
 /// // Build a pipeline that uses both
 /// final var pipeline = registry.pipeline(JsonFormat.INSTANCE)
@@ -37,9 +37,9 @@ import org.kpipe.sink.MessageSink;
 ///   .build();
 /// ```
 ///
-/// **Concurrency**: both maps are [ConcurrentHashMap]s; `register`/`get*`/`unregister*` are
-/// thread-safe. Lookups return wrapping operators/sinks that read the current map entry at
-/// invocation time, so live re-registration is observable.
+/// **Concurrency**: both maps are [ConcurrentHashMap]s; `registerOperator`/`registerSink`/`get*`/
+/// `unregister*` are thread-safe. Lookups return wrapping operators/sinks that read the current
+/// map entry at invocation time, so live re-registration is observable.
 public class MessageProcessorRegistry {
 
   private static final Logger LOGGER = System.getLogger(MessageProcessorRegistry.class.getName());
@@ -132,7 +132,7 @@ public class MessageProcessorRegistry {
   /// @param key      the registry key (must be non-null)
   /// @param operator the operator to register (must be non-null)
   /// @param <T>      the pipeline value type the operator acts on
-  public <T> void register(final RegistryKey<T> key, final UnaryOperator<T> operator) {
+  public <T> void registerOperator(final RegistryKey<T> key, final UnaryOperator<T> operator) {
     Objects.requireNonNull(key, "key cannot be null");
     Objects.requireNonNull(operator, "operator cannot be null");
     operators.put(key, operator);
@@ -149,7 +149,7 @@ public class MessageProcessorRegistry {
     Objects.requireNonNull(type, "type cannot be null");
     Objects.requireNonNull(enumClass, "enumClass cannot be null");
     for (final var constant : enumClass.getEnumConstants()) {
-      register(RegistryKey.of(constant.name(), type), constant);
+      registerOperator(RegistryKey.of(constant.name(), type), constant);
     }
   }
 
@@ -216,19 +216,18 @@ public class MessageProcessorRegistry {
   /// @param operator the operator to wrap
   /// @param <T>      the pipeline value type
   /// @return a new operator that logs and swallows exceptions raised by the original
-  public static <T> UnaryOperator<T> withErrorHandling(final UnaryOperator<T> operator) {
+  public static <T> UnaryOperator<T> withOperatorErrorHandling(final UnaryOperator<T> operator) {
     return RegistryFunctions.withOperatorErrorHandling(operator, LOGGER);
   }
 
   // ───────────────────────────── Sinks ─────────────────────────────
 
-  /// Registers a typed sink under `key`. Overload of the operator [#register] — Java resolves
-  /// by argument type ([UnaryOperator] vs [MessageSink]).
+  /// Registers a typed sink under `key`.
   ///
   /// @param key  the registry key (must be non-null)
   /// @param sink the sink to register (must be non-null)
   /// @param <T>  the pipeline value type the sink consumes
-  public <T> void register(final RegistryKey<T> key, final MessageSink<T> sink) {
+  public <T> void registerSink(final RegistryKey<T> key, final MessageSink<T> sink) {
     Objects.requireNonNull(key, "key cannot be null");
     Objects.requireNonNull(sink, "sink cannot be null");
     sinks.put(key, sink);
@@ -244,7 +243,7 @@ public class MessageProcessorRegistry {
     Objects.requireNonNull(type, "type cannot be null");
     Objects.requireNonNull(enumClass, "enumClass cannot be null");
     for (final var constant : enumClass.getEnumConstants()) {
-      register(RegistryKey.of(constant.name(), type), constant);
+      registerSink(RegistryKey.of(constant.name(), type), constant);
     }
   }
 
@@ -300,13 +299,12 @@ public class MessageProcessorRegistry {
     return sinks.metrics(key);
   }
 
-  /// Wraps a sink with error-handling logic that suppresses exceptions. Overload of the operator
-  /// [#withErrorHandling(UnaryOperator)] — Java resolves by argument type.
+  /// Wraps a sink with error-handling logic that suppresses exceptions.
   ///
   /// @param sink the sink to wrap
   /// @param <T>  the pipeline value type
   /// @return a new sink that logs and swallows exceptions raised by the original
-  public static <T> MessageSink<T> withErrorHandling(final MessageSink<T> sink) {
+  public static <T> MessageSink<T> withSinkErrorHandling(final MessageSink<T> sink) {
     return RegistryFunctions.withConsumerErrorHandling(sink, LOGGER)::accept;
   }
 

--- a/lib/kpipe-core/src/main/java/org/kpipe/registry/Operators.java
+++ b/lib/kpipe-core/src/main/java/org/kpipe/registry/Operators.java
@@ -100,8 +100,8 @@ public final class Operators {
   /// Wraps an operator with error handling that suppresses exceptions and returns the original
   /// input on failure.
   ///
-  /// Convenience facade over [MessageProcessorRegistry#withErrorHandling] so users can stay on
-  /// the [Operators] namespace without importing the registry just to wrap an operator.
+  /// Convenience facade over [MessageProcessorRegistry#withOperatorErrorHandling] so users can
+  /// stay on the [Operators] namespace without importing the registry just to wrap an operator.
   ///
   /// Example:
   /// ```java
@@ -112,7 +112,7 @@ public final class Operators {
   /// @param <T> the operator's value type
   /// @return an operator that returns its input on exception (logged via the registry's logger)
   public static <T> UnaryOperator<T> safe(final UnaryOperator<T> op) {
-    return MessageProcessorRegistry.withErrorHandling(op);
+    return MessageProcessorRegistry.withOperatorErrorHandling(op);
   }
 
   /// Returns an operator that filters out messages missing the given field.

--- a/lib/kpipe-core/src/main/java/org/kpipe/registry/PipelineDiagnostics.java
+++ b/lib/kpipe-core/src/main/java/org/kpipe/registry/PipelineDiagnostics.java
@@ -1,0 +1,83 @@
+package org.kpipe.registry;
+
+/// Builds diagnostic messages for deserialization failures at the byte boundary.
+///
+/// The §12 burn (protobuf seed messages failing decode because `skipBytes(5)` was wrong for the
+/// proto wire envelope) cost real debugging hours. The signal was indirect — `messagesProcessed`
+/// rising while `sinkInvocationCount` stayed at 0 — because the exception message gave no hint
+/// that the bytes looked like a Confluent envelope. This helper closes that gap: on a failing
+/// deserialize it hex-dumps the leading bytes and, when the payload looks like a Confluent
+/// magic-byte envelope and the caller forgot to set `skipBytes(...)`, suggests the right count
+/// for the configured format.
+final class PipelineDiagnostics {
+
+  private static final int HEX_DUMP_BYTES = 16;
+  private static final byte CONFLUENT_MAGIC = 0x00;
+
+  private PipelineDiagnostics() {}
+
+  /// Wraps a deserialization failure with a hex dump of the leading bytes and (when applicable)
+  /// a hint about a missing `skipBytes(...)` call.
+  ///
+  /// @param data              the bytes handed to `format.deserialize(...)` after any configured
+  ///                          `skipBytes` was applied (may be the original record when
+  ///                          `skipBytes == 0`)
+  /// @param configuredSkip    the `skipBytes` value the pipeline was built with — only the
+  ///                          zero case triggers a "you may need to skip the envelope" hint
+  /// @param formatClassName   the simple name of the `MessageFormat` impl, used to pick the
+  ///                          right skipBytes suggestion (Avro = 5, Protobuf = 6)
+  /// @param cause             the exception thrown by the format
+  /// @return a `RuntimeException` whose message carries the diagnostic; the original cause is
+  ///         preserved via `getCause()`
+  static RuntimeException wrap(
+    final byte[] data,
+    final int configuredSkip,
+    final String formatClassName,
+    final RuntimeException cause
+  ) {
+    final var msg = new StringBuilder("Deserialization failed");
+    if (formatClassName != null) msg.append(" in ").append(formatClassName);
+    msg.append(": ").append(cause.getMessage() == null ? cause.getClass().getSimpleName() : cause.getMessage());
+    if (data != null && data.length > 0) {
+      msg.append(". Leading bytes: ").append(hexDump(data));
+      if (configuredSkip == 0 && data[0] == CONFLUENT_MAGIC) {
+        final var suggestion = suggestionFor(formatClassName);
+        if (suggestion != null) {
+          msg
+            .append(". First byte is 0x00 — looks like a Confluent Schema Registry envelope. ")
+            .append("Did you forget ")
+            .append(suggestion)
+            .append("?");
+        }
+      }
+    } else if (data == null) {
+      msg.append(". Payload: null");
+    } else {
+      msg.append(". Payload: empty");
+    }
+    return new RuntimeException(msg.toString(), cause);
+  }
+
+  private static String suggestionFor(final String formatClassName) {
+    if (formatClassName == null) return null;
+    final var lower = formatClassName.toLowerCase();
+    if (lower.contains("avro")) return "`.skipBytes(5)` for the 1-byte magic + 4-byte schema ID";
+    if (lower.contains("protobuf") || lower.contains("proto")) {
+      return "`.skipBytes(6)` for the 1-byte magic + 4-byte schema ID + 1-byte message-index header (single-message variant)";
+    }
+    return null;
+  }
+
+  private static String hexDump(final byte[] data) {
+    final var n = Math.min(data.length, HEX_DUMP_BYTES);
+    final var sb = new StringBuilder(2 + n * 3);
+    sb.append('[');
+    for (int i = 0; i < n; i++) {
+      if (i > 0) sb.append(' ');
+      sb.append(String.format("%02x", data[i] & 0xff));
+    }
+    if (data.length > n) sb.append(" …(").append(data.length).append(" bytes total)");
+    sb.append(']');
+    return sb.toString();
+  }
+}

--- a/lib/kpipe-core/src/main/java/org/kpipe/registry/TypedPipelineBuilder.java
+++ b/lib/kpipe-core/src/main/java/org/kpipe/registry/TypedPipelineBuilder.java
@@ -119,13 +119,22 @@ public final class TypedPipelineBuilder<T> {
       @Override
       public T deserialize(byte[] data) {
         if (data == null) return null;
+        final var formatName = format.getClass().getSimpleName();
         if (bytesToSkip > 0) {
           if (data.length <= bytesToSkip) return null;
           final var actualData = new byte[data.length - bytesToSkip];
           System.arraycopy(data, bytesToSkip, actualData, 0, actualData.length);
-          return format.deserialize(actualData);
+          try {
+            return format.deserialize(actualData);
+          } catch (final RuntimeException e) {
+            throw PipelineDiagnostics.wrap(data, bytesToSkip, formatName, e);
+          }
         }
-        return format.deserialize(data);
+        try {
+          return format.deserialize(data);
+        } catch (final RuntimeException e) {
+          throw PipelineDiagnostics.wrap(data, 0, formatName, e);
+        }
       }
 
       @Override

--- a/lib/kpipe-core/src/test/java/org/kpipe/registry/MessageProcessorRegistrySinksTest.java
+++ b/lib/kpipe-core/src/test/java/org/kpipe/registry/MessageProcessorRegistrySinksTest.java
@@ -28,7 +28,7 @@ class MessageProcessorRegistrySinksTest {
     final var testSink = mock(MessageSink.class);
     final var key = RegistryKey.of("testSink", Object.class);
 
-    registry.register(key, testSink);
+    registry.registerSink(key, testSink);
     final var retrieved = registry.getSink(key);
 
     assertNotNull(retrieved);
@@ -40,7 +40,7 @@ class MessageProcessorRegistrySinksTest {
   void shouldUnregisterSink() {
     final var testSink = mock(MessageSink.class);
     final var key = RegistryKey.<Object>of("sinkToRemove", Object.class);
-    registry.register(key, testSink);
+    registry.registerSink(key, testSink);
 
     assertTrue(registry.getAllSinks().containsKey(key));
     final var removed = registry.unregisterSink(key);
@@ -52,7 +52,7 @@ class MessageProcessorRegistrySinksTest {
   @Test
   void shouldClearAllSinks() {
     final var testSink = mock(MessageSink.class);
-    registry.register(RegistryKey.of("testSink", Object.class), testSink);
+    registry.registerSink(RegistryKey.of("testSink", Object.class), testSink);
 
     registry.clearSinks();
 
@@ -63,7 +63,7 @@ class MessageProcessorRegistrySinksTest {
   void shouldNotClearSinksWhenClearingOperators() {
     final var testSink = mock(MessageSink.class);
     final var sinkKey = RegistryKey.of("aSink", Object.class);
-    registry.register(sinkKey, testSink);
+    registry.registerSink(sinkKey, testSink);
 
     registry.clear(); // operator-side only
 
@@ -78,8 +78,8 @@ class MessageProcessorRegistrySinksTest {
     final var key1 = RegistryKey.of("sink1", Object.class);
     final var key2 = RegistryKey.of("sink2", Object.class);
 
-    registry.register(key1, sink1);
-    registry.register(key2, sink2);
+    registry.registerSink(key1, sink1);
+    registry.registerSink(key2, sink2);
 
     registry.compositeSink(key1, key2).accept("processed");
 
@@ -97,8 +97,8 @@ class MessageProcessorRegistrySinksTest {
     final var keyFailing = RegistryKey.of("failingSink", Object.class);
     final var keyWorking = RegistryKey.of("workingSink", Object.class);
 
-    registry.register(keyFailing, failingSink);
-    registry.register(keyWorking, workingSink);
+    registry.registerSink(keyFailing, failingSink);
+    registry.registerSink(keyWorking, workingSink);
 
     registry.compositeSink(keyFailing, keyWorking).accept("processed");
 
@@ -111,7 +111,7 @@ class MessageProcessorRegistrySinksTest {
     final MessageSink<Object> countingSink = value -> callCount.incrementAndGet();
 
     final var key = RegistryKey.of("countingSink", Object.class);
-    registry.register(key, countingSink);
+    registry.registerSink(key, countingSink);
     final var sink = registry.getSink(key);
 
     sink.accept("processed");
@@ -129,7 +129,7 @@ class MessageProcessorRegistrySinksTest {
     };
 
     final var key = RegistryKey.of("failingSink", Object.class);
-    registry.register(key, failingSink);
+    registry.registerSink(key, failingSink);
     final var sink = registry.getSink(key);
 
     try {
@@ -149,7 +149,7 @@ class MessageProcessorRegistrySinksTest {
       throw new RuntimeException("Test failure");
     };
 
-    final var safeSink = MessageProcessorRegistry.withErrorHandling(failingSink);
+    final var safeSink = MessageProcessorRegistry.withSinkErrorHandling(failingSink);
 
     safeSink.accept("processed"); // must not throw
   }
@@ -163,13 +163,13 @@ class MessageProcessorRegistrySinksTest {
   @Test
   void shouldRejectNullKey() {
     final var testSink = mock(MessageSink.class);
-    assertThrows(NullPointerException.class, () -> registry.register(null, testSink));
+    assertThrows(NullPointerException.class, () -> registry.registerSink(null, testSink));
   }
 
   @Test
   void shouldRejectNullSink() {
     assertThrows(NullPointerException.class, () ->
-      registry.register(RegistryKey.<Object>of("test", Object.class), (MessageSink<Object>) null)
+      registry.registerSink(RegistryKey.<Object>of("test", Object.class), (MessageSink<Object>) null)
     );
   }
 
@@ -178,7 +178,7 @@ class MessageProcessorRegistrySinksTest {
     final var key = RegistryKey.<String>of("typedSink", String.class);
     @SuppressWarnings("unchecked")
     final MessageSink<String> testSink = mock(MessageSink.class);
-    registry.register(key, testSink);
+    registry.registerSink(key, testSink);
 
     final var retrieved = registry.getSink(key);
     retrieved.accept("processed");
@@ -189,7 +189,7 @@ class MessageProcessorRegistrySinksTest {
   @Test
   void shouldThrowOnTypeMismatch() {
     final var key = RegistryKey.<String>of("typedSink", String.class);
-    registry.register(key, (MessageSink<String>) msg -> {});
+    registry.registerSink(key, (MessageSink<String>) msg -> {});
 
     assertThrows(ClassCastException.class, () -> {
       @SuppressWarnings("unchecked")

--- a/lib/kpipe-core/src/test/java/org/kpipe/registry/PipelineDiagnosticsTest.java
+++ b/lib/kpipe-core/src/test/java/org/kpipe/registry/PipelineDiagnosticsTest.java
@@ -1,0 +1,84 @@
+package org.kpipe.registry;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+class PipelineDiagnosticsTest {
+
+  @Test
+  void suggestsSkipBytes5ForAvroWhenPayloadStartsWithConfluentMagicByte() {
+    final var data = new byte[] { 0x00, 0x00, 0x00, 0x00, 0x42, 0x01, 0x02, 0x03 };
+    final var cause = new RuntimeException("Malformed data");
+
+    final var wrapped = PipelineDiagnostics.wrap(data, 0, "AvroFormat", cause);
+
+    assertTrue(wrapped.getMessage().contains("Confluent Schema Registry envelope"));
+    assertTrue(wrapped.getMessage().contains("`.skipBytes(5)`"));
+    assertSame(cause, wrapped.getCause());
+  }
+
+  @Test
+  void suggestsSkipBytes6ForProtobufWhenPayloadStartsWithConfluentMagicByte() {
+    final var data = new byte[] { 0x00, 0x00, 0x00, 0x00, 0x42, 0x00 };
+    final var wrapped = PipelineDiagnostics.wrap(data, 0, "ProtobufFormat", new RuntimeException("bad tag"));
+
+    assertTrue(wrapped.getMessage().contains("`.skipBytes(6)`"));
+  }
+
+  @Test
+  void doesNotSuggestSkipBytesWhenSkipAlreadyConfigured() {
+    final var data = new byte[] { 0x00, 0x00, 0x00, 0x00, 0x42, 0x01 };
+    final var wrapped = PipelineDiagnostics.wrap(data, 5, "AvroFormat", new RuntimeException("still wrong"));
+
+    assertTrue(wrapped.getMessage().contains("Deserialization failed"));
+    assertTrue(wrapped.getMessage().contains("Leading bytes"));
+    assertTrue(!wrapped.getMessage().contains("Confluent Schema Registry envelope"));
+  }
+
+  @Test
+  void doesNotSuggestSkipBytesWhenFirstByteIsNotMagic() {
+    final var data = new byte[] { 0x7b, 0x22, 0x66, 0x6f }; // {"fo
+    final var wrapped = PipelineDiagnostics.wrap(data, 0, "JsonFormat", new RuntimeException("not json"));
+
+    assertTrue(!wrapped.getMessage().contains("Confluent Schema Registry envelope"));
+    assertTrue(wrapped.getMessage().contains("Leading bytes: [7b 22 66 6f]"));
+  }
+
+  @Test
+  void doesNotSuggestForUnknownFormatEvenWithMagicByte() {
+    final var data = new byte[] { 0x00, 0x01, 0x02 };
+    final var wrapped = PipelineDiagnostics.wrap(data, 0, "CustomFormat", new RuntimeException("x"));
+
+    assertTrue(!wrapped.getMessage().contains("skipBytes"));
+  }
+
+  @Test
+  void truncatesLongPayloadAndReportsTotalLength() {
+    final var data = new byte[64];
+    for (int i = 0; i < data.length; i++) data[i] = (byte) i;
+    final var wrapped = PipelineDiagnostics.wrap(data, 0, "AvroFormat", new RuntimeException("bad"));
+
+    assertTrue(wrapped.getMessage().contains("…(64 bytes total)"));
+  }
+
+  @Test
+  void handlesEmptyAndNullPayloads() {
+    final var emptyWrapped = PipelineDiagnostics.wrap(new byte[0], 0, "AvroFormat", new RuntimeException("e"));
+    assertTrue(emptyWrapped.getMessage().contains("Payload: empty"));
+
+    final var nullWrapped = PipelineDiagnostics.wrap(null, 0, "AvroFormat", new RuntimeException("n"));
+    assertTrue(nullWrapped.getMessage().contains("Payload: null"));
+  }
+
+  @Test
+  void preservesOriginalCauseMessageInWrapper() {
+    final var cause = new IllegalArgumentException("Avro schema mismatch at field 'id'");
+    final var wrapped = PipelineDiagnostics.wrap(new byte[] { 0x7b }, 0, "JsonFormat", cause);
+
+    assertTrue(wrapped.getMessage().contains("Avro schema mismatch at field 'id'"));
+    assertEquals("Avro schema mismatch at field 'id'", wrapped.getCause().getMessage());
+  }
+}

--- a/lib/kpipe-format-avro/src/main/java/org/kpipe/format/avro/AvroFormat.java
+++ b/lib/kpipe-format-avro/src/main/java/org/kpipe/format/avro/AvroFormat.java
@@ -3,6 +3,7 @@ package org.kpipe.format.avro;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.util.Objects;
+import java.util.concurrent.ConcurrentHashMap;
 import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericDatumReader;
 import org.apache.avro.generic.GenericDatumWriter;
@@ -10,65 +11,130 @@ import org.apache.avro.generic.GenericRecord;
 import org.apache.avro.io.DecoderFactory;
 import org.apache.avro.io.EncoderFactory;
 import org.kpipe.registry.MessageFormat;
+import org.kpipe.registry.SchemaResolver;
 
-/// Avro codec for KPipe — stateless `MessageFormat<GenericRecord>` bound to a single [Schema].
-/// One schema per instance, no mutable state. For multiple schemas keyed by name, use
-/// [AvroSchemaCatalog] and pass the resolved schema here.
+/// Avro codec for KPipe. Operates in one of two modes:
+///
+/// **Static mode** — `new AvroFormat(schema)` or `AvroFormat.of(schemaJson)`. The codec is
+/// bound to a single [Schema] for both serialize and deserialize. Suitable for inline /
+/// classpath schemas or shops with strict append-only schema evolution (a v1-bound consumer
+/// can decode v2 producer bytes as long as evolution only appends optional fields).
+///
+/// **Schema-Registry mode** — `AvroFormat.withRegistry(resolver)`. The codec reads the
+/// Confluent wire envelope (1-byte magic + 4-byte big-endian schema ID) off each record,
+/// looks up the writer's schema via the provided [SchemaResolver], and decodes against it.
+/// Schemas resolved through the registry are cached in-process keyed by ID; cardinality is
+/// naturally bounded by how often producers register new schemas. Serialize is not supported
+/// in this mode (KPipe is a consumer-first library; if you need to write back to a topic
+/// through SR, construct a static-mode format with the writer schema you want).
 ///
 /// ```java
-/// // Direct: you have a Schema in hand.
-/// final var format = new AvroFormat(userSchema);
+/// // Static — schema in hand.
+/// final var fmt = new AvroFormat(userSchema);
 ///
-/// // Catalog-mediated: multiple schemas keyed by name.
+/// // Static — inline JSON.
+/// final var fmt = AvroFormat.of(userSchemaJson);
+///
+/// // Static — catalog-mediated.
 /// final var catalog = new AvroSchemaCatalog();
 /// catalog.add("user", userSchemaJson);
-/// final var format = new AvroFormat(catalog.get("user"));
+/// final var fmt = new AvroFormat(catalog.get("user"));
 ///
-/// // From inline JSON (the most common test/example shape):
-/// final var format = AvroFormat.of(userSchemaJson);
+/// // Schema-Registry — per-record auto-lookup.
+/// try (var resolver = new CachedSchemaResolver(
+///     new ConfluentSchemaResolver("http://schema-registry:8081"))) {
+///   final var fmt = AvroFormat.withRegistry(resolver);
+///   // fmt.deserialize(record.value()) reads the envelope, fetches the schema, decodes.
+/// }
 /// ```
+///
+/// Schema-Registry mode replaces the manual `KPipe.avro(...).skipBytes(5).pipe(...)` pattern.
+/// Do **not** combine `withRegistry(...)` with `skipBytes(5)` — the format already consumes
+/// the envelope.
 public final class AvroFormat implements MessageFormat<GenericRecord> {
 
-  private final Schema schema;
+  /// Confluent wire envelope: 1-byte magic (0x00) + 4-byte big-endian schema ID.
+  private static final int ENVELOPE_LENGTH = 5;
+  private static final byte CONFLUENT_MAGIC = 0x00;
 
-  /// Constructs a codec bound to `schema`.
+  private final Schema staticSchema;
+  private final SchemaResolver resolver;
+  private final ConcurrentHashMap<Integer, Schema> resolvedSchemas;
+
+  /// Constructs a static-mode codec bound to `schema`.
   ///
   /// @param schema the Avro schema used for both serialize and deserialize (must be non-null)
   public AvroFormat(final Schema schema) {
-    this.schema = Objects.requireNonNull(schema, "schema cannot be null");
+    this.staticSchema = Objects.requireNonNull(schema, "schema cannot be null");
+    this.resolver = null;
+    this.resolvedSchemas = null;
   }
 
-  /// Convenience constructor that parses the schema from inline JSON. Equivalent to
+  private AvroFormat(final SchemaResolver resolver) {
+    this.staticSchema = null;
+    this.resolver = Objects.requireNonNull(resolver, "resolver cannot be null");
+    this.resolvedSchemas = new ConcurrentHashMap<>();
+  }
+
+  /// Convenience factory that parses the schema from inline JSON. Equivalent to
   /// `new AvroFormat(new Schema.Parser().parse(schemaJson))`.
   ///
   /// @param schemaJson the Avro schema as JSON
-  /// @return a codec bound to the parsed schema
+  /// @return a static-mode codec bound to the parsed schema
   public static AvroFormat of(final String schemaJson) {
     Objects.requireNonNull(schemaJson, "schemaJson cannot be null");
     return new AvroFormat(new Schema.Parser().parse(schemaJson));
   }
 
-  /// Returns the schema this codec is bound to.
+  /// Constructs a Schema-Registry-backed codec. Each call to [#deserialize] reads the wire
+  /// envelope off the record, extracts the schema ID, looks up the writer's schema via
+  /// `resolver`, and decodes the remaining bytes against it. Resolved schemas are cached
+  /// internally by ID.
   ///
-  /// @return the bound schema (never null)
-  public Schema schema() {
-    return schema;
+  /// @param resolver schema resolver (typically wrap with `CachedSchemaResolver` for the
+  ///                 HTTP-call cache; this format also caches the parsed `Schema` per ID)
+  /// @return a registry-backed codec
+  public static AvroFormat withRegistry(final SchemaResolver resolver) {
+    return new AvroFormat(resolver);
   }
 
-  /// Creates a new [AvroConsoleSink] using this format's schema. Useful as the facade
-  /// `toConsole()` factory.
+  /// Returns true if this format reads the Confluent wire envelope per record.
+  ///
+  /// @return true in Schema-Registry mode, false in static mode
+  public boolean isRegistryBacked() {
+    return resolver != null;
+  }
+
+  /// Returns the schema this codec is bound to in static mode.
+  ///
+  /// @return the bound schema in static mode; null in Schema-Registry mode
+  public Schema schema() {
+    return staticSchema;
+  }
+
+  /// Creates an [AvroConsoleSink] using this format's schema. Only available in static mode.
   ///
   /// @return a console sink bound to this format's schema
+  /// @throws IllegalStateException if this format is in Schema-Registry mode
   public AvroConsoleSink<GenericRecord> consoleSink() {
-    return new AvroConsoleSink<>(schema);
+    if (staticSchema == null) throw new IllegalStateException(
+      "consoleSink() requires a static schema; AvroFormat.withRegistry(...) has no fixed schema. " +
+        "Either construct AvroFormat with a Schema, or instantiate AvroConsoleSink directly with the schema you want."
+    );
+    return new AvroConsoleSink<>(staticSchema);
   }
 
-  /// Serializes a `GenericRecord` to bytes using the bound schema.
+  /// Serializes a `GenericRecord` to bytes. Only available in static mode.
   ///
   /// @param data the record to serialize
   /// @return the binary-encoded bytes
+  /// @throws UnsupportedOperationException if this format is in Schema-Registry mode
   @Override
   public byte[] serialize(final GenericRecord data) {
+    if (resolver != null) throw new UnsupportedOperationException(
+      "AvroFormat.withRegistry(...) is consumer-only — serialize would require a writer schema. " +
+        "Use new AvroFormat(writerSchema) for the producer side."
+    );
     if (data == null) return null;
     try (final var output = new ByteArrayOutputStream()) {
       final var writer = new GenericDatumWriter<GenericRecord>(data.getSchema());
@@ -81,19 +147,55 @@ public final class AvroFormat implements MessageFormat<GenericRecord> {
     }
   }
 
-  /// Deserializes bytes to a `GenericRecord` using the bound schema.
+  /// Deserializes bytes to a `GenericRecord`. In static mode, the bound schema is used for
+  /// both writer and reader. In Schema-Registry mode, the writer schema is resolved per record
+  /// from the wire envelope and used to decode the remaining bytes.
   ///
-  /// @param data the binary-encoded bytes
+  /// @param data the binary-encoded bytes (with Confluent envelope in Schema-Registry mode)
   /// @return the decoded record, or null if `data` is null/empty
   @Override
   public GenericRecord deserialize(final byte[] data) {
     if (data == null || data.length == 0) return null;
-    final var reader = new GenericDatumReader<GenericRecord>(schema);
+    return resolver != null ? deserializeFromEnvelope(data) : deserializeStatic(data);
+  }
+
+  private GenericRecord deserializeStatic(final byte[] data) {
+    final var reader = new GenericDatumReader<GenericRecord>(staticSchema);
     final var decoder = DecoderFactory.get().binaryDecoder(data, null);
     try {
       return reader.read(null, decoder);
     } catch (final IOException e) {
       throw new RuntimeException("Failed to deserialize Avro record", e);
+    }
+  }
+
+  private GenericRecord deserializeFromEnvelope(final byte[] data) {
+    if (data.length < ENVELOPE_LENGTH) throw new RuntimeException(
+      "Record too short for Confluent wire envelope: " + data.length + " bytes; expected at least " + ENVELOPE_LENGTH
+    );
+    if (data[0] != CONFLUENT_MAGIC) throw new RuntimeException(
+      "Unexpected magic byte 0x%02x; expected 0x00 (Confluent Schema Registry envelope)".formatted(data[0] & 0xff)
+    );
+    final int schemaId =
+      ((data[1] & 0xff) << 24) | ((data[2] & 0xff) << 16) | ((data[3] & 0xff) << 8) | (data[4] & 0xff);
+
+    final var schema = resolvedSchemas.computeIfAbsent(schemaId, id -> {
+      final var json = resolver.lookupById(id);
+      if (json == null || json.isBlank()) throw new RuntimeException(
+        "Schema resolver returned empty schema for id " + id
+      );
+      return new Schema.Parser().parse(json);
+    });
+
+    final var reader = new GenericDatumReader<GenericRecord>(schema);
+    final var decoder = DecoderFactory.get().binaryDecoder(data, ENVELOPE_LENGTH, data.length - ENVELOPE_LENGTH, null);
+    try {
+      return reader.read(null, decoder);
+    } catch (final IOException e) {
+      throw new RuntimeException(
+        "Failed to decode Avro record under Confluent wire envelope (schema id " + schemaId + ")",
+        e
+      );
     }
   }
 }

--- a/lib/kpipe-format-avro/src/test/java/org/kpipe/format/avro/AvroFormatRegistryTest.java
+++ b/lib/kpipe-format-avro/src/test/java/org/kpipe/format/avro/AvroFormatRegistryTest.java
@@ -1,0 +1,207 @@
+package org.kpipe.format.avro;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.GenericData;
+import org.apache.avro.generic.GenericDatumWriter;
+import org.apache.avro.generic.GenericRecord;
+import org.apache.avro.io.EncoderFactory;
+import org.junit.jupiter.api.Test;
+import org.kpipe.registry.SchemaResolver;
+
+/// Tests for the Schema-Registry-backed mode of [AvroFormat]. Produces records framed in
+/// Confluent wire-envelope shape so the format's envelope-stripping and per-record schema
+/// lookup are exercised end-to-end.
+class AvroFormatRegistryTest {
+
+  private static final String USER_V1 = """
+    {"type":"record","name":"User","fields":[
+      {"name":"id","type":"string"},
+      {"name":"name","type":"string"}
+    ]}""";
+
+  private static final String USER_V2 = """
+    {"type":"record","name":"User","fields":[
+      {"name":"id","type":"string"},
+      {"name":"name","type":"string"},
+      {"name":"email","type":["null","string"],"default":null}
+    ]}""";
+
+  /// Encodes a record under the Confluent wire envelope: 1-byte magic (0x00) + 4-byte
+  /// big-endian schema id + Avro binary payload.
+  private static byte[] envelope(final int schemaId, final GenericRecord record) throws IOException {
+    final var bytes = new ByteArrayOutputStream();
+    bytes.write(0x00);
+    bytes.write(ByteBuffer.allocate(4).putInt(schemaId).array());
+    final var writer = new GenericDatumWriter<GenericRecord>(record.getSchema());
+    final var encoder = EncoderFactory.get().binaryEncoder(bytes, null);
+    writer.write(record, encoder);
+    encoder.flush();
+    return bytes.toByteArray();
+  }
+
+  /// Hands out preregistered schemas by id and counts lookups.
+  private static final class FakeResolver implements SchemaResolver {
+
+    final Map<Integer, String> schemas = new HashMap<>();
+    final AtomicInteger calls = new AtomicInteger();
+
+    FakeResolver put(final int id, final String json) {
+      schemas.put(id, json);
+      return this;
+    }
+
+    @Override
+    public String lookupById(final int schemaId) {
+      calls.incrementAndGet();
+      final var json = schemas.get(schemaId);
+      if (json == null) throw new RuntimeException("Unknown schema id " + schemaId);
+      return json;
+    }
+  }
+
+  @Test
+  void registryBackedFormatDecodesRecordsAgainstResolvedSchema() throws IOException {
+    final var schema = new Schema.Parser().parse(USER_V1);
+    final var record = new GenericData.Record(schema);
+    record.put("id", "u-1");
+    record.put("name", "Mariano");
+
+    final var resolver = new FakeResolver().put(101, USER_V1);
+    final var format = AvroFormat.withRegistry(resolver);
+
+    final var decoded = format.deserialize(envelope(101, record));
+
+    assertEquals("u-1", decoded.get("id").toString());
+    assertEquals("Mariano", decoded.get("name").toString());
+  }
+
+  @Test
+  void schemaIsCachedAfterFirstLookup() throws IOException {
+    final var schema = new Schema.Parser().parse(USER_V1);
+    final var record = new GenericData.Record(schema);
+    record.put("id", "u-1");
+    record.put("name", "Mariano");
+
+    final var resolver = new FakeResolver().put(101, USER_V1);
+    final var format = AvroFormat.withRegistry(resolver);
+
+    format.deserialize(envelope(101, record));
+    format.deserialize(envelope(101, record));
+    format.deserialize(envelope(101, record));
+
+    assertEquals(1, resolver.calls.get(), "the format must cache parsed schemas by id");
+  }
+
+  @Test
+  void mixedSchemaIdsResolveIndependently() throws IOException {
+    final var v1 = new Schema.Parser().parse(USER_V1);
+    final var v2 = new Schema.Parser().parse(USER_V2);
+
+    final var oldRecord = new GenericData.Record(v1);
+    oldRecord.put("id", "u-1");
+    oldRecord.put("name", "OldName");
+
+    final var newRecord = new GenericData.Record(v2);
+    newRecord.put("id", "u-2");
+    newRecord.put("name", "NewName");
+    newRecord.put("email", "new@example.com");
+
+    final var resolver = new FakeResolver().put(101, USER_V1).put(102, USER_V2);
+    final var format = AvroFormat.withRegistry(resolver);
+
+    final var decodedOld = format.deserialize(envelope(101, oldRecord));
+    final var decodedNew = format.deserialize(envelope(102, newRecord));
+
+    assertEquals("OldName", decodedOld.get("name").toString());
+    assertEquals("NewName", decodedNew.get("name").toString());
+    assertEquals("new@example.com", decodedNew.get("email").toString());
+    assertEquals(2, resolver.calls.get(), "two distinct ids = two lookups");
+  }
+
+  @Test
+  void wrongMagicByteThrows() {
+    final var resolver = new FakeResolver().put(1, USER_V1);
+    final var format = AvroFormat.withRegistry(resolver);
+
+    final var bad = new byte[] { 0x01, 0x00, 0x00, 0x00, 0x01, 0x42 };
+    final var ex = assertThrows(RuntimeException.class, () -> format.deserialize(bad));
+    assertTrue(ex.getMessage().contains("magic byte"), "must mention magic byte; got: " + ex.getMessage());
+  }
+
+  @Test
+  void payloadShorterThanEnvelopeThrows() {
+    final var resolver = new FakeResolver();
+    final var format = AvroFormat.withRegistry(resolver);
+
+    final var tooShort = new byte[] { 0x00, 0x00, 0x00 };
+    final var ex = assertThrows(RuntimeException.class, () -> format.deserialize(tooShort));
+    assertTrue(ex.getMessage().contains("envelope"));
+  }
+
+  @Test
+  void registryBackedSerializeThrows() {
+    final var format = AvroFormat.withRegistry(new FakeResolver());
+    final var schema = new Schema.Parser().parse(USER_V1);
+    final var record = new GenericData.Record(schema);
+    record.put("id", "u-1");
+    record.put("name", "Mariano");
+
+    assertThrows(UnsupportedOperationException.class, () -> format.serialize(record));
+  }
+
+  @Test
+  void registryBackedConsoleSinkThrows() {
+    final var format = AvroFormat.withRegistry(new FakeResolver());
+    assertThrows(IllegalStateException.class, format::consoleSink);
+  }
+
+  @Test
+  void registryBackedSchemaIsNull() {
+    assertNull(AvroFormat.withRegistry(new FakeResolver()).schema());
+  }
+
+  @Test
+  void isRegistryBackedReflectsMode() {
+    final var staticFormat = AvroFormat.of(USER_V1);
+    final var registryFormat = AvroFormat.withRegistry(new FakeResolver());
+    assertEquals(false, staticFormat.isRegistryBacked());
+    assertEquals(true, registryFormat.isRegistryBacked());
+  }
+
+  @Test
+  void rejectsNullResolver() {
+    assertThrows(NullPointerException.class, () -> AvroFormat.withRegistry(null));
+  }
+
+  @Test
+  void emptyPayloadReturnsNull() {
+    final var format = AvroFormat.withRegistry(new FakeResolver());
+    assertNull(format.deserialize(new byte[0]));
+    assertNull(format.deserialize(null));
+  }
+
+  @Test
+  void resolverReturningNullThrows() {
+    final var resolver = new SchemaResolver() {
+      @Override
+      public String lookupById(final int schemaId) {
+        return null;
+      }
+    };
+    final var format = AvroFormat.withRegistry(resolver);
+    final var anyEnvelope = new byte[] { 0x00, 0x00, 0x00, 0x00, 0x01, 0x42, 0x00 };
+    final var ex = assertThrows(RuntimeException.class, () -> format.deserialize(anyEnvelope));
+    assertTrue(ex.getMessage().contains("empty schema"));
+  }
+}

--- a/lib/kpipe-format-json/src/main/java/org/kpipe/format/json/JsonFormat.java
+++ b/lib/kpipe-format-json/src/main/java/org/kpipe/format/json/JsonFormat.java
@@ -43,7 +43,7 @@ public final class JsonFormat implements MessageFormat<Map<String, Object>> {
   /// @return a new pre-configured registry
   public static MessageProcessorRegistry newRegistry() {
     final var registry = new MessageProcessorRegistry(INSTANCE);
-    registry.register(JSON_LOGGING, new JsonConsoleSink<>());
+    registry.registerSink(JSON_LOGGING, new JsonConsoleSink<>());
     return registry;
   }
 

--- a/lib/kpipe-format-json/src/test/java/org/kpipe/format/json/MessageProcessorRegistryJsonTest.java
+++ b/lib/kpipe-format-json/src/test/java/org/kpipe/format/json/MessageProcessorRegistryJsonTest.java
@@ -47,7 +47,7 @@ class MessageProcessorRegistryJsonTest {
   @Test
   void shouldRegisterAndRetrieveJsonOperator() {
     final var key = RegistryKey.json("testOperator");
-    registry.register(key, obj -> {
+    registry.registerOperator(key, obj -> {
       obj.put("test", "value");
       return obj;
     });
@@ -63,11 +63,11 @@ class MessageProcessorRegistryJsonTest {
     final var op1 = RegistryKey.json("op1");
     final var op2 = RegistryKey.json("op2");
 
-    registry.register(op1, obj -> {
+    registry.registerOperator(op1, obj -> {
       obj.put("op1", "val1");
       return obj;
     });
-    registry.register(op2, obj -> {
+    registry.registerOperator(op2, obj -> {
       obj.put("op2", "val2");
       return obj;
     });
@@ -96,7 +96,7 @@ class MessageProcessorRegistryJsonTest {
     final UnaryOperator<Map<String, Object>> operator = message -> {
       throw new RuntimeException("Test exception");
     };
-    final var safeOperator = MessageProcessorRegistry.withErrorHandling(operator);
+    final var safeOperator = MessageProcessorRegistry.withOperatorErrorHandling(operator);
 
     final var input = new java.util.HashMap<String, Object>();
     final var result = safeOperator.apply(input);
@@ -109,7 +109,7 @@ class MessageProcessorRegistryJsonTest {
     final MessageSink<Map<String, Object>> sink = message -> {
       throw new RuntimeException("Test exception");
     };
-    final var safeSink = MessageProcessorRegistry.withErrorHandling(sink);
+    final var safeSink = MessageProcessorRegistry.withSinkErrorHandling(sink);
 
     assertDoesNotThrow(() -> safeSink.accept(new java.util.HashMap<>()));
   }
@@ -140,7 +140,7 @@ class MessageProcessorRegistryJsonTest {
   @Test
   void shouldTrackRegisteredProcessors() {
     final var key = RegistryKey.json("p1");
-    registry.register(key, obj -> obj);
+    registry.registerOperator(key, obj -> obj);
 
     assertTrue(registry.getKeys().contains(key));
   }
@@ -148,7 +148,7 @@ class MessageProcessorRegistryJsonTest {
   @Test
   void shouldUnregisterProcessor() {
     final var key = RegistryKey.json("p1");
-    registry.register(key, obj -> obj);
+    registry.registerOperator(key, obj -> obj);
 
     assertTrue(registry.getKeys().contains(key));
     final var removed = registry.unregister(key);
@@ -160,7 +160,7 @@ class MessageProcessorRegistryJsonTest {
   @Test
   void shouldTrackMetrics() {
     final var key = RegistryKey.json("metricsTest");
-    registry.register(key, obj -> obj);
+    registry.registerOperator(key, obj -> obj);
 
     final var pipeline = registry.pipeline(JsonFormat.INSTANCE).add(key).build();
 
@@ -174,7 +174,7 @@ class MessageProcessorRegistryJsonTest {
   @Test
   void shouldRegisterAndRetrieveTypedOperator() {
     final var key = RegistryKey.json("typedOp");
-    registry.register(key, obj -> {
+    registry.registerOperator(key, obj -> {
       obj.put("typed", "success");
       return obj;
     });
@@ -190,7 +190,7 @@ class MessageProcessorRegistryJsonTest {
   @Test
   void shouldComposePipelineUsingBuilder() {
     final var key1 = RegistryKey.json("builderOp1");
-    registry.register(key1, obj -> {
+    registry.registerOperator(key1, obj -> {
       obj.put("b1", "v1");
       return obj;
     });

--- a/lib/kpipe-format-protobuf/src/test/java/org/kpipe/format/protobuf/ProtobufFormatPipelineTest.java
+++ b/lib/kpipe-format-protobuf/src/test/java/org/kpipe/format/protobuf/ProtobufFormatPipelineTest.java
@@ -42,8 +42,8 @@ class ProtobufFormatPipelineTest {
     final UnaryOperator<Message> deactivate = msg ->
       msg.toBuilder().setField(msg.getDescriptorForType().findFieldByName("active"), false).build();
 
-    registry.register(ProtobufRegistryKey.of("setName"), setName);
-    registry.register(ProtobufRegistryKey.of("deactivate"), deactivate);
+    registry.registerOperator(ProtobufRegistryKey.of("setName"), setName);
+    registry.registerOperator(ProtobufRegistryKey.of("deactivate"), deactivate);
 
     final var pipeline = registry
       .pipeline(format)

--- a/lib/kpipe-metrics-otel/build.gradle.kts
+++ b/lib/kpipe-metrics-otel/build.gradle.kts
@@ -20,6 +20,7 @@ repositories {
 
 dependencies {
   api(project(":lib:kpipe-metrics"))
+  api(project(":lib:kpipe-core"))
   api(libs.opentelemetryApi)
 
   testImplementation(platform(libs.junitBom))

--- a/lib/kpipe-metrics-otel/src/main/java/module-info.java
+++ b/lib/kpipe-metrics-otel/src/main/java/module-info.java
@@ -14,6 +14,7 @@
 /// requires `opentelemetry-api`.
 module org.kpipe.metrics.otel {
   requires org.kpipe.metrics;
+  requires transitive org.kpipe.core;
   requires io.opentelemetry.api;
 
   exports org.kpipe.metrics.otel;

--- a/lib/kpipe-metrics-otel/src/main/java/org/kpipe/metrics/otel/PipelineMetricsObserver.java
+++ b/lib/kpipe-metrics-otel/src/main/java/org/kpipe/metrics/otel/PipelineMetricsObserver.java
@@ -1,0 +1,142 @@
+package org.kpipe.metrics.otel;
+
+import io.opentelemetry.api.OpenTelemetry;
+import io.opentelemetry.api.common.AttributeKey;
+import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.api.metrics.LongCounter;
+import io.opentelemetry.api.metrics.ObservableLongGauge;
+import java.util.Objects;
+import java.util.function.Consumer;
+import java.util.function.LongSupplier;
+import org.kpipe.registry.Result;
+
+/// OpenTelemetry-backed observer for pipeline outcomes. Hand to
+/// `Stream.peekResult(observer)` and each [Result] flowing through the pipeline increments one
+/// of three counters: `kpipe.pipeline.passed`, `kpipe.pipeline.filtered`, `kpipe.pipeline.failed`.
+///
+/// Why this is an observer, not a handler. The observer is invoked **after** the pipeline has
+/// already classified the record. It cannot suppress a filter, retry a failure, or reroute a
+/// pass. The downstream consumer flow (DLQ, retry, sink) runs regardless. If the observer
+/// itself throws, the exception is caught and swallowed by the wrapping pipeline
+/// (`DefaultSink`'s observer-wrap layer) — observer bugs cannot crash the consumer.
+///
+/// Example wiring (single-format facade):
+///
+/// ```java
+/// final var observer = new PipelineMetricsObserver(openTelemetry, "orders");
+/// try (var handle = KPipe.json("orders", props)
+///     .pipe(enrich)
+///     .peekResult(observer)
+///     .toCustom(sink)
+///     .start()) {
+///   handle.awaitShutdown();
+/// }
+/// ```
+///
+/// Optional: bind Confluent Schema Registry cache metrics via
+/// [#bindSchemaRegistryCache(LongSupplier, LongSupplier, LongSupplier)]. The observer uses
+/// `LongSupplier` rather than a concrete `CachedSchemaResolver` type so this module stays
+/// independent of `kpipe-schema-registry-confluent`.
+public final class PipelineMetricsObserver implements Consumer<Result<?>> {
+
+  private static final AttributeKey<String> PIPELINE_KEY = AttributeKey.stringKey("pipeline");
+
+  private final LongCounter passed;
+  private final LongCounter filtered;
+  private final LongCounter failed;
+  private final Attributes baseAttributes;
+  private final io.opentelemetry.api.metrics.Meter meter;
+
+  @SuppressWarnings("unused")
+  private ObservableLongGauge srCacheSizeGauge;
+
+  @SuppressWarnings("unused")
+  private ObservableLongGauge srCacheHitsGauge;
+
+  @SuppressWarnings("unused")
+  private ObservableLongGauge srCacheMissesGauge;
+
+  /// Creates an observer that reports pipeline-outcome counters under the given OTel meter.
+  ///
+  /// @param openTelemetry the OTel entry point (must be non-null)
+  /// @param pipelineName  optional pipeline label attached to every metric as `pipeline=...`;
+  ///                      pass null to omit the label entirely
+  public PipelineMetricsObserver(final OpenTelemetry openTelemetry, final String pipelineName) {
+    Objects.requireNonNull(openTelemetry, "openTelemetry cannot be null");
+    this.meter = openTelemetry.getMeter("org.kpipe.pipeline");
+    this.baseAttributes = pipelineName == null ? Attributes.empty() : Attributes.of(PIPELINE_KEY, pipelineName);
+    this.passed = meter
+      .counterBuilder("kpipe.pipeline.passed")
+      .setDescription("Records that flowed through the pipeline without filtering or failure")
+      .setUnit("{record}")
+      .build();
+    this.filtered = meter
+      .counterBuilder("kpipe.pipeline.filtered")
+      .setDescription("Records intentionally dropped by an operator returning null")
+      .setUnit("{record}")
+      .build();
+    this.failed = meter
+      .counterBuilder("kpipe.pipeline.failed")
+      .setDescription("Records whose pipeline raised an exception (captured as Result.Failed)")
+      .setUnit("{record}")
+      .build();
+  }
+
+  /// Pattern-matches the [Result] and increments the matching counter. Exceptions are not
+  /// expected from `LongCounter.add(...)` itself; if a downstream exporter throws, it
+  /// propagates and the `DefaultSink` observer-wrap layer catches it.
+  @Override
+  public void accept(final Result<?> result) {
+    if (result == null) return;
+    switch (result) {
+      case Result.Passed<?> __ -> passed.add(1, baseAttributes);
+      case Result.Filtered<?> __ -> filtered.add(1, baseAttributes);
+      case Result.Failed<?> __ -> failed.add(1, baseAttributes);
+    }
+  }
+
+  /// Registers three observable gauges that report the current state of a Confluent Schema
+  /// Registry cache (`CachedSchemaResolver` in `kpipe-schema-registry-confluent`). Wire the
+  /// suppliers to the resolver's `hitCount`, `missCount`, and `size` methods.
+  ///
+  /// Metrics emitted:
+  ///
+  ///   * `kpipe.schema_registry.cache.hits`   — cumulative hits since process start.
+  ///   * `kpipe.schema_registry.cache.misses` — cumulative misses (each one is one HTTP call).
+  ///   * `kpipe.schema_registry.cache.size`   — current distinct-id cardinality.
+  ///
+  /// Returns `this` for fluent chaining.
+  ///
+  /// @param hits   supplier of cumulative cache hits (must be non-null)
+  /// @param misses supplier of cumulative cache misses (must be non-null)
+  /// @param size   supplier of current cache size (must be non-null)
+  /// @return this observer
+  public PipelineMetricsObserver bindSchemaRegistryCache(
+    final LongSupplier hits,
+    final LongSupplier misses,
+    final LongSupplier size
+  ) {
+    Objects.requireNonNull(hits, "hits supplier cannot be null");
+    Objects.requireNonNull(misses, "misses supplier cannot be null");
+    Objects.requireNonNull(size, "size supplier cannot be null");
+    this.srCacheHitsGauge = meter
+      .gaugeBuilder("kpipe.schema_registry.cache.hits")
+      .ofLongs()
+      .setDescription("Cumulative cache hits for the Confluent Schema Registry resolver")
+      .setUnit("{lookup}")
+      .buildWithCallback(m -> m.record(hits.getAsLong(), baseAttributes));
+    this.srCacheMissesGauge = meter
+      .gaugeBuilder("kpipe.schema_registry.cache.misses")
+      .ofLongs()
+      .setDescription("Cumulative cache misses (each one resulted in a registry HTTP call)")
+      .setUnit("{lookup}")
+      .buildWithCallback(m -> m.record(misses.getAsLong(), baseAttributes));
+    this.srCacheSizeGauge = meter
+      .gaugeBuilder("kpipe.schema_registry.cache.size")
+      .ofLongs()
+      .setDescription("Current number of distinct schema ids cached")
+      .setUnit("{schema}")
+      .buildWithCallback(m -> m.record(size.getAsLong(), baseAttributes));
+    return this;
+  }
+}

--- a/lib/kpipe-metrics-otel/src/test/java/org/kpipe/metrics/otel/PipelineMetricsObserverTest.java
+++ b/lib/kpipe-metrics-otel/src/test/java/org/kpipe/metrics/otel/PipelineMetricsObserverTest.java
@@ -1,0 +1,79 @@
+package org.kpipe.metrics.otel;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import io.opentelemetry.api.OpenTelemetry;
+import org.junit.jupiter.api.Test;
+import org.kpipe.registry.Result;
+
+class PipelineMetricsObserverTest {
+
+  @Test
+  void buildsAgainstNoopOpenTelemetry() {
+    final var observer = new PipelineMetricsObserver(OpenTelemetry.noop(), "test-pipeline");
+    assertNotNull(observer);
+  }
+
+  @Test
+  void acceptsNullPipelineName() {
+    assertDoesNotThrow(() -> new PipelineMetricsObserver(OpenTelemetry.noop(), null));
+  }
+
+  @Test
+  void rejectsNullOpenTelemetry() {
+    assertThrows(NullPointerException.class, () -> new PipelineMetricsObserver(null, "test"));
+  }
+
+  @Test
+  void acceptsPassedResultWithoutThrowing() {
+    final var observer = new PipelineMetricsObserver(OpenTelemetry.noop(), "test");
+    assertDoesNotThrow(() -> observer.accept(Result.passed("hello")));
+  }
+
+  @Test
+  void acceptsFilteredResultWithoutThrowing() {
+    final var observer = new PipelineMetricsObserver(OpenTelemetry.noop(), "test");
+    assertDoesNotThrow(() -> observer.accept(Result.filtered()));
+  }
+
+  @Test
+  void acceptsFailedResultWithoutThrowing() {
+    final var observer = new PipelineMetricsObserver(OpenTelemetry.noop(), "test");
+    assertDoesNotThrow(() -> observer.accept(Result.failed(new RuntimeException("nope"))));
+  }
+
+  @Test
+  void acceptsNullResultSilently() {
+    final var observer = new PipelineMetricsObserver(OpenTelemetry.noop(), "test");
+    assertDoesNotThrow(() -> observer.accept(null));
+  }
+
+  @Test
+  void bindSchemaRegistryCacheReturnsSameInstanceForFluentChaining() {
+    final var observer = new PipelineMetricsObserver(OpenTelemetry.noop(), "test");
+    final var chained = observer.bindSchemaRegistryCache(() -> 10L, () -> 2L, () -> 7L);
+    assertSame(observer, chained);
+  }
+
+  @Test
+  void bindSchemaRegistryCacheRejectsNullSuppliers() {
+    final var observer = new PipelineMetricsObserver(OpenTelemetry.noop(), "test");
+    assertThrows(NullPointerException.class, () -> observer.bindSchemaRegistryCache(null, () -> 0L, () -> 0L));
+    assertThrows(NullPointerException.class, () -> observer.bindSchemaRegistryCache(() -> 0L, null, () -> 0L));
+    assertThrows(NullPointerException.class, () -> observer.bindSchemaRegistryCache(() -> 0L, () -> 0L, null));
+  }
+
+  @Test
+  void allThreeVariantsCanBeRecordedFromOneObserver() {
+    final var observer = new PipelineMetricsObserver(OpenTelemetry.noop(), "mixed");
+    observer.accept(Result.passed("a"));
+    observer.accept(Result.filtered());
+    observer.accept(Result.failed(new RuntimeException()));
+    observer.accept(Result.passed("b"));
+    // The OTel noop provider doesn't expose the recorded values, so we just verify the
+    // observer doesn't reject any variant or maintain bogus internal state.
+  }
+}

--- a/lib/kpipe-schema-registry-confluent/src/main/java/org/kpipe/schemaregistry/confluent/CachedSchemaResolver.java
+++ b/lib/kpipe-schema-registry-confluent/src/main/java/org/kpipe/schemaregistry/confluent/CachedSchemaResolver.java
@@ -1,0 +1,101 @@
+package org.kpipe.schemaregistry.confluent;
+
+import java.util.Objects;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicLong;
+import org.kpipe.registry.SchemaResolver;
+
+/// In-process LRU-free cache wrapping any [SchemaResolver].
+///
+/// **Why no TTL or LRU eviction in v1.** Confluent Schema Registry schema IDs are immutable —
+/// ID 42 today means the same schema tomorrow and three years from now. Schemas only get added,
+/// never reassigned. That makes the cache trivially correct:
+///
+/// - Cache hit: always returns the right schema for that ID.
+/// - Cache miss: one HTTP call to the underlying resolver, then cached forever.
+///
+/// Cardinality grows on the order of schema-version registrations — typically tens per topic
+/// over the lifetime of a production system, even with active evolution. Unbounded cache size
+/// is not a real concern at that rate. If a user does need a bound, they can wrap this
+/// resolver themselves; we'll add LRU here if a real workload demonstrates the need.
+///
+/// **Thread-safety.** Backed by a [ConcurrentHashMap] so the hot read path is lock-free per
+/// bucket. `computeIfAbsent` makes the load+store atomic — if two threads miss on the same ID
+/// concurrently, only one HTTP call goes out and the other waits for it to populate.
+///
+/// **Observability.** [#hitCount] and [#missCount] expose cumulative counters so the user can
+/// wire these into their metrics layer (see `kpipe-metrics-otel`'s
+/// `PipelineMetricsObserver.bindSchemaRegistryCache(...)`).
+///
+/// ```java
+/// final var raw = new ConfluentSchemaResolver("http://schema-registry:8081");
+/// final var cached = new CachedSchemaResolver(raw);
+/// final var format = AvroFormat.withRegistry(cached);  // per-record auto-lookup
+/// ```
+public final class CachedSchemaResolver implements SchemaResolver, AutoCloseable {
+
+  private final SchemaResolver delegate;
+  private final ConcurrentHashMap<Integer, String> cache = new ConcurrentHashMap<>();
+  private final AtomicLong hits = new AtomicLong();
+  private final AtomicLong misses = new AtomicLong();
+
+  /// Wraps `delegate` with an unbounded by-ID cache.
+  ///
+  /// @param delegate the resolver to call on cache miss (must be non-null)
+  public CachedSchemaResolver(final SchemaResolver delegate) {
+    this.delegate = Objects.requireNonNull(delegate, "delegate cannot be null");
+  }
+
+  @Override
+  public String lookupById(final int schemaId) {
+    final var hit = cache.get(schemaId);
+    if (hit != null) {
+      hits.incrementAndGet();
+      return hit;
+    }
+    return cache.computeIfAbsent(schemaId, id -> {
+      misses.incrementAndGet();
+      return delegate.lookupById(id);
+    });
+  }
+
+  /// Returns the number of cache hits since this resolver was constructed.
+  ///
+  /// @return cumulative hit count
+  public long hitCount() {
+    return hits.get();
+  }
+
+  /// Returns the number of cache misses (and thus underlying-resolver lookups) since
+  /// construction.
+  ///
+  /// @return cumulative miss count
+  public long missCount() {
+    return misses.get();
+  }
+
+  /// Returns the number of distinct schema IDs currently cached.
+  ///
+  /// @return current cache size
+  public int size() {
+    return cache.size();
+  }
+
+  /// Drops every cached entry. Provided for disaster-recovery scenarios (SR migration where
+  /// previously-stable IDs map to different schemas). Not part of normal operation — schema IDs
+  /// are immutable in routine SR use.
+  public void invalidateAll() {
+    cache.clear();
+  }
+
+  @Override
+  public void close() {
+    if (delegate instanceof AutoCloseable closeable) {
+      try {
+        closeable.close();
+      } catch (final Exception e) {
+        throw new RuntimeException("Failed to close delegate resolver", e);
+      }
+    }
+  }
+}

--- a/lib/kpipe-schema-registry-confluent/src/test/java/org/kpipe/schemaregistry/confluent/CachedSchemaResolverTest.java
+++ b/lib/kpipe-schema-registry-confluent/src/test/java/org/kpipe/schemaregistry/confluent/CachedSchemaResolverTest.java
@@ -1,0 +1,148 @@
+package org.kpipe.schemaregistry.confluent;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.jupiter.api.Test;
+import org.kpipe.registry.SchemaResolver;
+
+class CachedSchemaResolverTest {
+
+  /// Counts every lookup-by-id and serves a deterministic JSON string per id so tests can prove
+  /// the cache short-circuited the delegate.
+  private static final class CountingResolver implements SchemaResolver {
+
+    final AtomicInteger calls = new AtomicInteger();
+    final ConcurrentHashMap<Integer, String> seenIds = new ConcurrentHashMap<>();
+
+    @Override
+    public String lookupById(final int schemaId) {
+      calls.incrementAndGet();
+      seenIds.put(schemaId, "");
+      return "{\"type\":\"record\",\"name\":\"S" + schemaId + "\",\"fields\":[]}";
+    }
+  }
+
+  @Test
+  void firstLookupHitsTheDelegate() {
+    final var counter = new CountingResolver();
+    final var cached = new CachedSchemaResolver(counter);
+
+    final var json = cached.lookupById(42);
+
+    assertEquals("{\"type\":\"record\",\"name\":\"S42\",\"fields\":[]}", json);
+    assertEquals(1, counter.calls.get());
+    assertEquals(1, cached.missCount());
+    assertEquals(0, cached.hitCount());
+  }
+
+  @Test
+  void repeatedLookupOfSameIdServesFromCache() {
+    final var counter = new CountingResolver();
+    final var cached = new CachedSchemaResolver(counter);
+
+    final var first = cached.lookupById(42);
+    final var second = cached.lookupById(42);
+    final var third = cached.lookupById(42);
+
+    assertSame(first, second, "cached value must be the same instance on hit");
+    assertSame(second, third);
+    assertEquals(1, counter.calls.get(), "delegate must only be called on the first miss");
+    assertEquals(1, cached.missCount());
+    assertEquals(2, cached.hitCount());
+  }
+
+  @Test
+  void differentIdsHitTheDelegateIndependently() {
+    final var counter = new CountingResolver();
+    final var cached = new CachedSchemaResolver(counter);
+
+    cached.lookupById(1);
+    cached.lookupById(2);
+    cached.lookupById(3);
+    cached.lookupById(2); // hit
+    cached.lookupById(1); // hit
+
+    assertEquals(3, counter.calls.get());
+    assertEquals(3, cached.missCount());
+    assertEquals(2, cached.hitCount());
+    assertEquals(3, cached.size());
+  }
+
+  @Test
+  void concurrentMissesOnSameIdResultInExactlyOneDelegateCall() throws InterruptedException {
+    final var counter = new CountingResolver();
+    final var cached = new CachedSchemaResolver(counter);
+    final var threads = 32;
+    final var start = new CountDownLatch(1);
+    final var done = new CountDownLatch(threads);
+
+    for (int i = 0; i < threads; i++) {
+      Thread.ofVirtual().start(() -> {
+        try {
+          start.await();
+          cached.lookupById(7);
+        } catch (final InterruptedException e) {
+          Thread.currentThread().interrupt();
+        } finally {
+          done.countDown();
+        }
+      });
+    }
+
+    start.countDown();
+    done.await();
+
+    assertEquals(1, counter.calls.get(), "computeIfAbsent must atomicize the load");
+  }
+
+  @Test
+  void invalidateAllDropsEverything() {
+    final var counter = new CountingResolver();
+    final var cached = new CachedSchemaResolver(counter);
+    cached.lookupById(1);
+    cached.lookupById(2);
+    assertEquals(2, cached.size());
+
+    cached.invalidateAll();
+
+    assertEquals(0, cached.size());
+    cached.lookupById(1);
+    assertEquals(3, counter.calls.get(), "invalidateAll forces a re-fetch");
+  }
+
+  @Test
+  void rejectsNullDelegate() {
+    assertThrows(NullPointerException.class, () -> new CachedSchemaResolver(null));
+  }
+
+  @Test
+  void closePropagatesToCloseableDelegate() throws Exception {
+    final var closed = new AtomicInteger();
+    final class ClosableResolver implements SchemaResolver, AutoCloseable {
+
+      @Override
+      public String lookupById(final int schemaId) {
+        return "{}";
+      }
+
+      @Override
+      public void close() {
+        closed.incrementAndGet();
+      }
+    }
+    final var cached = new CachedSchemaResolver(new ClosableResolver());
+    cached.close();
+    assertEquals(1, closed.get());
+  }
+
+  @Test
+  void closeIsNoopForNonCloseableDelegate() {
+    final var cached = new CachedSchemaResolver(id -> "{}");
+    cached.close(); // must not throw
+  }
+}


### PR DESCRIPTION
## Summary

Seven ergonomics improvements bundled into 1.14. Unifying theme: make the fluent path honest about what's happening behind it, remove footguns that bit real users (or silently corrupted data), and close the gap between the actual capability surface and what adopters see in the README.

- **Registry rename** — kills the `register` / `withErrorHandling` overload-ambiguity cast trap on `x -> x`.
- **`PipelineDiagnostics`** — hex-dumps leading bytes on a deserialization failure and suggests the right `skipBytes(...)` when the payload looks like a Confluent envelope.
- **`Stream` Result observers** — `onFiltered`, `onFailed`, `peekResult` surface the §12 Passed/Filtered/Failed split without dropping to the explicit API.
- **Confluent SR per-record auto-lookup** (Avro) — `KPipe.avro(topic, props, resolver)` collapses the Confluent SR setup to one line and closes the schema-evolution-correctness hole the static-fetch path left open.
- **`PipelineMetricsObserver`** in `kpipe-metrics-otel` — per-Result-variant counters plus optional SR cache-counter binding.
- **`docs/escape-hatches.md`** — ports the §17 capability map to user-facing docs.
- **README rewrite** — production wiring snippet with DLQ + retry; new Observability section; SR section leads with auto-lookup.

### What changed

#### 1. `MessageProcessorRegistry` rename (no-deprecation, §16)

- `register(RegistryKey<T>, UnaryOperator<T>)` → `registerOperator(...)`
- `register(RegistryKey<T>, MessageSink<T>)` → `registerSink(...)`
- `withErrorHandling(UnaryOperator<T>)` → `withOperatorErrorHandling(...)`
- `withErrorHandling(MessageSink<T>)` → `withSinkErrorHandling(...)`

Old names deleted; every caller migrated (lib + format modules + tests + benchmarks + README + CLAUDE.md §7 / §17).

#### 2. `PipelineDiagnostics` with magic-byte hint

`TypedPipelineBuilder.deserialize` catches the format's `RuntimeException` and re-throws via `PipelineDiagnostics.wrap(...)`. Includes a hex dump of the first 16 bytes (with total length on truncation), and when `skipBytes(...)` wasn't set AND the first byte is `0x00`, a suggestion to use `skipBytes(5)` for Avro or `skipBytes(6)` for Protobuf.

#### 3. `Stream` Result observers

- `onFiltered(Runnable)` — fires after pipeline returns `Result.Filtered`.
- `onFailed(Consumer<Throwable>)` — fires after `Result.Failed` with the cause.
- `peekResult(Consumer<Result<T>>)` — fires on every outcome.

Pure observers. Exceptions thrown inside an observer are logged at WARNING and swallowed so observer bugs cannot crash the pipeline. `DefaultSink.buildPipeline()` wraps the base pipeline only when at least one observer is configured.

#### 4. Confluent SR per-record auto-lookup (Avro)

- `CachedSchemaResolver` in `kpipe-schema-registry-confluent` wraps any `SchemaResolver` with a `ConcurrentHashMap<Integer, String>` by-ID cache. No TTL, no LRU — Confluent SR schema IDs are immutable, so cache-by-ID is trivially correct. `computeIfAbsent` atomicizes load+store so concurrent misses on the same ID collapse to one HTTP call.
- `AvroFormat.withRegistry(SchemaResolver)` reads the 5-byte wire envelope per record, looks up the writer schema by ID through the resolver, caches the parsed `Schema` internally, and decodes against it via `GenericDatumReader(writerSchema, readerSchema)`. Avro's schema-resolution rules handle the evolution.
- Fluent entries: `KPipe.avro(topic, props, resolver)` (one-line SR consumer) and `Stream.withSchemaRegistry(resolver)` (swap mode on an existing stream).
- **Why this matters even with FORWARD-compatible evolution.** A static-fetch-at-startup codec treats one schema as both writer and reader. FORWARD allows non-append evolution (field removal with defaults, type promotion, union reordering) which the static path can't decode safely. Per-record auto-lookup uses the actual writer schema for each record. Doctrine in CLAUDE.md §19.
- **Protobuf is deferred.** Confluent Protobuf SR returns `.proto` source text; runtime auto-lookup needs `.proto` compilation (protoc-jar) — out of scope for this release. Static `new ProtobufFormat(descriptor)` + `.skipBytes(6)` remains for the single-top-level-message case.

#### 5. `PipelineMetricsObserver` in `kpipe-metrics-otel`

- Implements `Consumer<Result<?>>` so it plugs into `Stream.peekResult(...)`.
- Emits `kpipe.pipeline.passed`, `kpipe.pipeline.filtered`, `kpipe.pipeline.failed` counters via OTel, dimensioned by optional `pipeline` label.
- Optional `bindSchemaRegistryCache(LongSupplier hits, LongSupplier misses, LongSupplier size)` adds `kpipe.schema_registry.cache.{hits,misses,size}` gauges. Suppliers (not concrete types) keep `kpipe-metrics-otel` independent of `kpipe-schema-registry-confluent`.

#### 6. `docs/escape-hatches.md` + README rewrite

- Ported the §17 capability map to a user-facing doc with worked examples (custom `OffsetManager`, rebalance listeners, pre-shared registries). Updated for the new SR + observer rows.
- README adds a "Production wiring — ten lines" snippet right after the hello example showing DLQ + retry + backpressure. New Observability section. Confluent SR section now leads with the per-record `withSchemaRegistry` path; the static-fetch path is documented as the append-only-evolution discipline alternative.
- "What it does" bullets now mention multi-topic dispatch and DLQ/retries/circuit-breaker explicitly.

#### 7. Spotless markdown applies tree-wide

`target("**/*.md")` (was `*.md`, project-root-only) with build / .gradle / node_modules exclusions. The previous glob silently skipped `docs/**/*.md`.

### Migration notes

Breaking change for `kpipe-core` and `kpipe-api`. Callers of `register(...)` / `withErrorHandling(...)` will get a compile error pointing at the renamed methods. The migration is a 1:1 rename — no semantic change.

The `KPipe.avro(format, topic, props)` signature is unchanged. Existing Avro consumers using static-mode `AvroFormat` continue to work.

## Test plan

- [x] `:lib:kpipe-core:test` — 8 new tests in `PipelineDiagnosticsTest`.
- [x] `:lib:kpipe-api:test` — 10 new tests in `StreamResultObserversTest`.
- [x] `:lib:kpipe-format-avro:test` — 13 new tests in `AvroFormatRegistryTest` covering envelope parsing, schema caching, mode flags, magic-byte validation, evolution across versions.
- [x] `:lib:kpipe-schema-registry-confluent:test` — 8 new tests in `CachedSchemaResolverTest` covering hit/miss counters, concurrent miss collapsing via virtual threads, invalidation, lifecycle.
- [x] `:lib:kpipe-metrics-otel:test` — 10 new tests in `PipelineMetricsObserverTest` covering result-variant dispatch, null safety, fluent chaining.
- [x] `:lib:kpipe-format-json:test`, `:lib:kpipe-format-protobuf:test` — pass after the rename migration.
- [x] `:benchmarks:compileJmhJava` — benchmark callers migrated.
- [x] `:spotlessCheck` — passes across all modules and root.
- [x] `:examples:schema-registry:compileJava` — updated example uses the new one-line SR factory.
- [ ] CI: full `check` excluding Docker-dependent Testcontainers integration tests.