### PR TITLE
fix(release): publish every :lib module, not just the hand-listed ten

### DIFF
--- a/lib/build.gradle.kts
+++ b/lib/build.gradle.kts
@@ -107,66 +107,19 @@ jreleaser {
         create("sonatype") {
           active.set(ALWAYS)
           url.set("https://central.sonatype.com/api/v1/publisher")
-          stagingRepository(
-            project(":lib:kpipe-bom").layout.buildDirectory
-              .dir("staging-deploy")
-              .get()
-              .asFile.absolutePath,
-          )
-          stagingRepository(
-            project(":lib:kpipe-core").layout.buildDirectory
-              .dir("staging-deploy")
-              .get()
-              .asFile.absolutePath,
-          )
-          stagingRepository(
-            project(":lib:kpipe-metrics").layout.buildDirectory
-              .dir("staging-deploy")
-              .get()
-              .asFile.absolutePath,
-          )
-          stagingRepository(
-            project(":lib:kpipe-metrics-otel").layout.buildDirectory
-              .dir("staging-deploy")
-              .get()
-              .asFile.absolutePath,
-          )
-          stagingRepository(
-            project(":lib:kpipe-producer").layout.buildDirectory
-              .dir("staging-deploy")
-              .get()
-              .asFile.absolutePath,
-          )
-          stagingRepository(
-            project(":lib:kpipe-consumer").layout.buildDirectory
-              .dir("staging-deploy")
-              .get()
-              .asFile.absolutePath,
-          )
-          stagingRepository(
-            project(":lib:kpipe-format-json").layout.buildDirectory
-              .dir("staging-deploy")
-              .get()
-              .asFile.absolutePath,
-          )
-          stagingRepository(
-            project(":lib:kpipe-format-avro").layout.buildDirectory
-              .dir("staging-deploy")
-              .get()
-              .asFile.absolutePath,
-          )
-          stagingRepository(
-            project(":lib:kpipe-format-protobuf").layout.buildDirectory
-              .dir("staging-deploy")
-              .get()
-              .asFile.absolutePath,
-          )
-          stagingRepository(
-            project(":lib:kpipe-api").layout.buildDirectory
-              .dir("staging-deploy")
-              .get()
-              .asFile.absolutePath,
-          )
+          // Iterate every `:lib` subproject (which all apply maven-publish in `subprojects {}`
+          // above) so adding a new lib module automatically participates in the release. The
+          // previous hand-maintained list silently dropped kpipe-tracing-otel and
+          // kpipe-schema-registry-confluent through v1.16.0; sourcing the list from the actual
+          // project graph removes that failure mode entirely.
+          subprojects.forEach { sub ->
+            stagingRepository(
+              sub.layout.buildDirectory
+                .dir("staging-deploy")
+                .get()
+                .asFile.absolutePath,
+            )
+          }
           enabled.set(true)
           sign.set(false)
           maxRetries.set(60)


### PR DESCRIPTION
## Summary

`kpipe-tracing-otel` and `kpipe-schema-registry-confluent` haven't been on Maven Central since they were added. The `lib/build.gradle.kts` JReleaser deploy block hard-codes the per-module `stagingRepository(...)` llist, and those two modules were never added to it — so every release through `v1.16.0` quietly dropped them.

### Verification

```bash
$ for a in kpipe-tracing-otel kpipe-schema-registry-confluent; do
    curl -s -o /dev/null -w "%{http_code}
" \
      "https://repo1.maven.org/maven2/io/github/eschizoid/$a/maven-metadata.xml"
  done
404
404
```

All ten of the other lib artifacts return `200` at `1.16.0`. `maven-publish` was staging the JARs locally just fine; JReleaser only pushed the ten paths it was told about.

## Fix

Replace the hand-maintained `stagingRepository(...)` list with:

```kotlin
subprojects.forEach { sub ->
  stagingRepository(
    sub.layout.buildDirectory.dir("staging-deploy").get().asFile.absolutePath,
  )
}
```

Sources the staging set from the actual project graph. Adding a new lib module is now a single `include("lib:foo")` in `settings.gradle.kts`; nothing else to remember on release day.

## "Won't this publish the examples?"

No. Inside `lib/build.gradle.kts`, `subprojects` only sees subprojects of `:lib` — the 12 `:lib:kpipe-*` modules. The `:examples` tree is a sibling top-level project, not under `:lib`. Verified:

```bash
$ ./gradlew :lib:jreleaserConfig -i 2>&1 | grep 'staging-deploy'
  /Users/.../lib/kpipe-api/build/staging-deploy
  /Users/.../lib/kpipe-bom/build/staging-deploy
  /Users/.../lib/kpipe-consumer/build/staging-deploy
  /Users/.../lib/kpipe-core/build/staging-deploy
  /Users/.../lib/kpipe-format-avro/build/staging-deploy
  /Users/.../lib/kpipe-format-json/build/staging-deploy
  /Users/.../lib/kpipe-format-protobuf/build/staging-deploy
  /Users/.../lib/kpipe-metrics/build/staging-deploy
  /Users/.../lib/kpipe-metrics-otel/build/staging-deploy
  /Users/.../lib/kpipe-producer/build/staging-deploy
  /Users/.../lib/kpipe-schema-registry-confluent/build/staging-deploy
  /Users/.../lib/kpipe-tracing-otel/build/staging-deploy
```

Exactly 12, no `examples` paths.

## Test plan

- [x] `./gradlew :lib:jreleaserConfig -i` lists all 12 `:lib:kpipe-*` staging paths and zero examples
- [x] Next release (`v1.16.1` or `v1.17.0`) publishes `kpipe-tracing-otel` and `kpipe-schema-registry-confluent` to Central
