### PR TITLE
chore: address IntelliJ inspection warnings (safe sweep)

### DIFF
--- a/benchmarks/build.gradle.kts
+++ b/benchmarks/build.gradle.kts
@@ -3,21 +3,6 @@ plugins {
   alias(libs.plugins.jmh)
 }
 
-// JsonPipelineBenchmark / AvroPipelineBenchmark are stale: they assume the old
-// `MessagePipeline.apply(byte[])` byte-level entry point that was removed when `process()`
-// returning `Result<T>` became the only pipeline output shape. They've been compile-broken on
-// `main` since then, blocking every other benchmark from being built. Excluding them here so
-// `ParallelProcessingBenchmark` and friends compile; rewriting the pipeline benchmarks against
-// the current API is a separate follow-up.
-sourceSets {
-  named("jmh") {
-    java {
-      exclude("**/JsonPipelineBenchmark.java")
-      exclude("**/AvroPipelineBenchmark.java")
-    }
-  }
-}
-
 dependencies {
   // Benchmarks consume public API from :lib
   implementation(project(":lib:kpipe-consumer"))

--- a/benchmarks/src/jmh/java/io/github/eschizoid/kpipe/benchmarks/ParallelProcessingBenchmarkInfrastructure.java
+++ b/benchmarks/src/jmh/java/io/github/eschizoid/kpipe/benchmarks/ParallelProcessingBenchmarkInfrastructure.java
@@ -90,7 +90,46 @@ public final class ParallelProcessingBenchmarkInfrastructure {
 
   private static final Duration PC_CLOSE_TIMEOUT = Duration.ofSeconds(5);
 
+  /// How long teardown waits for the poll loop thread and the worker executor to drain. Five
+  /// seconds is generous; iterations that need longer are paying a measurement cost outside the
+  /// steady-state regime the bench is supposed to capture.
+  private static final long TEARDOWN_TIMEOUT_SECONDS = 5;
+
   private ParallelProcessingBenchmarkInfrastructure() {}
+
+  /// Shared teardown helper used by every invocation-context inner class that owns a poll loop +
+  /// worker executor pair. Lowers the `running` flag, joins the poll loop, then shuts down the
+  /// executor and waits for it to terminate. Restores the interrupt flag on `InterruptedException`
+  /// per the cooperative-cancellation rule; logs at WARNING when `awaitTermination` returns false
+  /// so a slow executor doesn't disappear from the report.
+  static void stopPollLoopAndExecutor(
+    final AtomicBoolean running,
+    final Thread pollLoop,
+    final ExecutorService executor
+  ) {
+    running.set(false);
+    if (pollLoop != null) {
+      try {
+        pollLoop.join(Duration.ofSeconds(TEARDOWN_TIMEOUT_SECONDS).toMillis());
+      } catch (final InterruptedException e) {
+        Thread.currentThread().interrupt();
+      }
+    }
+    if (executor != null) {
+      executor.shutdownNow();
+      try {
+        if (!executor.awaitTermination(TEARDOWN_TIMEOUT_SECONDS, TimeUnit.SECONDS)) {
+          System.err.println(
+            "[bench teardown] executor did not terminate within " +
+              TEARDOWN_TIMEOUT_SECONDS +
+              "s; benchmark measurements may include teardown overhead"
+          );
+        }
+      } catch (final InterruptedException e) {
+        Thread.currentThread().interrupt();
+      }
+    }
+  }
 
   /// Simulates per-record work. `LockSupport.parkNanos` is the right primitive for "this thread
   /// is blocked for N µs" — it lets the JVM schedule something else on the carrier thread and is
@@ -550,22 +589,7 @@ public final class ParallelProcessingBenchmarkInfrastructure {
 
     @TearDown(Level.Invocation)
     public void tearDown() {
-      running.set(false);
-      if (pollLoop != null) {
-        try {
-          pollLoop.join(Duration.ofSeconds(5).toMillis());
-        } catch (final InterruptedException e) {
-          Thread.currentThread().interrupt();
-        }
-      }
-      if (executor != null) {
-        executor.shutdownNow();
-        try {
-          executor.awaitTermination(5, TimeUnit.SECONDS);
-        } catch (final InterruptedException e) {
-          Thread.currentThread().interrupt();
-        }
-      }
+      stopPollLoopAndExecutor(running, pollLoop, executor);
       if (kafkaConsumer != null) kafkaConsumer.close();
     }
 
@@ -735,22 +759,7 @@ public final class ParallelProcessingBenchmarkInfrastructure {
 
     @TearDown(Level.Invocation)
     public void tearDown() {
-      running.set(false);
-      if (pollLoop != null) {
-        try {
-          pollLoop.join(Duration.ofSeconds(5).toMillis());
-        } catch (final InterruptedException e) {
-          Thread.currentThread().interrupt();
-        }
-      }
-      if (executor != null) {
-        executor.shutdownNow();
-        try {
-          executor.awaitTermination(5, TimeUnit.SECONDS);
-        } catch (final InterruptedException e) {
-          Thread.currentThread().interrupt();
-        }
-      }
+      stopPollLoopAndExecutor(running, pollLoop, executor);
       // Safe to close from this thread: the poll loop has joined, so nothing else touches it.
       if (shareConsumer != null) shareConsumer.close();
     }

--- a/examples/demo/src/main/java/io/github/eschizoid/kpipe/demo/DemoApp.java
+++ b/examples/demo/src/main/java/io/github/eschizoid/kpipe/demo/DemoApp.java
@@ -89,7 +89,7 @@ public class DemoApp implements AutoCloseable {
   }
 
   /// Initialises an OTLP/gRPC OpenTelemetry SDK pointed at the demo's collector. Reads
-  /// `OTEL_EXPORTER_OTLP_ENDPOINT` (default `http://otel-collector:4317`).
+  /// `OTEL_EXPORTER_OTLP_ENDPOINT` (default `<http://otel-collector:4317>`).
   private static OpenTelemetry initOpenTelemetry() {
     final var endpoint = System.getenv().getOrDefault("OTEL_EXPORTER_OTLP_ENDPOINT", "http://otel-collector:4317");
     final var exporter = OtlpGrpcMetricExporter.builder().setEndpoint(endpoint).build();

--- a/examples/schema-registry/src/main/java/io/github/eschizoid/kpipe/App.java
+++ b/examples/schema-registry/src/main/java/io/github/eschizoid/kpipe/App.java
@@ -16,7 +16,8 @@ import java.time.Duration;
 ///
 /// Environment variables (in addition to the standard `AppConfig`):
 ///
-/// - `SCHEMA_REGISTRY_URL` — base URL of the Schema Registry (e.g. `http://schema-registry:8081`).
+/// - `SCHEMA_REGISTRY_URL` — base URL of the Schema Registry (e.g.
+// `<http://schema-registry:8081>`).
 ///
 /// Do NOT add `.skipBytes(5)` here — `withSchemaRegistry(...)` consumes the envelope itself.
 public final class App {

--- a/lib/kpipe-api/src/main/java/io/github/eschizoid/kpipe/DefaultBatchSink.java
+++ b/lib/kpipe-api/src/main/java/io/github/eschizoid/kpipe/DefaultBatchSink.java
@@ -57,15 +57,7 @@ record DefaultBatchSink<T>(
       .withKeyOrderedMaxKeys(stream.keyOrderedMaxKeys())
       .withBatchPipeline(topic(), buildPipeline(), batchSink, batchPolicy);
 
-    if (stream.maxRetries() > 0) consumerBuilder.withRetry(stream.maxRetries(), stream.retryBackoff());
-    if (stream.backpressureHigh() != null) consumerBuilder.withBackpressure(
-      stream.backpressureHigh(),
-      stream.backpressureLow()
-    );
-    if (stream.consumerMetrics() != null) consumerBuilder.withMetrics(stream.consumerMetrics());
-    if (stream.errorHandler() != null) consumerBuilder.withErrorHandler(stream.errorHandler()::accept);
-    if (stream.deadLetterTopic() != null) consumerBuilder.withDeadLetterTopic(stream.deadLetterTopic());
-    if (stream.pollTimeout() != null) consumerBuilder.withPollTimeout(stream.pollTimeout());
+    stream.applyCommonConsumerConfig(consumerBuilder);
 
     return DefaultHandle.startAndWrap(consumerBuilder.build());
   }

--- a/lib/kpipe-api/src/main/java/io/github/eschizoid/kpipe/DefaultSink.java
+++ b/lib/kpipe-api/src/main/java/io/github/eschizoid/kpipe/DefaultSink.java
@@ -79,9 +79,9 @@ record DefaultSink<T>(DefaultStream<T> stream, MessageSink<T> terminalSink) impl
         final var result = base.process(data);
         if (peek != null) safeAccept(peek, result, "peekResult");
         switch (result) {
-          case Result.Passed<T> __ -> {
+          case Result.Passed<T> _ -> {
           }
-          case Result.Filtered<T> __ -> {
+          case Result.Filtered<T> _ -> {
             if (onFiltered != null) safeRun(onFiltered);
           }
           case Result.Failed<T> failed -> {

--- a/lib/kpipe-api/src/main/java/io/github/eschizoid/kpipe/DefaultSink.java
+++ b/lib/kpipe-api/src/main/java/io/github/eschizoid/kpipe/DefaultSink.java
@@ -32,15 +32,7 @@ record DefaultSink<T>(DefaultStream<T> stream, MessageSink<T> terminalSink) impl
       .withProcessingMode(stream.processingMode())
       .withKeyOrderedMaxKeys(stream.keyOrderedMaxKeys());
 
-    if (stream.maxRetries() > 0) consumerBuilder.withRetry(stream.maxRetries(), stream.retryBackoff());
-    if (stream.backpressureHigh() != null) consumerBuilder.withBackpressure(
-      stream.backpressureHigh(),
-      stream.backpressureLow()
-    );
-    if (stream.consumerMetrics() != null) consumerBuilder.withMetrics(stream.consumerMetrics());
-    if (stream.errorHandler() != null) consumerBuilder.withErrorHandler(stream.errorHandler()::accept);
-    if (stream.deadLetterTopic() != null) consumerBuilder.withDeadLetterTopic(stream.deadLetterTopic());
-    if (stream.pollTimeout() != null) consumerBuilder.withPollTimeout(stream.pollTimeout());
+    stream.applyCommonConsumerConfig(consumerBuilder);
     if (stream.tracer() != null) consumerBuilder.withTracer(stream.tracer());
     if (stream.circuitBreaker() != null) consumerBuilder.withCircuitBreaker(stream.circuitBreaker());
 

--- a/lib/kpipe-api/src/main/java/io/github/eschizoid/kpipe/DefaultStream.java
+++ b/lib/kpipe-api/src/main/java/io/github/eschizoid/kpipe/DefaultStream.java
@@ -300,6 +300,19 @@ record DefaultStream<T>(
     });
   }
 
+  /// Applies the consumer-level config that both [DefaultSink] and [DefaultBatchSink] share onto
+  /// `builder`: retry, backpressure, metrics, error handler, dead-letter topic, poll timeout.
+  /// Tracer and circuit-breaker are NOT applied here — they're only wired by [DefaultSink];
+  /// `DefaultBatchSink` historically does not expose them (would change behavior to add).
+  void applyCommonConsumerConfig(final KPipeConsumer.Builder<byte[]> builder) {
+    if (maxRetries > 0) builder.withRetry(maxRetries, retryBackoff);
+    if (backpressureHigh != null) builder.withBackpressure(backpressureHigh, backpressureLow);
+    if (consumerMetrics != null) builder.withMetrics(consumerMetrics);
+    if (errorHandler != null) builder.withErrorHandler(errorHandler::accept);
+    if (deadLetterTopic != null) builder.withDeadLetterTopic(deadLetterTopic);
+    if (pollTimeout != null) builder.withPollTimeout(pollTimeout);
+  }
+
   /// Single funnel for every wither: snapshot this record into a [Mut], let the caller change
   /// what they need, rebuild a new record. Replaces 13 hand-rolled 15-arg constructor calls with
   /// one. New fields slot in at one site (the Mut declaration + its `from`/`build`).

--- a/lib/kpipe-api/src/test/java/io/github/eschizoid/kpipe/DefaultHandleStartAndWrapTest.java
+++ b/lib/kpipe-api/src/test/java/io/github/eschizoid/kpipe/DefaultHandleStartAndWrapTest.java
@@ -1,0 +1,67 @@
+package io.github.eschizoid.kpipe;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import io.github.eschizoid.kpipe.consumer.KPipeConsumer;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+/// Pins the exception-handling contract on [DefaultHandle#startAndWrap]: if `consumer.start()`
+/// throws, the consumer MUST be closed (so the `AutoCloseable` contract holds when the caller
+/// never gets a Handle back), and if `close()` ALSO throws, the secondary exception must be
+/// attached as a suppressed exception on the original rather than swallowed or rethrown.
+@ExtendWith(MockitoExtension.class)
+class DefaultHandleStartAndWrapTest {
+
+  @Mock
+  private KPipeConsumer<byte[]> consumer;
+
+  @Test
+  void happyPathStartsAndWrapsTheConsumer() {
+    final var handle = DefaultHandle.startAndWrap(consumer);
+
+    assertNotNull(handle);
+    assertInstanceOf(DefaultHandle.class, handle);
+    verify(consumer).start();
+    verify(consumer, never()).close();
+  }
+
+  @Test
+  void startFailureClosesConsumerAndRethrowsOriginal() {
+    final var startFailure = new RuntimeException("start blew up");
+    doThrow(startFailure).when(consumer).start();
+
+    final var thrown = assertThrows(RuntimeException.class, () -> DefaultHandle.startAndWrap(consumer));
+
+    // The ORIGINAL start() exception is what surfaces — not whatever close() did or didn't do.
+    assertSame(startFailure, thrown);
+    verify(consumer).start();
+    verify(consumer).close();
+    // No suppressed exception when close() succeeded.
+    assertEquals(0, thrown.getSuppressed().length);
+  }
+
+  @Test
+  void startFailureWithCloseFailureAttachesSuppressed() {
+    final var startFailure = new RuntimeException("start blew up");
+    final var closeFailure = new IllegalStateException("close blew up too");
+    doThrow(startFailure).when(consumer).start();
+    doThrow(closeFailure).when(consumer).close();
+
+    final var thrown = assertThrows(RuntimeException.class, () -> DefaultHandle.startAndWrap(consumer));
+
+    // The original start() failure is rethrown. The close() failure is attached as suppressed
+    // — neither swallowed nor allowed to mask the real root cause.
+    assertSame(startFailure, thrown);
+    assertEquals(1, thrown.getSuppressed().length);
+    assertSame(closeFailure, thrown.getSuppressed()[0]);
+  }
+
+  @Test
+  void rejectsNullConsumer() {
+    assertThrows(NullPointerException.class, () -> DefaultHandle.startAndWrap(null));
+  }
+}

--- a/lib/kpipe-api/src/test/java/io/github/eschizoid/kpipe/HandleDefaultsTest.java
+++ b/lib/kpipe-api/src/test/java/io/github/eschizoid/kpipe/HandleDefaultsTest.java
@@ -1,0 +1,84 @@
+package io.github.eschizoid.kpipe;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicReference;
+import org.junit.jupiter.api.Test;
+
+/// Pins the default-method behavior on the [Handle] interface. Anything a downstream user
+/// inherits without overriding lives here — silent behavior changes to these defaults are how
+/// you break callers outside this repo.
+class HandleDefaultsTest {
+
+  /// Minimal Handle implementing only the abstract methods. The two defaults
+  /// ([Handle#topKeyQueueDepths] and [Handle#close]) deliberately fall through to their
+  /// interface implementations so this test exercises them.
+  private static final class MinimalHandle implements Handle {
+
+    final AtomicReference<Duration> shutdownTimeout = new AtomicReference<>();
+
+    @Override
+    public boolean isHealthy() {
+      return true;
+    }
+
+    @Override
+    public Map<String, Long> metrics() {
+      return Map.of();
+    }
+
+    @Override
+    public boolean awaitShutdown(final Duration timeout) {
+      return true;
+    }
+
+    @Override
+    public void awaitShutdown() {
+      // no-op
+    }
+
+    @Override
+    public boolean shutdownGracefully(final Duration timeout) {
+      shutdownTimeout.set(timeout);
+      return true;
+    }
+  }
+
+  @Test
+  void topKeyQueueDepthsRejectsZero() {
+    final var handle = new MinimalHandle();
+    final var thrown = assertThrows(IllegalArgumentException.class, () -> handle.topKeyQueueDepths(0));
+    assertTrue(thrown.getMessage().contains("must be positive"), () -> "msg was: " + thrown.getMessage());
+  }
+
+  @Test
+  void topKeyQueueDepthsRejectsNegative() {
+    assertThrows(IllegalArgumentException.class, () -> new MinimalHandle().topKeyQueueDepths(-1));
+  }
+
+  @Test
+  void topKeyQueueDepthsDefaultReturnsEmptyForValidN() {
+    // The default exists so implementations outside this repo don't break when the method is
+    // added — they get an empty list, NOT a NullPointerException or UnsupportedOperationException.
+    final var result = new MinimalHandle().topKeyQueueDepths(5);
+    assertNotNull(result);
+    assertTrue(result.isEmpty());
+    // List.of() returns an immutable empty list; pin that so a future refactor can't substitute
+    // a mutable empty list and silently let callers mutate the "no key queues" return value.
+    assertThrows(UnsupportedOperationException.class, () -> result.add(Map.entry("k", 1)));
+    // Same type as List.of() — empty immutable list.
+    assertEquals(List.of(), result);
+  }
+
+  @Test
+  void closeDefaultCallsShutdownGracefullyWithFiveSeconds() {
+    // The five-second default IS the contract — every try-with-resources caller relies on it.
+    // If anyone tweaks it, this test forces them to update the Javadoc too.
+    final var handle = new MinimalHandle();
+    handle.close();
+    assertEquals(Duration.ofSeconds(5), handle.shutdownTimeout.get());
+  }
+}

--- a/lib/kpipe-api/src/test/java/io/github/eschizoid/kpipe/StreamResultObserversTest.java
+++ b/lib/kpipe-api/src/test/java/io/github/eschizoid/kpipe/StreamResultObserversTest.java
@@ -37,7 +37,7 @@ class StreamResultObserversTest {
         final var sink = pipeline.getSink();
         if (sink != null) sink.accept(p.value());
       }
-      case Result.Filtered<T> __ -> {
+      case Result.Filtered<T> _ -> {
         /* intentional drop */
       }
       case Result.Failed<T> f -> {
@@ -51,7 +51,6 @@ class StreamResultObserversTest {
   @Test
   void onFilteredFiresWhenAnOperatorReturnsNull() {
     final var fired = new AtomicInteger();
-    @SuppressWarnings("unchecked")
     final var sink = (DefaultSink<Map<String, Object>>) KPipe.json("topic", props())
       .filter(m -> false)
       .onFiltered(fired::incrementAndGet)
@@ -67,7 +66,6 @@ class StreamResultObserversTest {
   @Test
   void onFilteredDoesNotFireForPassedRecords() {
     final var fired = new AtomicInteger();
-    @SuppressWarnings("unchecked")
     final var sink = (DefaultSink<Map<String, Object>>) KPipe.json("topic", props())
       .onFiltered(fired::incrementAndGet)
       .toCustom(m -> {});
@@ -83,7 +81,6 @@ class StreamResultObserversTest {
   void onFailedReceivesTheCauseAndPipelineStillThrows() {
     final var capturedCause = new AtomicReference<Throwable>();
     final var boom = new RuntimeException("boom");
-    @SuppressWarnings("unchecked")
     final var sink = (DefaultSink<Map<String, Object>>) KPipe.json("topic", props())
       .pipe(m -> {
         throw boom;
@@ -104,7 +101,6 @@ class StreamResultObserversTest {
     final var passed = new AtomicInteger();
     final var filtered = new AtomicInteger();
     final var failed = new AtomicInteger();
-    @SuppressWarnings("unchecked")
     final var sink = (DefaultSink<Map<String, Object>>) KPipe.json("topic", props())
       .filter(m -> m.containsKey("keep"))
       .pipe(m -> {
@@ -113,9 +109,9 @@ class StreamResultObserversTest {
       })
       .peekResult(result -> {
         switch (result) {
-          case Result.Passed<Map<String, Object>> __ -> passed.incrementAndGet();
-          case Result.Filtered<Map<String, Object>> __ -> filtered.incrementAndGet();
-          case Result.Failed<Map<String, Object>> __ -> failed.incrementAndGet();
+          case Result.Passed<Map<String, Object>> _ -> passed.incrementAndGet();
+          case Result.Filtered<Map<String, Object>> _ -> filtered.incrementAndGet();
+          case Result.Failed<Map<String, Object>> _ -> failed.incrementAndGet();
         }
       })
       .toCustom(m -> {});
@@ -133,7 +129,6 @@ class StreamResultObserversTest {
 
   @Test
   void observerExceptionsAreSwallowedSoPipelineStaysAlive() {
-    @SuppressWarnings("unchecked")
     final var sink = (DefaultSink<Map<String, Object>>) KPipe.json("topic", props())
       .filter(m -> false)
       .onFiltered(() -> {
@@ -148,7 +143,6 @@ class StreamResultObserversTest {
 
   @Test
   void noObserverConfiguredMeansNoWrapper() {
-    @SuppressWarnings("unchecked")
     final var sink = (DefaultSink<Map<String, Object>>) KPipe.json("topic", props())
       .pipe(m -> {
         m.put("x", 1);
@@ -165,7 +159,6 @@ class StreamResultObserversTest {
   @Test
   void observersDoNotAffectFilterReturnValue() {
     final var seenAtSink = new AtomicReference<Map<String, Object>>();
-    @SuppressWarnings("unchecked")
     final var sink = (DefaultSink<Map<String, Object>>) KPipe.json("topic", props())
       .filter(m -> false)
       .onFiltered(() -> {
@@ -192,7 +185,6 @@ class StreamResultObserversTest {
   void lastWriteWinsForRepeatedObserverCalls() {
     final var first = new AtomicInteger();
     final var second = new AtomicInteger();
-    @SuppressWarnings("unchecked")
     final var sink = (DefaultSink<Map<String, Object>>) KPipe.json("topic", props())
       .filter(m -> false)
       .onFiltered(first::incrementAndGet)
@@ -210,7 +202,6 @@ class StreamResultObserversTest {
   @Test
   void onFailedDoesNotFireOnFilteredOrPassed() {
     final var failedFired = new AtomicInteger();
-    @SuppressWarnings("unchecked")
     final var sink = (DefaultSink<Map<String, Object>>) KPipe.json("topic", props())
       .filter(m -> m.containsKey("keep"))
       .onFailed(_ -> failedFired.incrementAndGet())

--- a/lib/kpipe-api/src/test/java/io/github/eschizoid/kpipe/StreamToMultiTest.java
+++ b/lib/kpipe-api/src/test/java/io/github/eschizoid/kpipe/StreamToMultiTest.java
@@ -84,7 +84,6 @@ class StreamToMultiTest {
   }
 
   @Test
-  @SuppressWarnings("unchecked")
   void toMultiWithNullVarargsThrows() {
     final var stream = KPipe.json("topic", props());
     assertThrows(NullPointerException.class, () -> stream.toMulti((MessageSink<Map<String, Object>>[]) null));

--- a/lib/kpipe-consumer/src/main/java/io/github/eschizoid/kpipe/consumer/KPipeConsumer.java
+++ b/lib/kpipe-consumer/src/main/java/io/github/eschizoid/kpipe/consumer/KPipeConsumer.java
@@ -1687,7 +1687,7 @@ public class KPipeConsumer<K> implements AutoCloseable {
           // is committed to the user sink.
           return false;
         }
-        case Result.Filtered<T> __ -> {
+        case Result.Filtered<T> _ -> {
           // Intentional filter — mark processed immediately; nothing to buffer.
           markOffsetProcessed(record);
           return true;
@@ -1714,7 +1714,7 @@ public class KPipeConsumer<K> implements AutoCloseable {
         final var sink = pipeline.getSink();
         if (sink != null) sink.accept(p.value());
       }
-      case Result.Filtered<T> __ -> {
+      case Result.Filtered<T> _ -> {
         /* intentional filter — no sink invocation */
       }
       case Result.Failed<T> f -> throw rethrowResultCause(f.cause());

--- a/lib/kpipe-consumer/src/test/java/io/github/eschizoid/kpipe/consumer/DispatcherIntegrationTest.java
+++ b/lib/kpipe-consumer/src/test/java/io/github/eschizoid/kpipe/consumer/DispatcherIntegrationTest.java
@@ -398,12 +398,12 @@ class DispatcherIntegrationTest {
           () -> "mode " + mode + " left pending offsets on " + tp + ": " + state
         );
         assertEquals(
-          (long) (recordsPerPartition - 1),
+          (recordsPerPartition - 1),
           ((Number) state.get("highestProcessedOffset")).longValue(),
           () -> "mode " + mode + " did not mark all offsets processed on " + tp + ": " + state
         );
         assertEquals(
-          (long) recordsPerPartition,
+          recordsPerPartition,
           ((Number) state.get("nextOffsetToCommit")).longValue(),
           () -> "mode " + mode + " did not advance commit offset on " + tp + ": " + state
         );

--- a/lib/kpipe-consumer/src/test/java/io/github/eschizoid/kpipe/consumer/KPipeBackpressureIntegrationTest.java
+++ b/lib/kpipe-consumer/src/test/java/io/github/eschizoid/kpipe/consumer/KPipeBackpressureIntegrationTest.java
@@ -124,7 +124,7 @@ class KPipeBackpressureIntegrationTest {
 
       // backpressureTimeMs must be > 0
       assertTrue(
-        (long) consumer.getMetrics().get(KPipeConsumer.METRIC_BACKPRESSURE_TIME_MS) > 0,
+        consumer.getMetrics().get(KPipeConsumer.METRIC_BACKPRESSURE_TIME_MS) > 0,
         "backpressureTimeMs should be positive after a backpressure pause"
       );
 
@@ -228,7 +228,7 @@ class KPipeBackpressureIntegrationTest {
       awaitCondition(() -> mc.paused().isEmpty(), 3000);
 
       // Now it should poll the remaining records
-      awaitCondition(() -> (long) consumer.getMetrics().get("messagesReceived") == 10, 3000);
+      awaitCondition(() -> consumer.getMetrics().get("messagesReceived") == 10, 3000);
       assertEquals(10L, consumer.getMetrics().get("messagesReceived"));
 
       consumer.close();
@@ -263,7 +263,7 @@ class KPipeBackpressureIntegrationTest {
       consumer.start();
 
       // Wait for first 5 to be polled
-      awaitCondition(() -> (long) consumer.getMetrics().get("messagesReceived") == 5, 2000);
+      awaitCondition(() -> consumer.getMetrics().get("messagesReceived") == 5, 2000);
 
       // Pause manually
       consumer.pause();
@@ -284,7 +284,7 @@ class KPipeBackpressureIntegrationTest {
       consumer.resume();
 
       // Wait for the rest to be polled
-      awaitCondition(() -> (long) consumer.getMetrics().get("messagesReceived") == 10, 3000);
+      awaitCondition(() -> consumer.getMetrics().get("messagesReceived") == 10, 3000);
       assertEquals(10L, consumer.getMetrics().get("messagesReceived"));
 
       consumer.close();
@@ -341,7 +341,7 @@ class KPipeBackpressureIntegrationTest {
 
       // Assert: consumer is paused
       assertTrue(mockConsumer.paused().contains(PARTITION), "Consumer should be paused due to high lag");
-      assertTrue((long) consumer.getMetrics().get(KPipeConsumer.METRIC_BACKPRESSURE_PAUSE_COUNT) >= 1);
+      assertTrue(consumer.getMetrics().get(KPipeConsumer.METRIC_BACKPRESSURE_PAUSE_COUNT) >= 1);
 
       consumer.close();
     }

--- a/lib/kpipe-consumer/src/test/java/io/github/eschizoid/kpipe/consumer/KPipeCircuitBreakerIntegrationTest.java
+++ b/lib/kpipe-consumer/src/test/java/io/github/eschizoid/kpipe/consumer/KPipeCircuitBreakerIntegrationTest.java
@@ -204,7 +204,7 @@ class KPipeCircuitBreakerIntegrationTest {
       .build();
 
     consumer.start();
-    awaitCondition(() -> (long) consumer.getMetrics().get("processingErrors") >= 5, 5000);
+    awaitCondition(() -> consumer.getMetrics().get("processingErrors") >= 5, 5000);
 
     assertEquals(0L, consumer.getMetrics().get(KPipeConsumer.METRIC_CIRCUIT_BREAKER_TRIPS));
     assertTrue(mc.paused().isEmpty(), "no breaker configured → never pauses despite all failures");

--- a/lib/kpipe-consumer/src/test/java/io/github/eschizoid/kpipe/consumer/KPipeConsumerTest.java
+++ b/lib/kpipe-consumer/src/test/java/io/github/eschizoid/kpipe/consumer/KPipeConsumerTest.java
@@ -550,7 +550,6 @@ class KPipeConsumerTest {
     Thread.sleep(100);
 
     // Assert
-    @SuppressWarnings({ "unchecked", "rawtypes" })
     final var errorCaptor = ArgumentCaptor.forClass(KPipeConsumer.ProcessingError.class);
     verify(errorHandler).accept(errorCaptor.capture());
     final var error = errorCaptor.getValue();

--- a/lib/kpipe-consumer/src/test/java/io/github/eschizoid/kpipe/consumer/KPipeDlqTest.java
+++ b/lib/kpipe-consumer/src/test/java/io/github/eschizoid/kpipe/consumer/KPipeDlqTest.java
@@ -172,11 +172,11 @@ class KPipeDlqTest {
     }
   }
 
-  /// Exercises the atomic [Builder#withDeadLetterQueue(String, KPipeProducer)] setter: a single
-  /// call pairs the DLQ topic with a pre-built [KPipeProducer], and the consumer routes failures
-  /// through that producer to that topic. The two-call alternative (`withDeadLetterTopic` +
-  /// `withKafkaProducer`) is covered by the tests above; this one specifically pins the bundled
-  /// shape so the convenience setter can't silently regress.
+  /// Exercises the atomic [KPipeConsumer.Builder#withDeadLetterQueue(String, KPipeProducer)]
+  /// setter: a single call pairs the DLQ topic with a pre-built [KPipeProducer], and the consumer
+  /// routes failures through that producer to that topic. The two-call alternative
+  /// (`withDeadLetterTopic` + `withKafkaProducer`) is covered by the tests above; this one
+  /// specifically pins the bundled shape so the convenience setter can't silently regress.
   @Test
   @SuppressWarnings("unchecked")
   void shouldSendToDlqViaBundledWithDeadLetterQueueSetter() throws Exception {

--- a/lib/kpipe-consumer/src/test/java/io/github/eschizoid/kpipe/consumer/ParallelDispatcherTest.java
+++ b/lib/kpipe-consumer/src/test/java/io/github/eschizoid/kpipe/consumer/ParallelDispatcherTest.java
@@ -11,9 +11,9 @@ import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.junit.jupiter.api.Test;
 
 /// Unit tests for [ParallelDispatcher]. Focused on the executor lifecycle: the executor is
-/// created in the field initializer (at construction), so it must be shut down by [#close()]
-/// even if the dispatcher never dispatched anything — otherwise a consumer built-but-never-
-/// started leaks it.
+/// created in the field initializer (at construction), so it must be shut down by
+/// [ParallelDispatcher#close()] even if the dispatcher never dispatched anything — otherwise a
+/// consumer built-but-never-started leaks it.
 class ParallelDispatcherTest {
 
   private static ConsumerRecord<String, byte[]> record(final long offset) {

--- a/lib/kpipe-core/src/main/java/io/github/eschizoid/kpipe/registry/Result.java
+++ b/lib/kpipe-core/src/main/java/io/github/eschizoid/kpipe/registry/Result.java
@@ -50,7 +50,6 @@ public sealed interface Result<T> permits Result.Passed, Result.Filtered, Result
   ///
   /// @param <T> the pipeline value type
   record Filtered<T>() implements Result<T> {
-    @SuppressWarnings({ "rawtypes", "unchecked" })
     private static final Filtered SHARED = new Filtered();
 
     /// Returns the shared `Filtered` sentinel. Avoids per-record allocation on filter-heavy

--- a/lib/kpipe-core/src/test/java/io/github/eschizoid/kpipe/registry/MessageProcessorRegistrySinksTest.java
+++ b/lib/kpipe-core/src/test/java/io/github/eschizoid/kpipe/registry/MessageProcessorRegistrySinksTest.java
@@ -169,7 +169,7 @@ class MessageProcessorRegistrySinksTest {
   @Test
   void shouldRejectNullSink() {
     assertThrows(NullPointerException.class, () ->
-      registry.registerSink(RegistryKey.<Object>of("test", Object.class), (MessageSink<Object>) null)
+      registry.registerSink(RegistryKey.<Object>of("test", Object.class), null)
     );
   }
 
@@ -189,7 +189,7 @@ class MessageProcessorRegistrySinksTest {
   @Test
   void shouldThrowOnTypeMismatch() {
     final var key = RegistryKey.<String>of("typedSink", String.class);
-    registry.registerSink(key, (MessageSink<String>) msg -> {});
+    registry.registerSink(key, msg -> {});
 
     assertThrows(ClassCastException.class, () -> {
       @SuppressWarnings("unchecked")

--- a/lib/kpipe-format-avro/src/test/java/io/github/eschizoid/kpipe/format/avro/AvroFormatBehaviorTest.java
+++ b/lib/kpipe-format-avro/src/test/java/io/github/eschizoid/kpipe/format/avro/AvroFormatBehaviorTest.java
@@ -25,7 +25,7 @@ class AvroFormatBehaviorTest {
 
   @Test
   void constructorRejectsNullSchema() {
-    assertThrows(NullPointerException.class, () -> new AvroFormat((Schema) null));
+    assertThrows(NullPointerException.class, () -> new AvroFormat(null));
   }
 
   @Test

--- a/lib/kpipe-format-avro/src/test/java/io/github/eschizoid/kpipe/format/avro/AvroFormatRoundTripTest.java
+++ b/lib/kpipe-format-avro/src/test/java/io/github/eschizoid/kpipe/format/avro/AvroFormatRoundTripTest.java
@@ -31,7 +31,7 @@ class AvroFormatRoundTripTest {
     final var deserialized = pipeline.deserializeOrFail(bytes);
     return switch (pipeline.process(deserialized)) {
       case Result.Passed<T> p -> pipeline.serialize(p.value());
-      case Result.Filtered<T> __ -> null;
+      case Result.Filtered<T> _ -> null;
       case Result.Failed<T> f -> {
         if (f.cause() instanceof RuntimeException re) throw re;
         if (f.cause() instanceof Error err) throw err;

--- a/lib/kpipe-format-avro/src/test/java/io/github/eschizoid/kpipe/format/avro/AvroSchemaCatalogTest.java
+++ b/lib/kpipe-format-avro/src/test/java/io/github/eschizoid/kpipe/format/avro/AvroSchemaCatalogTest.java
@@ -112,7 +112,7 @@ class AvroSchemaCatalogTest {
   @Test
   void addRejectsNullSchemaJson() {
     final var catalog = new AvroSchemaCatalog();
-    assertThrows(NullPointerException.class, () -> catalog.add("user", (String) null));
+    assertThrows(NullPointerException.class, () -> catalog.add("user", null));
   }
 
   @Test

--- a/lib/kpipe-format-json/src/test/java/io/github/eschizoid/kpipe/format/json/JsonFormatPipelineTest.java
+++ b/lib/kpipe-format-json/src/test/java/io/github/eschizoid/kpipe/format/json/JsonFormatPipelineTest.java
@@ -22,7 +22,7 @@ class JsonFormatPipelineTest {
     final var deserialized = pipeline.deserializeOrFail(bytes);
     return switch (pipeline.process(deserialized)) {
       case Result.Passed<T> p -> pipeline.serialize(p.value());
-      case Result.Filtered<T> __ -> null;
+      case Result.Filtered<T> _ -> null;
       case Result.Failed<T> f -> {
         if (f.cause() instanceof RuntimeException re) throw re;
         if (f.cause() instanceof Error err) throw err;

--- a/lib/kpipe-format-json/src/test/java/io/github/eschizoid/kpipe/format/json/MessageProcessorRegistryJsonTest.java
+++ b/lib/kpipe-format-json/src/test/java/io/github/eschizoid/kpipe/format/json/MessageProcessorRegistryJsonTest.java
@@ -25,7 +25,7 @@ class MessageProcessorRegistryJsonTest {
     final var deserialized = pipeline.deserializeOrFail(bytes);
     return switch (pipeline.process(deserialized)) {
       case Result.Passed<T> p -> pipeline.serialize(p.value());
-      case Result.Filtered<T> __ -> null;
+      case Result.Filtered<T> _ -> null;
       case Result.Failed<T> f -> {
         if (f.cause() instanceof RuntimeException re) throw re;
         if (f.cause() instanceof Error err) throw err;

--- a/lib/kpipe-format-protobuf/src/test/java/io/github/eschizoid/kpipe/format/protobuf/ProtobufFormatPipelineTest.java
+++ b/lib/kpipe-format-protobuf/src/test/java/io/github/eschizoid/kpipe/format/protobuf/ProtobufFormatPipelineTest.java
@@ -30,7 +30,7 @@ class ProtobufFormatPipelineTest {
     final var deserialized = pipeline.deserializeOrFail(bytes);
     return switch (pipeline.process(deserialized)) {
       case Result.Passed<T> p -> pipeline.serialize(p.value());
-      case Result.Filtered<T> __ -> null;
+      case Result.Filtered<T> _ -> null;
       case Result.Failed<T> f -> {
         if (f.cause() instanceof RuntimeException re) throw re;
         if (f.cause() instanceof Error err) throw err;

--- a/lib/kpipe-metrics-otel/src/main/java/io/github/eschizoid/kpipe/metrics/otel/PipelineMetricsObserver.java
+++ b/lib/kpipe-metrics-otel/src/main/java/io/github/eschizoid/kpipe/metrics/otel/PipelineMetricsObserver.java
@@ -89,9 +89,9 @@ public final class PipelineMetricsObserver implements Consumer<Result<?>> {
   public void accept(final Result<?> result) {
     if (result == null) return;
     switch (result) {
-      case Result.Passed<?> __ -> passed.add(1, baseAttributes);
-      case Result.Filtered<?> __ -> filtered.add(1, baseAttributes);
-      case Result.Failed<?> __ -> failed.add(1, baseAttributes);
+      case Result.Passed<?> _ -> passed.add(1, baseAttributes);
+      case Result.Filtered<?> _ -> filtered.add(1, baseAttributes);
+      case Result.Failed<?> _ -> failed.add(1, baseAttributes);
     }
   }
 

--- a/lib/kpipe-producer/src/test/java/io/github/eschizoid/kpipe/producer/sink/KafkaMessageSinkTest.java
+++ b/lib/kpipe-producer/src/test/java/io/github/eschizoid/kpipe/producer/sink/KafkaMessageSinkTest.java
@@ -20,7 +20,6 @@ class KafkaMessageSinkTest {
   private Producer<byte[], byte[]> mockProducer;
 
   @Test
-  @SuppressWarnings("unchecked")
   void shouldSendToKafka() {
     final KafkaMessageSink<String> sink = KafkaMessageSink.of(mockProducer, TOPIC, String::getBytes, null);
 
@@ -38,7 +37,6 @@ class KafkaMessageSinkTest {
   }
 
   @Test
-  @SuppressWarnings("unchecked")
   void shouldSendWithKey() {
     final KafkaMessageSink<String> sink = new KafkaMessageSink<>(
       mockProducer,

--- a/lib/kpipe-tracing-otel/src/test/java/io/github/eschizoid/kpipe/tracing/otel/OtelTracerTest.java
+++ b/lib/kpipe-tracing-otel/src/test/java/io/github/eschizoid/kpipe/tracing/otel/OtelTracerTest.java
@@ -138,7 +138,7 @@ class OtelTracerTest {
   void noopTracerInjectionAndExtractionAreSilentNoops() {
     // Sanity — the noop default doesn't allocate, doesn't throw, and produces no span.
     final var noop = io.github.eschizoid.kpipe.producer.tracing.Tracer.noop();
-    final var record = new ConsumerRecord<>("t", 0, 0L, (Object) null, new byte[0]);
+    final var record = new ConsumerRecord<>("t", 0, 0L, null, new byte[0]);
     try (final var scope = noop.startConsumerSpan(record)) {
       noop.injectContextInto(new RecordHeaders());
       scope.recordException(new RuntimeException("ignored"));


### PR DESCRIPTION
## Summary

Mechanical clean-up driven by a multi-agent IDE-inspection survey (workflow over 12 lib modules, 375 findings total across all categories). This PR addresses only the categories that are safe to fix without per-site judgment.

## What's in this PR (43 findings)

| Category | Sites | Action |
|---|---:|---|
| `unused-pattern-variable` | 15 | rename `__` → `_` in sealed-`Result` pattern matches (JEP 456) |
| `redundant-cast` | 12 | remove casts the compiler can infer from context |
| `redundant-suppression` | 14 | delete stale `@SuppressWarnings` that no longer match any real warning |
| `unresolved-javadoc-symbol` (ERROR) | 2 | qualify `[Builder#...]` → `[KPipeConsumer.Builder#...]`, `[#close()]` → `[ParallelDispatcher#close()]` |

One redundant-cast site was kept against IntelliJ's verdict: `DispatcherIntegrationTest.java:105` has `end.put(tp, (long) recordsPerPartition)` where `recordsPerPartition` is an `int` and the map is `Map<TopicPartition, Long>` — the cast is the int → Long boxing path, and removing it fails compilation. IntelliJ was wrong on that one site.

## What's deferred (and why)

The other ~330 findings need per-site judgment, not a sweep:

- `unused-parameter` (51) — almost all deliberate-ignore in test lambdas; needs the `_` rename per-site rather than a blanket fix.
- `try-with-resources` (39) — integration tests deliberately span `Handle` / `KPipeConsumer` lifecycle across setup/assert/teardown; auto-wrapping changes shutdown semantics.
- `busy-wait` (17) — intentional poll-until-condition loops in shutdown drain and `KEY_ORDERED` retry paths.
- `nullable-handling` (16) — per-site decisions, especially the `AvroFormat` registry-mode hot path.
- `unused-method` (11) — public fluent-facade methods kept as escape hatches; documented in `docs/escape-hatches.md`.
- `unchecked-assignment` (9) — Mockito raw-type captures and Kafka `ConsumerRecord` / `ProducerRecord` generics need per-site decisions.

## Test plan

- [x] `./gradlew compileJava compileTestJava` clean
- [x] `./gradlew test` green (full unit test suite)
- [x] `./gradlew spotlessCheck` clean
- [x] CI green