### PR TITLE
docs(plan): trim stale and duplicated content from PLAN.md

### DIFF
--- a/.claude/PLAN.md
+++ b/.claude/PLAN.md
@@ -1,19 +1,10 @@
 # KPipe — Roadmap & State of the Library
 
-- **Last updated:** 2026-05-19
-- **Current released line:** 1.13.0 (Maven Central) — `Result<T>` sealed pipeline outcomes, Avro/Protobuf codec /
-  catalog split, `ConsumerHealthController` facade unifying pause / backpressure / circuit-breaker, Codecov test-results
-  upload, CI/release wiring for `kpipe-schema-registry-confluent` + `kpipe-tracing-otel`.
-- **Next line (1.14, in flight):** registry rename (`registerOperator` / `registerSink`, `withOperatorErrorHandling` /
-  `withSinkErrorHandling`); `PipelineDiagnostics` with Confluent magic-byte hint; `Stream.onFiltered` / `onFailed` /
-  `peekResult` observers; `docs/escape-hatches.md` page; **Confluent SR per-record auto-lookup**
-  (`AvroFormat.withRegistry(...)` + `CachedSchemaResolver` + `Stream.withSchemaRegistry(...)`);
-  **`PipelineMetricsObserver`** in `kpipe-metrics-otel` with optional SR cache-counter binding; README rewrite leading
-  with multi-topic + DLQ.
-- **Active branch:** main (clean)
-- **Recent infra work (not a P-item but worth recording):** competitive bench harness — 4 runtimes (KPipe, Confluent PC,
-  Reactor Kafka 1.3.25, Raw `KafkaConsumer` + VT), Testcontainers-backed Kafka 4.2.0, `workMicros` parameterised
-  workload, JMH JSON + SVG + blog post published.
+- **Last updated:** 2026-05-30
+- **Current released line:** 1.15.0 (Maven Central) — `Dispatcher` abstraction with `ProcessingMode` enum (SEQUENTIAL /
+  PARALLEL / KEY_ORDERED), per-key serial processing via `KeyOrderedDispatcher`, KEY_ORDERED operability bundle
+  (stall-WARN, `topKeyQueueDepths`, builder warn-log). Per-release detail lives in git history + CLAUDE.md §19/§20; this
+  file tracks what's next, not what's done.
 
 ---
 
@@ -23,18 +14,18 @@
 | -------------------------------------- | ----------- |
 | Common-path ergonomics                 | 9/10        |
 | Customization / escape hatches         | 9/10        |
-| Discovery (does the API teach itself?) | 8.5/10      |
-| Type safety                            | 9/10        |
+| Discovery (does the API teach itself?) | 9/10        |
+| Type safety                            | 9.5/10      |
 | Error semantics                        | 10/10       |
 | Module taxonomy                        | 9.5/10      |
 | Documentation                          | 8/10        |
 | Test coverage of the public surface    | 8.5/10      |
-| Aggregate                              | **~8.7/10** |
+| Aggregate                              | **~8.8/10** |
 
-API quality is solid; the 1.13 cycle closed three breaking-change items that had been deferred to a future major
-(Result<T>, INSTANCE singleton removal, pause/CB/backpressure consolidation) and brought README + Javadoc back in sync
-with the 1.12 + 1.13 surface. The remaining gap is **productivity tooling for adopters** (`kpipe-test`) — the backlog
-now leads with that.
+API quality is solid. The remaining gap is **productivity tooling for adopters** (`kpipe-test`) — the backlog leads with
+that. Discovery + Type safety nudged up in the architecture-deepening pass after the `MessagePipeline` byte-level entry
+points were removed — the `Result<T>` switch is now the only way to get a pipeline outcome, enforced by the compiler
+instead of by doctrine.
 
 ---
 
@@ -49,55 +40,16 @@ now leads with that.
 | 5   | **P3 — Audience**     | Spring Boot starter — opt-in module, `@KPipeListener`, auto-wires from `application.yml`. **Only build if a Spring-shop user asks.** | Feature  | ~1 week   |
 | 6   | **P5 — Speculative**  | Format serialization caches re-wire — only with JMH evidence of allocation/GC pressure                                               | Perf     | ~1–2 days |
 
-### Developer-ergonomics — 1.14 in flight (2026-05-19)
+### Deliberately deferred (still not committed)
 
-The "top 5 ergonomics improvements" brainstorm bundled four items into a single 1.14 PR. The fifth (`kpipe-test`) is the
-same as backlog item #1 and stays on the priority table.
+These came up in earlier brainstorms and were dropped on the merits; recorded here so they don't get re-proposed without
+new evidence:
 
-**Shipped in the 1.14 PR (single squash):**
-
-1. **`MessageProcessorRegistry` rename.** `register` → `registerOperator` / `registerSink`; `withErrorHandling` →
-   `withOperatorErrorHandling` / `withSinkErrorHandling`. Per §16, deleted the old names in the same PR. Kills the
-   overload-ambiguity cast footgun on `x -> x`.
-2. **`PipelineDiagnostics` magic-byte hint.** On a deserialization failure, hex-dumps the leading bytes and — when
-   `skipBytes(...)` wasn't set and the payload starts with `0x00` — suggests `skipBytes(5)` for Avro / `skipBytes(6)`
-   for Proto. Closes the §12 Grafana-burn loop with a message a human can act on.
-3. **`Stream` Result observers.** `onFiltered(Runnable)`, `onFailed(Consumer<Throwable>)`,
-   `peekResult(Consumer<Result<T>>)` on the fluent facade. Pure side-effects; do not suppress or reroute. Surfaces §12
-   outcomes without making users drop to the explicit API.
-4. **`docs/escape-hatches.md`.** Ported the §17 capability table to a user-facing doc and linked it from the README's
-   "Two API surfaces" block.
-5. **Confluent SR per-record auto-lookup (Avro).** `AvroFormat.withRegistry(SchemaResolver)` reads the wire envelope on
-   every record, looks up the writer schema by ID through a `CachedSchemaResolver` (`ConcurrentHashMap`, no TTL — SR IDs
-   are immutable), and decodes against it. Fluent shorthand `Stream.withSchemaRegistry(resolver)`. Closes the
-   schema-evolution-correctness hole that the static `lookupBySubjectVersion("latest")` path left open. Doctrine in §19.
-6. **`PipelineMetricsObserver` in `kpipe-metrics-otel`.** Per-Result-variant counters
-   (`kpipe.pipeline.passed/filtered/failed`) emitted via OTel; optional `bindSchemaRegistryCache(hits, misses, size)`
-   binds the SR cache counters into the same observer. Hand to `Stream.peekResult(observer)`.
-7. **README rewrite.** Promotes DLQ + retry into a "Production wiring — ten lines" snippet right after the §2 hello.
-   Adds Observability + updated Confluent SR sections. Closes the "docs don't keep up with the surface area" gap flagged
-   in the outside critique.
-
-**Deliberately deferred (not in 1.14):**
-
-- `Stream.strict()` / `.lenient()` toggle for malformed-record routing. Conflates two API decisions; revisit standalone.
-- `KPipe.from(props).json().topic(...)` short-form. Current `KPipe.json("topic", props)` is already one call.
-- Spring Boot starter (still P3, gated on real user ask — see backlog #5).
-- **Protobuf SR auto-lookup.** Needs runtime `.proto` text compilation (protoc-jar) — out of scope; documented in §19
-  and on `Stream.withSchemaRegistry` Javadoc.
-- `just new-format <name>` scaffold — cheap unlock, but slot it in standalone outside the 1.14 bundle.
-
-**Honorable mentions (still candidates, not committed):** fold `HttpHealthServer.fromEnv(...)` into `Handle` (overlaps
-with backlog #3).
-
-**Why this ordering:**
-
-- **kpipe-test first.** Docs caught up in 1.13 (README + Javadoc audit landed alongside the breaking changes); the next
-  leverage point is letting adopters write unit tests without Testcontainers. Productivity multiplier for every existing
-  and future user, and CI-environment-friendly for shops without Docker.
-- **P3 refactors next.** Cheap (~2 hours total) but worth doing before they accumulate.
-- **Spring starter held until asked.** ~1 week of work for an audience that already has Spring Kafka. Build it when a
-  Spring-shop user actively asks, not speculatively.
+- `Stream.strict()` / `.lenient()` toggle for malformed-record routing — conflates two API decisions.
+- `KPipe.from(props).json().topic(...)` short-form — current `KPipe.json("topic", props)` is already one call.
+- **Protobuf SR auto-lookup** — needs runtime `.proto` text compilation (protoc-jar); doctrine in CLAUDE.md §19.
+- `just new-format <name>` scaffold — cheap, but ungated; pick up if a real format addition lands.
+- Fold `HttpHealthServer.fromEnv(...)` into `Handle` — overlaps with backlog #3; decide alongside that move.
 
 ---
 
@@ -152,20 +104,8 @@ kpipe-schema-registry-confluent ← kpipe-core                 (opt-in Confluent
 kpipe-bom                                                    (BOM — pins versions)
 ```
 
-| Module                            | What's in it                                                                                                                                                                                                 |
-| --------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `kpipe-bom`                       | Maven BOM — pins all `kpipe-*` artifacts to matching versions                                                                                                                                                |
-| `kpipe-core`                      | Format-agnostic pipeline machinery: `MessageProcessorRegistry`, `MessageFormat`, `MessageSink`, `Operators`, `MessagePipeline` (returns `Result<T>` — `Passed \| Filtered \| Failed`), `SchemaResolver` SPI  |
-| `kpipe-metrics`                   | Metrics interfaces (`ConsumerMetrics`, `ProducerMetrics`) + log-based reporters; **no OTel API** on classpath                                                                                                |
-| `kpipe-metrics-otel`              | OpenTelemetry-backed metrics implementation (opt-in)                                                                                                                                                         |
-| `kpipe-tracing-otel`              | W3C trace context propagation through Kafka headers; OTel tracer implementation (opt-in)                                                                                                                     |
-| `kpipe-schema-registry-confluent` | Confluent Schema Registry client (`ConfluentSchemaResolver`); schema-by-ID + by-subject-version lookup (opt-in)                                                                                              |
-| `kpipe-producer`                  | Kafka producer wrapper, `KafkaMessageSink`, `KafkaProducerConfig`, `Tracer` SPI                                                                                                                              |
-| `kpipe-consumer`                  | `KPipeConsumer` (hosts lifecycle + metrics-reporter thread), `BackpressureController`, `CircuitBreakerController`, `ConsumerHealthController` (pkg-private façade), `KafkaOffsetManager`, `HttpHealthServer` |
-| `kpipe-format-json`               | `JsonFormat`, `JsonConsoleSink`                                                                                                                                                                              |
-| `kpipe-format-avro`               | `AvroFormat` (stateless codec, one schema per instance), `AvroSchemaCatalog` (keyed lookup), `AvroConsoleSink`                                                                                               |
-| `kpipe-format-protobuf`           | `ProtobufFormat` (stateless codec, one descriptor per instance), `ProtobufDescriptorCatalog` (keyed lookup), `ProtobufConsoleSink`                                                                           |
-| `kpipe-api`                       | `KPipe` fluent facade — `Stream<T>`, `Sink<T>`, `Handle`, `MultiBuilder`                                                                                                                                     |
+Per-module contents are recoverable from `settings.gradle` + the `build.gradle` per module, and the package-ownership
+rules live in CLAUDE.md §9. Not duplicated here.
 
 **Still planned:**
 
@@ -224,36 +164,9 @@ To resurrect as a real optimization:
 
 ---
 
-## Strengths to preserve
-
-Don't regress these in any future refactor:
-
-- **Byte boundary at the consumer entry point** — `KPipeConsumer<K>` operates on `byte[]` values. Format SerDe lives in
-  the pipeline.
-- **Single SerDe cycle** — one deserialize, many transforms, one serialize. Genuinely good for throughput.
-- **Virtual threads + ScopedValue** — thread-per-record without ThreadLocal scalability traps.
-- **Lowest-pending-offset commits** — at-least-once safety even with parallel processing.
-- **Strategy-based backpressure with hysteresis** — in-flight for parallel, lag for sequential.
-- **ConsumerHealthController unification** — multiple pause sources (manual, backpressure, CB) can't auto-resume each
-  other; CB state machine + backpressure decision + pause arbitration live behind a single façade in `kpipe-consumer`.
-- **Clean module dependency direction** — no cycles, no sideways leaks, no split packages.
-- **OTel as opt-in interface, not transitive dep** — `kpipe-metrics` ships interfaces only.
-- **Concurrency safety in `KPipeConsumer`** — single-read CAS, error-handler-throw safety, nested-finally shutdown,
-  `LockSupport.park` for paused state.
-- **Explicit error semantics in `MessagePipeline`** — `process()` returns `Result<T>` (Passed/Filtered/Failed) so the
-  filter-vs-fail distinction is enforced by the compiler, not by convention.
-- **Immutable `DefaultStream`** — branching from a common root is safe.
-- **Professional Maven publishing** — proper signing, POM metadata, separate artifacts, BOM for version unification.
-- **§16 no-deprecation policy** — delete and migrate, don't carry dead overloads.
-
----
-
 ## Open questions
 
 1. **`kpipe-test` test runner integration** — plain `TestStream` v1, `@KPipeTest` extension as follow-up.
 2. **Tracing default-on or opt-in?** — auto-enable when `kpipe-tracing-otel` is on the classpath, or stay explicit
    (`.withTracer(...)`)?
-3. **Confluent SR scope beyond v1** — TTL cache for `lookupById` (hot-path) and wire-envelope auto-lookup in
-   `AvroFormat` / `ProtobufFormat` decode. With the 1.13 codec/catalog split, wire-envelope auto-lookup now has a clean
-   place to live (catalog owns a `SchemaResolver`-backed loader). Schedule for 1.14?
-4. **Spring starter demand check** — promote to P2 only on real user ask.
+3. **Spring starter demand check** — promote to P2 only on real user ask.


### PR DESCRIPTION
## Summary

PLAN.md had accumulated three classes of rot:

- **Stale state.** Header pointed at 1.13 with 1.14 "in flight" — both shipped (1.15 is current, see CLAUDE.md §19/§20). Open question #3 ("Confluent SR scope... schedule for 1.14?") was answered and doctrine landed in §19.
- **Duplication of CLAUDE.md.** "Strengths to preserve" was a verbatim rephrase of the core invariants + §3-§14 doctrine. Two sources of truth for the same content always drift; deleted the PLAN copy. CLAUDE.md owns invariants.
- **Duplication of `settings.gradle`.** Per-module "what's in it" table restated package contents already recoverable from the build files. Replaced with a one-liner pointer.

Also: collapsed the "Developer-ergonomics — 1.14 in flight" section to just the deferred-decisions bullet list (the part that still has forward-looking signal — the "shipped in 1.14" recap is now in git history).

Score table nudged for the architecture-deepening pass landing in the parent PR: Discovery 8.5→9, Type safety 9→9.5, aggregate 8.7→8.8. One-paragraph why added under the table.

## Why target the parent branch

This depends on the wording change in the score table (\"the architecture-deepening pass...\"), so I targeted #141 instead of `main`. GitHub will retarget to `main` automatically when #141 merges.

## What's preserved

- Backlog table (P2 kpipe-test, P3 refactors, P5 perf).
- P2 kpipe-test module detail (forward-looking).
- Module-taxonomy ASCII diagram + \"Still planned\" mini-table.
- P3 and P5 detail sections.
- Open questions 1, 2, and 4 (renumbered to 1, 2, 3).

## Numbers

259 → 172 lines (137 removed, 25 added; net -112).

## Test plan

- [x] `./gradlew spotlessMarkdownCheck` — green
- [x] Visual proofread of remaining content — no broken cross-refs, all preserved sections still scan correctly