### PR TITLE
bench: restore JsonPipelineBenchmark + AvroPipelineBenchmark (closes #151)

### DIFF
--- a/benchmarks/src/jmh/java/io/github/eschizoid/kpipe/benchmarks/AvroPipelineBenchmark.java
+++ b/benchmarks/src/jmh/java/io/github/eschizoid/kpipe/benchmarks/AvroPipelineBenchmark.java
@@ -2,12 +2,13 @@ package io.github.eschizoid.kpipe.benchmarks;
 
 import io.github.eschizoid.kpipe.format.avro.AvroFormat;
 import io.github.eschizoid.kpipe.format.avro.AvroRegistryKey;
+import io.github.eschizoid.kpipe.registry.MessagePipeline;
 import io.github.eschizoid.kpipe.registry.MessageProcessorRegistry;
+import io.github.eschizoid.kpipe.registry.Result;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.concurrent.TimeUnit;
-import java.util.function.Function;
 import java.util.function.UnaryOperator;
 import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericData;
@@ -40,8 +41,8 @@ public class AvroPipelineBenchmark {
   private AvroFormat format;
   private byte[] avroBytes;
   private byte[] avroWithMagicBytes;
-  private Function<byte[], byte[]> kpipePipeline;
-  private Function<byte[], byte[]> kpipeMagicPipeline;
+  private MessagePipeline<GenericRecord> kpipePipeline;
+  private MessagePipeline<GenericRecord> kpipeMagicPipeline;
 
   @Setup
   public void setup() throws IOException {
@@ -112,13 +113,23 @@ public class AvroPipelineBenchmark {
 
   @Benchmark
   public void kpipeAvroPipeline(final Blackhole bh) {
-    bh.consume(kpipePipeline.apply(avroBytes));
+    final var value = kpipePipeline.deserializeOrFail(avroBytes);
+    final var result = kpipePipeline.process(value);
+    if (!(result instanceof Result.Passed<GenericRecord> passed)) {
+      throw new AssertionError("benchmark input should always pass: " + result);
+    }
+    bh.consume(kpipePipeline.serialize(passed.value()));
   }
 
   @Benchmark
   public void kpipeAvroMagicPipeline(final Blackhole bh) {
-    // This tests the zero-copy offset handling
-    bh.consume(kpipeMagicPipeline.apply(avroWithMagicBytes));
+    // This tests the zero-copy offset handling: deserialize starts at byte 5, no copy
+    final var value = kpipeMagicPipeline.deserializeOrFail(avroWithMagicBytes);
+    final var result = kpipeMagicPipeline.process(value);
+    if (!(result instanceof Result.Passed<GenericRecord> passed)) {
+      throw new AssertionError("benchmark input should always pass: " + result);
+    }
+    bh.consume(kpipeMagicPipeline.serialize(passed.value()));
   }
 
   @Benchmark

--- a/benchmarks/src/jmh/java/io/github/eschizoid/kpipe/benchmarks/JsonPipelineBenchmark.java
+++ b/benchmarks/src/jmh/java/io/github/eschizoid/kpipe/benchmarks/JsonPipelineBenchmark.java
@@ -1,11 +1,13 @@
 package io.github.eschizoid.kpipe.benchmarks;
 
 import io.github.eschizoid.kpipe.format.json.JsonFormat;
+import io.github.eschizoid.kpipe.registry.MessagePipeline;
 import io.github.eschizoid.kpipe.registry.MessageProcessorRegistry;
 import io.github.eschizoid.kpipe.registry.RegistryKey;
+import io.github.eschizoid.kpipe.registry.Result;
 import java.nio.charset.StandardCharsets;
+import java.util.Map;
 import java.util.concurrent.TimeUnit;
-import java.util.function.Function;
 import org.openjdk.jmh.annotations.*;
 import org.openjdk.jmh.infra.Blackhole;
 
@@ -32,7 +34,7 @@ public class JsonPipelineBenchmark {
   private static final long BENCHMARK_TIMESTAMP = 1_700_000_000_000L;
 
   private byte[] jsonBytes;
-  private Function<byte[], byte[]> kpipePipeline;
+  private MessagePipeline<Map<String, Object>> kpipePipeline;
 
   @Setup
   public void setup() {
@@ -75,7 +77,12 @@ public class JsonPipelineBenchmark {
 
   @Benchmark
   public void kpipeJsonPipeline(final Blackhole bh) {
-    bh.consume(kpipePipeline.apply(jsonBytes));
+    final var value = kpipePipeline.deserializeOrFail(jsonBytes);
+    final var result = kpipePipeline.process(value);
+    if (!(result instanceof Result.Passed<Map<String, Object>> passed)) {
+      throw new AssertionError("benchmark input should always pass: " + result);
+    }
+    bh.consume(kpipePipeline.serialize(passed.value()));
   }
 
   @Benchmark


### PR DESCRIPTION
## Summary

Resolves #151. Both pipeline benchmarks have been compile-broken on \`main\` since the architecture-deepening pass removed the byte-level \`MessagePipeline.apply(byte[])\` shim — they still declared the field as \`Function<byte[], byte[]>\` and called \`.apply(jsonBytes)\` on what was now a \`MessagePipeline<Map<String, Object>>\` / \`MessagePipeline<GenericRecord>\`. \`compileJmhJava\` was failing across the whole \`:benchmarks\` module on \`main\`, which is why PR #153 had to exclude these two files to run any benchmark at all.

## Changes

Rewrite the kpipe-side benchmark methods against the current pipeline API:

\`\`\`java
final var value = pipeline.deserializeOrFail(bytes);
final var result = pipeline.process(value);
if (!(result instanceof Result.Passed<T> passed)) {
  throw new AssertionError("benchmark input should always pass: " + result);
}
bh.consume(pipeline.serialize(passed.value()));
\`\`\`

Same per-record work as the old \`pipeline.apply(bytes)\` (deserialize → operators → serialize), just unrolled to match the new sealed-\`Result<T>\` return shape. The pattern-match-or-fail keeps the bench loud if input ever falls into \`Filtered\` or \`Failed\` — silent assumption breakage would falsify the numbers.

Manual SerDe paths are untouched; they never used \`.apply(byte[])\`.

## Smoke numbers (1 iter × 1 fork × 1 warmup, sanity-only)

| Benchmark | ops/s |
|---|---:|
| \`JsonPipelineBenchmark.kpipeJsonPipeline\` | 663,820 |
| \`JsonPipelineBenchmark.manualJsonSerDeChained\` | 258,721 |
| \`JsonPipelineBenchmark.manualJsonSingleSerDe\` | 836,126 |
| \`AvroPipelineBenchmark.kpipeAvroPipeline\` | 867,447 |
| \`AvroPipelineBenchmark.kpipeAvroMagicPipeline\` | 657,508 |
| \`AvroPipelineBenchmark.manualAvroMagicHandling\` | 1,042,793 |

The single-SerDe-tax story these benches exist to surface is intact (kpipe \`663k\` vs manual chained \`259k\` on JSON, ~2.6×).

## Coordination with PR #153

PR #153 added a temporary exclusion of both files in \`benchmarks/build.gradle.kts\` to unblock the JMH source set. If this PR merges **after** #153, the exclusion lines should also be removed (they'll point at compilable files at that point). If this PR merges **before** #153, the exclusion still works but is no longer necessary — #153's rebase can drop it.

## Test plan

- [x] \`./gradlew :benchmarks:compileJmhJava\` clean
- [x] \`./gradlew :benchmarks:jmh -Pjmh.includes='(JsonPipelineBenchmark|AvroPipelineBenchmark)' -Pjmh.iterations=1 -Pjmh.warmupIterations=1 -Pjmh.fork=1\` produces all 6 cells
- [x] \`./gradlew spotlessCheck\` clean
- [ ] CI green