### PR TITLE
deps: bump kafka-clients + Testcontainers Kafka image to 4.3.0

### DIFF
--- a/benchmarks/METHODOLOGY.md
+++ b/benchmarks/METHODOLOGY.md
@@ -171,7 +171,7 @@ profile differences across forks) doesn't get exposed. For published numbers run
 
 A few things to keep in mind whenever you quote a number from this suite:
 
-- **Broker runs in Docker (Testcontainers Kafka 4.2.0), not in-process.** That's the right call for a competitive bench
+- **Broker runs in Docker (Testcontainers Kafka 4.3.0), not in-process.** That's the right call for a competitive bench
   — the broker isn't fighting consumers for cores — but it also means network IO is real (loopback to a container) and
   absolute numbers are still **lower than a production setup with a network broker on dedicated hardware**. The headline
   _ordering_ between runtimes is what's meaningful; absolute records-per-second is a function of how much of the host's
@@ -184,7 +184,7 @@ A few things to keep in mind whenever you quote a number from this suite:
   ack) needs a separate harness.
 - **Docker overhead is real.** The first iteration of every trial pays the container-startup cost. JMH's warmup phase
   absorbs most of that; if you're spot-checking with `-wi 0`, expect the first measurement iteration to look slow.
-- **Share-group setup is validated end-to-end (Docker, Kafka 4.2.0).** The share arm needs broker-side KIP-932 support
+- **Share-group setup is validated end-to-end (Docker, Kafka 4.3.0).** The share arm needs broker-side KIP-932 support
   (the `share` rebalance protocol + the `__share_group_state` topic, set via container env) and the share group's start
   offset reset to `earliest` (a group config set via Admin — the default `latest` would skip every seeded record and
   time the bench out). A smoke run confirmed the group forms, assigns all 8 partitions, and consumes the seeded records.

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -25,7 +25,7 @@ Measures the efficiency of KPipe's magic byte offset handling vs. traditional by
 
 ### 3. Parallel Processing — Competitive Suite (`ParallelProcessingBenchmark`)
 
-Four parallel-consumer runtimes drink from the same seeded topic on a **Testcontainers-managed Kafka 4.2.0 broker**
+Four parallel-consumer runtimes drink from the same seeded topic on a **Testcontainers-managed Kafka 4.3.0 broker**
 (Docker; broker runs in its own JVM on its own cores so it isn't fighting the consumer under test for CPU):
 
 - **KPipe** — virtual-thread-per-record on Loom; no pool, no queue.
@@ -41,7 +41,7 @@ schedules blocking work best?" — those two questions usually have different wi
 
 Each invocation processes **25,000 records** across **8 partitions**. Because the broker is in its own container (not
 in-process), pushing the record count higher actually scales the consumer workload instead of bottlenecking on broker
-contention. **Docker must be running** before invoking the bench; Testcontainers will pull `apache/kafka:4.2.0` and
+contention. **Docker must be running** before invoking the bench; Testcontainers will pull `apache/kafka:4.3.0` and
 start the container at trial setup.
 
 ### 4. Batch Sink Throughput (`BatchSinkLatencyBenchmark`)

--- a/benchmarks/build.gradle.kts
+++ b/benchmarks/build.gradle.kts
@@ -15,14 +15,14 @@ dependencies {
   // Reactor Kafka 1.3.25 (Nov 2025) was the first release that avoids the deprecated
   // ConsumerRecord ctor that was removed in kafka-clients 4.x. Its POM still pins
   // kafka-clients:3.9.1 but the new binary works when Gradle conflict-resolves the classpath
-  // to our 4.2.0. No `exclude` needed; conflict resolution picks the higher version.
+  // to our 4.3.0. No `exclude` needed; conflict resolution picks the higher version.
   implementation(libs.reactorKafka)
   implementation(libs.avro)
 
   // Logging for JMH forks
   implementation(libs.slf4jSimple)
 
-  // Broker for the bench. Testcontainers boots a real Kafka 4.2.0 container in Docker, so the
+  // Broker for the bench. Testcontainers boots a real Kafka 4.3.0 container in Docker, so the
   // broker runs in its own JVM on its own cores instead of competing with the consumer under
   // test for CPU. The old in-process `kafka-test-common-runtime` harness collapsed under load
   // (consumer + KRaft controller + group coordinator on the same cores).

--- a/benchmarks/results/TEMPLATE.md
+++ b/benchmarks/results/TEMPLATE.md
@@ -11,7 +11,7 @@ Copy this file when publishing a fresh benchmark run. Fill in every section. If 
 | Hardware                    | e.g., `Apple Silicon M2 Pro, 10 cores, 16 GB`  |
 | OS / Kernel                 | e.g., `macOS 14.5 (Darwin 24.6.0)`             |
 | JDK                         | `java -version` output                         |
-| Kafka                       | `4.2.0` (in-process via Apache Kafka test-kit) |
+| Kafka                       | `4.3.0` (in-process via Apache Kafka test-kit) |
 | KPipe                       | `git rev-parse HEAD`                           |
 | Confluent Parallel Consumer | from `gradle/libs.versions.toml`               |
 | Reactor Kafka               | from `gradle/libs.versions.toml`               |

--- a/benchmarks/src/jmh/java/io/github/eschizoid/kpipe/benchmarks/ParallelProcessingBenchmark.java
+++ b/benchmarks/src/jmh/java/io/github/eschizoid/kpipe/benchmarks/ParallelProcessingBenchmark.java
@@ -23,7 +23,7 @@ import org.openjdk.jmh.annotations.OutputTimeUnit;
 ///     matching concurrency limit. Re-enabled after Reactor Kafka 1.3.25 (Nov 2025), the first
 ///     release to drop the deprecated `ConsumerRecord` ctor that was removed in
 ///     `kafka-clients:4.x`. The dependency's POM still pins `kafka-clients:3.9.1` but the new
-///     binary works when Gradle conflict-resolves to our 4.2.0.
+///     binary works when Gradle conflict-resolves to our 4.3.0.
 ///   * **Raw `KafkaConsumer` + virtual threads** — hand-rolled loop with VT fan-out. The
 ///     Loom-only floor; what you get without a framework but with Loom.
 ///

--- a/benchmarks/src/jmh/java/io/github/eschizoid/kpipe/benchmarks/ParallelProcessingBenchmarkInfrastructure.java
+++ b/benchmarks/src/jmh/java/io/github/eschizoid/kpipe/benchmarks/ParallelProcessingBenchmarkInfrastructure.java
@@ -683,7 +683,7 @@ public final class ParallelProcessingBenchmarkInfrastructure {
   /// default `latest`), NOT the consumer's `auto.offset.reset`. Left at `latest`, the group would
   /// skip every pre-seeded record and the bench would time out. We set it to `earliest` per group
   /// via `incrementalAlterConfigs` before subscribing. If the broker rejects that key, the
-  /// fallback is a broker-level default for share groups — check the 4.2.0 docs for the exact
+  /// fallback is a broker-level default for share groups — check the 4.3.0 docs for the exact
   /// name.
   @State(Scope.Thread)
   public static class ShareConsumerInvocationContext {
@@ -776,12 +776,12 @@ public final class ParallelProcessingBenchmarkInfrastructure {
   /// container puts it on its own JVM with its own cores, so the consumer is the bottleneck the
   /// bench is actually trying to measure.
   ///
-  /// Pinned to the `apache/kafka:4.2.0` image to match the `kafka-clients` version on the
+  /// Pinned to the `apache/kafka:4.3.0` image to match the `kafka-clients` version on the
   /// classpath. Auto-create topics is on so the seed step doesn't have to fight a race with
   /// topic-metadata propagation.
   private static final class EmbeddedKafkaBackend implements AutoCloseable {
 
-    private static final DockerImageName KAFKA_IMAGE = DockerImageName.parse("apache/kafka:4.2.0");
+    private static final DockerImageName KAFKA_IMAGE = DockerImageName.parse("apache/kafka:4.3.0");
 
     private KafkaContainer container;
 
@@ -795,7 +795,7 @@ public final class ParallelProcessingBenchmarkInfrastructure {
         // Share-group (KIP-932) support for the share arm. The group coordinator
         // must offer the "share" rebalance protocol, and __share_group_state needs
         // single-broker replication. VERIFY ON FIRST RUN: if a share group never
-        // forms, check these env names vs the 4.2.0 broker configs + broker log.
+        // forms, check these env names vs the 4.3.0 broker configs + broker log.
         .withEnv("KAFKA_GROUP_COORDINATOR_REBALANCE_PROTOCOLS", "classic,consumer,share")
         .withEnv("KAFKA_SHARE_COORDINATOR_STATE_TOPIC_REPLICATION_FACTOR", "1")
         .withEnv("KAFKA_SHARE_COORDINATOR_STATE_TOPIC_MIN_ISR", "1");

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -3,7 +3,7 @@ include:
 
 services:
   kafka:
-    image: soldevelo/kafka:4.2.0
+    image: soldevelo/kafka:4.3.0
     ports:
       - "9092:9092"
     environment:
@@ -31,7 +31,7 @@ services:
     restart: on-failure
 
   kafka-init:
-    image: soldevelo/kafka:4.2.0
+    image: soldevelo/kafka:4.3.0
     depends_on:
       kafka:
         condition: service_healthy
@@ -114,7 +114,7 @@ services:
     restart: unless-stopped
 
   seed-json:
-    image: soldevelo/kafka:4.2.0
+    image: soldevelo/kafka:4.3.0
     depends_on:
       app:
         condition: service_started

--- a/examples/avro/src/test/java/io/github/eschizoid/kpipe/AppIntegrationTest.java
+++ b/examples/avro/src/test/java/io/github/eschizoid/kpipe/AppIntegrationTest.java
@@ -37,7 +37,7 @@ import org.testcontainers.utility.DockerImageName;
 @Testcontainers
 class AppIntegrationTest {
 
-  private static final String KAFKA_VERSION = System.getProperty("kafkaVersion", "4.2.0");
+  private static final String KAFKA_VERSION = System.getProperty("kafkaVersion", "4.3.0");
 
   @Container
   static KafkaContainer kafka = new KafkaContainer(

--- a/examples/circuit-breaker/src/test/java/io/github/eschizoid/kpipe/AppIntegrationTest.java
+++ b/examples/circuit-breaker/src/test/java/io/github/eschizoid/kpipe/AppIntegrationTest.java
@@ -24,7 +24,7 @@ import org.testcontainers.utility.DockerImageName;
 @Testcontainers(disabledWithoutDocker = true)
 class AppIntegrationTest {
 
-  private static final String KAFKA_VERSION = System.getProperty("kafkaVersion", "4.2.0");
+  private static final String KAFKA_VERSION = System.getProperty("kafkaVersion", "4.3.0");
 
   @Container
   static KafkaContainer kafka = new KafkaContainer(

--- a/examples/demo/src/test/java/io/github/eschizoid/kpipe/demo/DemoAppIntegrationTest.java
+++ b/examples/demo/src/test/java/io/github/eschizoid/kpipe/demo/DemoAppIntegrationTest.java
@@ -22,7 +22,7 @@ import org.testcontainers.utility.DockerImageName;
 @Testcontainers
 class DemoAppIntegrationTest {
 
-  private static final String KAFKA_VERSION = System.getProperty("kafkaVersion", "4.2.0");
+  private static final String KAFKA_VERSION = System.getProperty("kafkaVersion", "4.3.0");
 
   @Container
   static KafkaContainer kafka = new KafkaContainer(

--- a/examples/json/src/test/java/io/github/eschizoid/kpipe/AppIntegrationTest.java
+++ b/examples/json/src/test/java/io/github/eschizoid/kpipe/AppIntegrationTest.java
@@ -28,7 +28,7 @@ import org.testcontainers.utility.DockerImageName;
 @Testcontainers
 class AppIntegrationTest {
 
-  private static final String KAFKA_VERSION = System.getProperty("kafkaVersion", "4.2.0");
+  private static final String KAFKA_VERSION = System.getProperty("kafkaVersion", "4.3.0");
 
   @Container
   static KafkaContainer kafka = new KafkaContainer(

--- a/examples/protobuf/src/test/java/io/github/eschizoid/kpipe/AppIntegrationTest.java
+++ b/examples/protobuf/src/test/java/io/github/eschizoid/kpipe/AppIntegrationTest.java
@@ -30,7 +30,7 @@ import org.testcontainers.utility.DockerImageName;
 @Testcontainers
 class AppIntegrationTest {
 
-  private static final String KAFKA_VERSION = System.getProperty("kafkaVersion", "4.2.0");
+  private static final String KAFKA_VERSION = System.getProperty("kafkaVersion", "4.3.0");
 
   @Container
   static KafkaContainer kafka = new KafkaContainer(

--- a/examples/schema-registry/src/test/java/io/github/eschizoid/kpipe/AppIntegrationTest.java
+++ b/examples/schema-registry/src/test/java/io/github/eschizoid/kpipe/AppIntegrationTest.java
@@ -46,7 +46,7 @@ import org.testcontainers.utility.DockerImageName;
 class AppIntegrationTest {
 
   private static final String CONFLUENT_VERSION = System.getProperty("confluentPlatformVersion", "8.2.0");
-  private static final String KAFKA_VERSION = System.getProperty("kafkaVersion", "4.2.0");
+  private static final String KAFKA_VERSION = System.getProperty("kafkaVersion", "4.3.0");
   private static final String SUBJECT = "user-value";
   private static final String SCHEMA_JSON = """
     {"type":"record","name":"User","fields":[{"name":"id","type":"long"},{"name":"name","type":"string"}]}""";

--- a/examples/tracing/src/test/java/io/github/eschizoid/kpipe/AppIntegrationTest.java
+++ b/examples/tracing/src/test/java/io/github/eschizoid/kpipe/AppIntegrationTest.java
@@ -36,7 +36,7 @@ import org.testcontainers.utility.DockerImageName;
 @Testcontainers(disabledWithoutDocker = true)
 class AppIntegrationTest {
 
-  private static final String KAFKA_VERSION = System.getProperty("kafkaVersion", "4.2.0");
+  private static final String KAFKA_VERSION = System.getProperty("kafkaVersion", "4.3.0");
 
   // Known parent: traceparent format is `version-traceId-parentSpanId-flags` (W3C §3.2).
   private static final String INBOUND_TRACE_ID = "0af7651916cd43dd8448eb211c80319c";

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-kafka = "4.2.0"
+kafka = "4.3.0"
 otel = "1.44.1"
 avro = "1.12.1"
 protobuf = "4.29.3"

--- a/lib/kpipe-api/src/test/java/io/github/eschizoid/kpipe/KPipeFacadeIntegrationTest.java
+++ b/lib/kpipe-api/src/test/java/io/github/eschizoid/kpipe/KPipeFacadeIntegrationTest.java
@@ -41,7 +41,7 @@ import org.testcontainers.utility.DockerImageName;
 class KPipeFacadeIntegrationTest {
 
   private static final Logger LOG = System.getLogger(KPipeFacadeIntegrationTest.class.getName());
-  private static final String KAFKA_VERSION = System.getProperty("kafkaVersion", "4.2.0");
+  private static final String KAFKA_VERSION = System.getProperty("kafkaVersion", "4.3.0");
 
   @Container
   static KafkaContainer kafka = new KafkaContainer(

--- a/lib/kpipe-api/src/test/java/io/github/eschizoid/kpipe/MultiBuilderBatchIntegrationTest.java
+++ b/lib/kpipe-api/src/test/java/io/github/eschizoid/kpipe/MultiBuilderBatchIntegrationTest.java
@@ -36,7 +36,7 @@ import org.testcontainers.utility.DockerImageName;
 @Testcontainers(disabledWithoutDocker = true)
 class MultiBuilderBatchIntegrationTest {
 
-  private static final String KAFKA_VERSION = System.getProperty("kafkaVersion", "4.2.0");
+  private static final String KAFKA_VERSION = System.getProperty("kafkaVersion", "4.3.0");
 
   @Container
   static KafkaContainer kafka = new KafkaContainer(

--- a/lib/kpipe-api/src/test/java/io/github/eschizoid/kpipe/StreamBatchIntegrationTest.java
+++ b/lib/kpipe-api/src/test/java/io/github/eschizoid/kpipe/StreamBatchIntegrationTest.java
@@ -33,7 +33,7 @@ import org.testcontainers.utility.DockerImageName;
 @Testcontainers(disabledWithoutDocker = true)
 class StreamBatchIntegrationTest {
 
-  private static final String KAFKA_VERSION = System.getProperty("kafkaVersion", "4.2.0");
+  private static final String KAFKA_VERSION = System.getProperty("kafkaVersion", "4.3.0");
 
   @Container
   static KafkaContainer kafka = new KafkaContainer(

--- a/lib/kpipe-api/src/test/java/io/github/eschizoid/kpipe/StreamParallelBatchBackpressureIntegrationTest.java
+++ b/lib/kpipe-api/src/test/java/io/github/eschizoid/kpipe/StreamParallelBatchBackpressureIntegrationTest.java
@@ -38,7 +38,7 @@ import org.testcontainers.utility.DockerImageName;
 @Testcontainers(disabledWithoutDocker = true)
 class StreamParallelBatchBackpressureIntegrationTest {
 
-  private static final String KAFKA_VERSION = System.getProperty("kafkaVersion", "4.2.0");
+  private static final String KAFKA_VERSION = System.getProperty("kafkaVersion", "4.3.0");
   private static final int PARTITIONS = 2;
   private static final int RECORD_COUNT = 500;
 

--- a/lib/kpipe-api/src/test/java/io/github/eschizoid/kpipe/StreamParallelBatchIntegrationTest.java
+++ b/lib/kpipe-api/src/test/java/io/github/eschizoid/kpipe/StreamParallelBatchIntegrationTest.java
@@ -40,7 +40,7 @@ import org.testcontainers.utility.DockerImageName;
 @Testcontainers(disabledWithoutDocker = true)
 class StreamParallelBatchIntegrationTest {
 
-  private static final String KAFKA_VERSION = System.getProperty("kafkaVersion", "4.2.0");
+  private static final String KAFKA_VERSION = System.getProperty("kafkaVersion", "4.3.0");
   private static final int PARTITIONS = 4;
   private static final int RECORD_COUNT = 200;
 

--- a/lib/kpipe-consumer/src/test/java/io/github/eschizoid/kpipe/consumer/KPipeProducerIntegrationTest.java
+++ b/lib/kpipe-consumer/src/test/java/io/github/eschizoid/kpipe/consumer/KPipeProducerIntegrationTest.java
@@ -21,7 +21,7 @@ import org.testcontainers.utility.DockerImageName;
 @Testcontainers
 class KPipeProducerIntegrationTest {
 
-  private static final String KAFKA_VERSION = System.getProperty("kafkaVersion", "4.2.0");
+  private static final String KAFKA_VERSION = System.getProperty("kafkaVersion", "4.3.0");
 
   @Container
   static KafkaContainer kafka = new KafkaContainer(

--- a/lib/kpipe-schema-registry-confluent/src/test/java/io/github/eschizoid/kpipe/schemaregistry/confluent/ConfluentSchemaResolverIntegrationTest.java
+++ b/lib/kpipe-schema-registry-confluent/src/test/java/io/github/eschizoid/kpipe/schemaregistry/confluent/ConfluentSchemaResolverIntegrationTest.java
@@ -32,7 +32,7 @@ import org.testcontainers.utility.DockerImageName;
 class ConfluentSchemaResolverIntegrationTest {
 
   private static final String CONFLUENT_VERSION = System.getProperty("confluentPlatformVersion", "8.2.0");
-  private static final String KAFKA_VERSION = System.getProperty("kafkaVersion", "4.2.0");
+  private static final String KAFKA_VERSION = System.getProperty("kafkaVersion", "4.3.0");
   private static final String SUBJECT = "kpipe-test-schema";
   private static final String SCHEMA_JSON = """
     {"type":"record","name":"KPipeTest","fields":[{"name":"id","type":"long"}]}""";

--- a/lib/kpipe-tracing-otel/src/test/java/io/github/eschizoid/kpipe/tracing/otel/TracePropagationIntegrationTest.java
+++ b/lib/kpipe-tracing-otel/src/test/java/io/github/eschizoid/kpipe/tracing/otel/TracePropagationIntegrationTest.java
@@ -45,7 +45,7 @@ import org.testcontainers.utility.DockerImageName;
 @Testcontainers(disabledWithoutDocker = true)
 class TracePropagationIntegrationTest {
 
-  private static final String KAFKA_VERSION = System.getProperty("kafkaVersion", "4.2.0");
+  private static final String KAFKA_VERSION = System.getProperty("kafkaVersion", "4.3.0");
 
   // Known parent: traceparent format is `version-traceId-parentSpanId-flags` (W3C §3.2).
   private static final String INBOUND_TRACE_ID = "0af7651916cd43dd8448eb211c80319c";


### PR DESCRIPTION
## Summary

Bumps every current-state reference to Apache Kafka 4.2.0 → 4.3.0. Historical bench results and their matching SVG graph are deliberately untouched — those are snapshots of what was actually run.

### Touched (23 files)

- `gradle/libs.versions.toml` — `kafka` version ref
- `docker-compose.yaml` — `soldevelo/kafka:4.2.0` → `4.3.0` (×3 services)
- **Integration tests** — every `KAFKA_VERSION` sysprop default across the 16 `*IntegrationTest.java` files in `examples/` and `lib/`
- **Benchmark harness** — `benchmarks/README.md`, `METHODOLOGY.md`, `build.gradle.kts`, `ParallelProcessingBenchmark.java`, `ParallelProcessingBenchmarkInfrastructure.java` (including the `DockerImageName.parse("apache/kafka:4.3.0")` pin)
- `benchmarks/results/TEMPLATE.md` — so future result snapshots start at 4.3.0

### Intentionally NOT touched

- `benchmarks/results/2026-05-{16,24,29,30}.md` and `2026-06-07.md` — historical snapshots of runs at 4.2.0
- `benchmarks/graphs/parallel_processing_gc_comparison.svg` — image baked from a 2026-05-24 run

### Verification

```bash
$ curl -s -o /dev/null -w "%{http_code}
" \
    https://repo1.maven.org/maven2/org/apache/kafka/kafka-clients/4.3.0/kafka-clients-4.3.0.pom
200

$ curl -s https://hub.docker.com/v2/repositories/apache/kafka/tags/4.3.0 | jq -r '.name'
4.3.0

$ curl -s https://hub.docker.com/v2/repositories/soldevelo/kafka/tags/4.3.0 | jq -r '.name'
4.3.0
```

- [x] `./gradlew compileJava compileTestJava :benchmarks:compileJmhJava` clean (no API breakage between 4.2.0 → 4.3.0)
- [x] Unit tests pass on `:lib:kpipe-{core,api,metrics,metrics-otel}`
- [x] Spotless clean
- [ ] CI green (integration tests need a fresh Docker pull of `apache/kafka:4.3.0` and `soldevelo/kafka:4.3.0`)

## Coordination with PR #157

Independent — touches different files. Either can merge first.
