### PR TITLE
test: assert OTel metrics emission against a real SDK + tighten OtelSpanScope

### DIFF
--- a/lib/kpipe-metrics-otel/build.gradle.kts
+++ b/lib/kpipe-metrics-otel/build.gradle.kts
@@ -29,6 +29,12 @@ dependencies {
 
   testImplementation(libs.mockitoCore)
   testImplementation(libs.mockitoJunitJupiter)
+
+  // Real SDK + InMemoryMetricReader for assertions that the OTel impls actually emit metrics
+  // with the right name, value, and attributes — the previous noop-only smoke tests would let
+  // emission regressions land silently.
+  testImplementation(libs.opentelemetrySdk)
+  testImplementation(libs.opentelemetrySdkTesting)
 }
 
 tasks.test {

--- a/lib/kpipe-metrics-otel/src/test/java/io/github/eschizoid/kpipe/metrics/otel/OtelConsumerMetricsTest.java
+++ b/lib/kpipe-metrics-otel/src/test/java/io/github/eschizoid/kpipe/metrics/otel/OtelConsumerMetricsTest.java
@@ -1,68 +1,247 @@
 package io.github.eschizoid.kpipe.metrics.otel;
 
-import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.*;
 
-import io.github.eschizoid.kpipe.metrics.ConsumerMetrics;
-import io.opentelemetry.api.OpenTelemetry;
+import io.opentelemetry.api.common.AttributeKey;
+import io.opentelemetry.sdk.OpenTelemetrySdk;
+import io.opentelemetry.sdk.metrics.SdkMeterProvider;
+import io.opentelemetry.sdk.metrics.data.MetricData;
+import io.opentelemetry.sdk.testing.exporter.InMemoryMetricReader;
+import java.util.Collection;
 import org.junit.jupiter.api.Test;
 
-/// Smoke tests for [OtelConsumerMetrics] using the no-op OTel provider — verifies the
-/// implementation wires up correctly without requiring an SDK.
+/// Asserts that [OtelConsumerMetrics] actually emits the documented counters and histogram into a
+/// real OTel SDK — not just that the calls don't throw. Built around `InMemoryMetricReader` so
+/// every assertion is on captured metric data: name, value, and attributes. Catches the class of
+/// regression where someone accidentally drops a `counter.add(...)` call or changes a metric
+/// name; the previous noop-only tests against `OpenTelemetry.noop()` would have happily passed.
 class OtelConsumerMetricsTest {
 
-  @Test
-  void shouldImplementConsumerMetricsInterface() {
-    final ConsumerMetrics metrics = new OtelConsumerMetrics(OpenTelemetry.noop());
-    assertNotNull(metrics);
-  }
+  private static final AttributeKey<String> TOPIC_KEY = AttributeKey.stringKey("topic");
+  private static final AttributeKey<String> PIPELINE_KEY = AttributeKey.stringKey("pipeline");
+  private static final AttributeKey<String> CB_STATE_KEY = AttributeKey.stringKey("circuit_breaker.state");
 
-  @Test
-  void shouldAcceptInFlightSupplier() {
-    final var metrics = new OtelConsumerMetrics(OpenTelemetry.noop(), () -> 42L);
-    assertNotNull(metrics);
-  }
-
-  @Test
-  void shouldAcceptPipelineLabel() {
-    final var metrics = new OtelConsumerMetrics(OpenTelemetry.noop(), "my-pipeline");
-    assertNotNull(metrics);
-  }
-
-  @Test
-  void shouldRecordEventsWithoutThrowing() {
-    final var metrics = new OtelConsumerMetrics(OpenTelemetry.noop(), () -> 0L, "test");
-    assertDoesNotThrow(() -> metrics.recordMessageReceived());
-    assertDoesNotThrow(() -> metrics.recordMessageProcessed());
-    assertDoesNotThrow(() -> metrics.recordProcessingError());
-    assertDoesNotThrow(() -> metrics.recordProcessingDuration(42L));
-    assertDoesNotThrow(metrics::recordBackpressurePause);
-    assertDoesNotThrow(() -> metrics.recordBackpressureTime(150L));
-  }
-
-  @Test
-  void shouldRecordTopicScopedEventsWithoutThrowing() {
-    final var metrics = new OtelConsumerMetrics(OpenTelemetry.noop(), () -> 0L, "test");
-    assertDoesNotThrow(() -> metrics.recordMessageReceived("events-a"));
-    assertDoesNotThrow(() -> metrics.recordMessageProcessed("events-a"));
-    assertDoesNotThrow(() -> metrics.recordProcessingError("events-a"));
-    assertDoesNotThrow(() -> metrics.recordProcessingDuration("events-a", 42L));
-  }
-
-  @Test
-  void shouldSupportConcurrentRecordingFromVirtualThreads() throws InterruptedException {
-    final var metrics = new OtelConsumerMetrics(OpenTelemetry.noop(), () -> 0L, "concurrent");
-    final var threads = new Thread[50];
-    for (int i = 0; i < threads.length; i++) {
-      threads[i] = Thread.ofVirtual().start(() -> {
-        metrics.recordMessageReceived();
-        metrics.recordMessageProcessed();
-        metrics.recordProcessingError();
-        metrics.recordProcessingDuration(10L);
-        metrics.recordBackpressurePause();
-        metrics.recordBackpressureTime(5L);
-      });
+  /// Per-test fixture so each metric capture is isolated.
+  private record Fixture(OtelConsumerMetrics metrics, InMemoryMetricReader reader) {
+    Collection<MetricData> collect() {
+      return reader.collectAllMetrics();
     }
-    for (final var t : threads) t.join();
+  }
+
+  private static Fixture fixture(final String pipelineName) {
+    final var reader = InMemoryMetricReader.create();
+    final var sdk = OpenTelemetrySdk.builder()
+      .setMeterProvider(SdkMeterProvider.builder().registerMetricReader(reader).build())
+      .build();
+    return new Fixture(new OtelConsumerMetrics(sdk, () -> 0L, pipelineName), reader);
+  }
+
+  private static MetricData findByName(final Collection<MetricData> metrics, final String name) {
+    return metrics
+      .stream()
+      .filter(m -> m.getName().equals(name))
+      .findFirst()
+      .orElseThrow(() ->
+        new AssertionError(
+          "metric not emitted: " + name + " (saw: " + metrics.stream().map(MetricData::getName).sorted().toList() + ")"
+        )
+      );
+  }
+
+  @Test
+  void recordMessageReceivedEmitsCounter() {
+    final var f = fixture("test");
+    f.metrics().recordMessageReceived();
+    final var counter = findByName(f.collect(), "kpipe.consumer.messages.received");
+    final var point = counter.getLongSumData().getPoints().iterator().next();
+    assertEquals(1L, point.getValue(), "expected one increment");
+    assertEquals("test", point.getAttributes().get(PIPELINE_KEY), "pipeline attribute must be attached");
+  }
+
+  @Test
+  void topicScopedRecordMessageReceivedAttachesTopicAttribute() {
+    final var f = fixture("test");
+    f.metrics().recordMessageReceived("orders");
+    final var point = findByName(f.collect(), "kpipe.consumer.messages.received")
+      .getLongSumData()
+      .getPoints()
+      .iterator()
+      .next();
+    assertEquals(1L, point.getValue());
+    assertEquals("orders", point.getAttributes().get(TOPIC_KEY));
+    assertEquals("test", point.getAttributes().get(PIPELINE_KEY));
+  }
+
+  @Test
+  void recordMessageProcessedEmitsCounter() {
+    final var f = fixture(null);
+    f.metrics().recordMessageProcessed();
+    final var point = findByName(f.collect(), "kpipe.consumer.messages.processed")
+      .getLongSumData()
+      .getPoints()
+      .iterator()
+      .next();
+    assertEquals(1L, point.getValue());
+    assertNull(
+      point.getAttributes().get(PIPELINE_KEY),
+      "null pipelineName must omit the attribute, not write the literal 'null'"
+    );
+  }
+
+  @Test
+  void recordProcessingErrorEmitsCounter() {
+    final var f = fixture("test");
+    f.metrics().recordProcessingError("orders");
+    final var point = findByName(f.collect(), "kpipe.consumer.messages.errors")
+      .getLongSumData()
+      .getPoints()
+      .iterator()
+      .next();
+    assertEquals(1L, point.getValue());
+    assertEquals("orders", point.getAttributes().get(TOPIC_KEY));
+  }
+
+  @Test
+  void recordProcessingDurationEmitsHistogram() {
+    final var f = fixture("test");
+    f.metrics().recordProcessingDuration(42L);
+    f.metrics().recordProcessingDuration(58L);
+    final var hist = findByName(f.collect(), "kpipe.consumer.processing.duration")
+      .getHistogramData()
+      .getPoints()
+      .iterator()
+      .next();
+    assertEquals(2L, hist.getCount(), "two samples recorded");
+    assertEquals(100.0, hist.getSum(), 0.001, "sum must be 42 + 58");
+  }
+
+  @Test
+  void backpressureMetricsEmit() {
+    final var f = fixture("test");
+    f.metrics().recordBackpressurePause();
+    f.metrics().recordBackpressureTime(150L);
+    f.metrics().recordBackpressureTime(50L);
+    final var metrics = f.collect();
+    assertEquals(
+      1L,
+      findByName(metrics, "kpipe.consumer.backpressure.pauses")
+        .getLongSumData()
+        .getPoints()
+        .iterator()
+        .next()
+        .getValue()
+    );
+    assertEquals(
+      200L,
+      findByName(metrics, "kpipe.consumer.backpressure.time").getLongSumData().getPoints().iterator().next().getValue(),
+      "backpressure.time is a counter summing total paused ms"
+    );
+  }
+
+  @Test
+  void circuitBreakerTripsEmits() {
+    final var f = fixture("test");
+    f.metrics().recordCircuitBreakerTrip();
+    f.metrics().recordCircuitBreakerTrip();
+    final var point = findByName(f.collect(), "kpipe.consumer.circuit_breaker.trips")
+      .getLongSumData()
+      .getPoints()
+      .iterator()
+      .next();
+    assertEquals(2L, point.getValue());
+  }
+
+  @Test
+  void circuitBreakerStateChangeEmitsWithStateAttribute() {
+    final var f = fixture("test");
+    f.metrics().recordCircuitBreakerStateChange(CircuitState.OPEN);
+    f.metrics().recordCircuitBreakerStateChange(CircuitState.HALF_OPEN);
+    f.metrics().recordCircuitBreakerStateChange(CircuitState.OPEN);
+    final var counter = findByName(f.collect(), "kpipe.consumer.circuit_breaker.state_changes");
+    // Three increments expected, but they split across two distinct attribute sets (OPEN ×2,
+    // HALF_OPEN ×1). Sum across the points must be 3 and each attribute set must match.
+    final var points = counter.getLongSumData().getPoints();
+    final var total = points
+      .stream()
+      .mapToLong(p -> p.getValue())
+      .sum();
+    assertEquals(3L, total, "all three state changes accounted for");
+    final var openCount = points
+      .stream()
+      .filter(p -> "OPEN".equals(p.getAttributes().get(CB_STATE_KEY)))
+      .mapToLong(p -> p.getValue())
+      .sum();
+    final var halfOpenCount = points
+      .stream()
+      .filter(p -> "HALF_OPEN".equals(p.getAttributes().get(CB_STATE_KEY)))
+      .mapToLong(p -> p.getValue())
+      .sum();
+    assertEquals(2L, openCount, "two transitions into OPEN");
+    assertEquals(1L, halfOpenCount, "one transition into HALF_OPEN");
+  }
+
+  @Test
+  void circuitBreakerStateChangeIgnoresNull() {
+    final var f = fixture("test");
+    f.metrics().recordCircuitBreakerStateChange(null);
+    final var sum = f
+      .collect()
+      .stream()
+      .filter(m -> m.getName().equals("kpipe.consumer.circuit_breaker.state_changes"))
+      .findFirst();
+    assertTrue(
+      sum.isEmpty() || sum.get().getLongSumData().getPoints().isEmpty(),
+      "null state must not record anything — would otherwise attach a literal 'null' attribute"
+    );
+  }
+
+  @Test
+  void circuitBreakerTimeOpenEmits() {
+    final var f = fixture("test");
+    f.metrics().recordCircuitBreakerTimeOpen(5000L);
+    final var point = findByName(f.collect(), "kpipe.consumer.circuit_breaker.time_open")
+      .getLongSumData()
+      .getPoints()
+      .iterator()
+      .next();
+    assertEquals(5000L, point.getValue());
+  }
+
+  @Test
+  void inFlightGaugeIsRegisteredAndUsesSupplier() {
+    final var reader = InMemoryMetricReader.create();
+    final var sdk = OpenTelemetrySdk.builder()
+      .setMeterProvider(SdkMeterProvider.builder().registerMetricReader(reader).build())
+      .build();
+    // Construct with a supplier that returns a fixed value; the gauge callback must fire on
+    // collection and surface that value.
+    @SuppressWarnings("unused")
+    final var metrics = new OtelConsumerMetrics(sdk, () -> 17L, "test");
+    final var point = findByName(reader.collectAllMetrics(), "kpipe.consumer.messages.inflight")
+      .getLongGaugeData()
+      .getPoints()
+      .iterator()
+      .next();
+    assertEquals(17L, point.getValue(), "inflight gauge must read from the supplier");
+  }
+
+  @Test
+  void topicAttributeCacheReturnsSameAttributesForRepeatedTopic() {
+    // Recording the same topic many times shouldn't allocate a new Attributes per call.
+    // This is observable as a stable per-topic point set: 1000 increments → one point with
+    // value=1000 (not 1000 points each with value=1).
+    final var f = fixture("test");
+    for (int i = 0; i < 1000; i++) f.metrics().recordMessageReceived("orders");
+    final var points = findByName(f.collect(), "kpipe.consumer.messages.received").getLongSumData().getPoints();
+    assertEquals(1, points.size(), "all increments under the same topic attribute must merge into one point");
+    assertEquals(1000L, points.iterator().next().getValue());
+  }
+
+  /// Minimal enum stand-in for a circuit-breaker state, since this module does not depend on
+  /// `kpipe-consumer`.
+  private enum CircuitState {
+    CLOSED,
+    OPEN,
+    HALF_OPEN,
   }
 }

--- a/lib/kpipe-metrics-otel/src/test/java/io/github/eschizoid/kpipe/metrics/otel/OtelProducerMetricsTest.java
+++ b/lib/kpipe-metrics-otel/src/test/java/io/github/eschizoid/kpipe/metrics/otel/OtelProducerMetricsTest.java
@@ -1,40 +1,85 @@
 package io.github.eschizoid.kpipe.metrics.otel;
 
-import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.*;
 
-import io.github.eschizoid.kpipe.metrics.ProducerMetrics;
-import io.opentelemetry.api.OpenTelemetry;
+import io.opentelemetry.sdk.OpenTelemetrySdk;
+import io.opentelemetry.sdk.metrics.SdkMeterProvider;
+import io.opentelemetry.sdk.metrics.data.MetricData;
+import io.opentelemetry.sdk.testing.exporter.InMemoryMetricReader;
+import java.util.Collection;
 import org.junit.jupiter.api.Test;
 
-/// Smoke tests for [OtelProducerMetrics] using the no-op OTel provider.
+/// Asserts that [OtelProducerMetrics] emits each of the documented producer counters into a real
+/// OTel SDK. Same rationale as [OtelConsumerMetricsTest] — the previous noop-only tests would
+/// have let a dropped `counter.add(...)` regression land silently.
 class OtelProducerMetricsTest {
 
-  @Test
-  void shouldImplementProducerMetricsInterface() {
-    final ProducerMetrics metrics = new OtelProducerMetrics(OpenTelemetry.noop());
-    assertNotNull(metrics);
-  }
-
-  @Test
-  void shouldRecordEventsWithoutThrowing() {
-    final var metrics = new OtelProducerMetrics(OpenTelemetry.noop());
-    assertDoesNotThrow(metrics::recordMessageSent);
-    assertDoesNotThrow(metrics::recordMessageFailed);
-    assertDoesNotThrow(metrics::recordDlqSent);
-  }
-
-  @Test
-  void shouldSupportConcurrentRecordingFromVirtualThreads() throws InterruptedException {
-    final var metrics = new OtelProducerMetrics(OpenTelemetry.noop());
-    final var threads = new Thread[50];
-    for (var i = 0; i < threads.length; i++) {
-      threads[i] = Thread.ofVirtual().start(() -> {
-        metrics.recordMessageSent();
-        metrics.recordMessageFailed();
-        metrics.recordDlqSent();
-      });
+  private record Fixture(OtelProducerMetrics metrics, InMemoryMetricReader reader) {
+    Collection<MetricData> collect() {
+      return reader.collectAllMetrics();
     }
-    for (final var t : threads) t.join();
+  }
+
+  private static Fixture fixture() {
+    final var reader = InMemoryMetricReader.create();
+    final var sdk = OpenTelemetrySdk.builder()
+      .setMeterProvider(SdkMeterProvider.builder().registerMetricReader(reader).build())
+      .build();
+    return new Fixture(new OtelProducerMetrics(sdk), reader);
+  }
+
+  private static long valueOf(final Collection<MetricData> metrics, final String name) {
+    return metrics
+      .stream()
+      .filter(m -> m.getName().equals(name))
+      .findFirst()
+      .orElseThrow(() ->
+        new AssertionError(
+          "metric not emitted: " + name + " (saw: " + metrics.stream().map(MetricData::getName).sorted().toList() + ")"
+        )
+      )
+      .getLongSumData()
+      .getPoints()
+      .iterator()
+      .next()
+      .getValue();
+  }
+
+  @Test
+  void recordMessageSentEmitsCounter() {
+    final var f = fixture();
+    f.metrics().recordMessageSent();
+    f.metrics().recordMessageSent();
+    f.metrics().recordMessageSent();
+    assertEquals(3L, valueOf(f.collect(), "kpipe.producer.messages.sent"));
+  }
+
+  @Test
+  void recordMessageFailedEmitsCounter() {
+    final var f = fixture();
+    f.metrics().recordMessageFailed();
+    assertEquals(1L, valueOf(f.collect(), "kpipe.producer.messages.failed"));
+  }
+
+  @Test
+  void recordDlqSentEmitsCounter() {
+    final var f = fixture();
+    f.metrics().recordDlqSent();
+    f.metrics().recordDlqSent();
+    assertEquals(2L, valueOf(f.collect(), "kpipe.producer.dlq.sent"));
+  }
+
+  @Test
+  void countersAreIndependent() {
+    // A sent message must not accidentally tick the failed counter (or vice versa). The
+    // previous noop tests couldn't catch a regression where someone wired the wrong field.
+    final var f = fixture();
+    f.metrics().recordMessageSent();
+    f.metrics().recordMessageFailed();
+    f.metrics().recordDlqSent();
+    final var metrics = f.collect();
+    assertEquals(1L, valueOf(metrics, "kpipe.producer.messages.sent"));
+    assertEquals(1L, valueOf(metrics, "kpipe.producer.messages.failed"));
+    assertEquals(1L, valueOf(metrics, "kpipe.producer.dlq.sent"));
   }
 }

--- a/lib/kpipe-metrics-otel/src/test/java/io/github/eschizoid/kpipe/metrics/otel/PipelineMetricsObserverTest.java
+++ b/lib/kpipe-metrics-otel/src/test/java/io/github/eschizoid/kpipe/metrics/otel/PipelineMetricsObserverTest.java
@@ -1,25 +1,54 @@
 package io.github.eschizoid.kpipe.metrics.otel;
 
-import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertSame;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.*;
 
 import io.github.eschizoid.kpipe.registry.Result;
-import io.opentelemetry.api.OpenTelemetry;
+import io.opentelemetry.api.common.AttributeKey;
+import io.opentelemetry.sdk.OpenTelemetrySdk;
+import io.opentelemetry.sdk.metrics.SdkMeterProvider;
+import io.opentelemetry.sdk.metrics.data.MetricData;
+import io.opentelemetry.sdk.testing.exporter.InMemoryMetricReader;
+import java.util.Collection;
+import java.util.concurrent.atomic.AtomicLong;
 import org.junit.jupiter.api.Test;
 
+/// Asserts that [PipelineMetricsObserver] increments the right `kpipe.pipeline.*` counter for
+/// each `Result<T>` variant and that the optional Schema Registry cache gauges expose the
+/// configured suppliers. Built against `InMemoryMetricReader`, not `OpenTelemetry.noop()`, so the
+/// assertions are on captured metric data rather than just on the absence of exceptions.
 class PipelineMetricsObserverTest {
 
-  @Test
-  void buildsAgainstNoopOpenTelemetry() {
-    final var observer = new PipelineMetricsObserver(OpenTelemetry.noop(), "test-pipeline");
-    assertNotNull(observer);
+  private static final AttributeKey<String> PIPELINE_KEY = AttributeKey.stringKey("pipeline");
+
+  private record Fixture(PipelineMetricsObserver observer, InMemoryMetricReader reader) {
+    Collection<MetricData> collect() {
+      return reader.collectAllMetrics();
+    }
   }
 
-  @Test
-  void acceptsNullPipelineName() {
-    assertDoesNotThrow(() -> new PipelineMetricsObserver(OpenTelemetry.noop(), null));
+  private static Fixture fixture(final String pipelineName) {
+    final var reader = InMemoryMetricReader.create();
+    final var sdk = OpenTelemetrySdk.builder()
+      .setMeterProvider(SdkMeterProvider.builder().registerMetricReader(reader).build())
+      .build();
+    return new Fixture(new PipelineMetricsObserver(sdk, pipelineName), reader);
+  }
+
+  private static long valueOf(final Collection<MetricData> metrics, final String name) {
+    return metrics
+      .stream()
+      .filter(m -> m.getName().equals(name))
+      .findFirst()
+      .orElseThrow(() ->
+        new AssertionError(
+          "metric not emitted: " + name + " (saw: " + metrics.stream().map(MetricData::getName).sorted().toList() + ")"
+        )
+      )
+      .getLongSumData()
+      .getPoints()
+      .iterator()
+      .next()
+      .getValue();
   }
 
   @Test
@@ -28,52 +57,132 @@ class PipelineMetricsObserverTest {
   }
 
   @Test
-  void acceptsPassedResultWithoutThrowing() {
-    final var observer = new PipelineMetricsObserver(OpenTelemetry.noop(), "test");
-    assertDoesNotThrow(() -> observer.accept(Result.passed("hello")));
+  void passedResultIncrementsPassedCounter() {
+    final var f = fixture("test");
+    f.observer().accept(Result.passed("value"));
+    f.observer().accept(Result.passed("value"));
+    final var metrics = f.collect();
+    assertEquals(2L, valueOf(metrics, "kpipe.pipeline.passed"));
   }
 
   @Test
-  void acceptsFilteredResultWithoutThrowing() {
-    final var observer = new PipelineMetricsObserver(OpenTelemetry.noop(), "test");
-    assertDoesNotThrow(() -> observer.accept(Result.filtered()));
+  void filteredResultIncrementsFilteredCounter() {
+    final var f = fixture("test");
+    f.observer().accept(Result.filtered());
+    assertEquals(1L, valueOf(f.collect(), "kpipe.pipeline.filtered"));
   }
 
   @Test
-  void acceptsFailedResultWithoutThrowing() {
-    final var observer = new PipelineMetricsObserver(OpenTelemetry.noop(), "test");
-    assertDoesNotThrow(() -> observer.accept(Result.failed(new RuntimeException("nope"))));
+  void failedResultIncrementsFailedCounter() {
+    final var f = fixture("test");
+    f.observer().accept(Result.failed(new RuntimeException("boom")));
+    assertEquals(1L, valueOf(f.collect(), "kpipe.pipeline.failed"));
   }
 
   @Test
-  void acceptsNullResultSilently() {
-    final var observer = new PipelineMetricsObserver(OpenTelemetry.noop(), "test");
-    assertDoesNotThrow(() -> observer.accept(null));
+  void countersAreIndependent() {
+    // Mixed sequence: one Passed, two Filtered, three Failed. Each counter must reflect only
+    // its own variant — catches the regression where the switch arms are crossed.
+    final var f = fixture("test");
+    f.observer().accept(Result.passed("value"));
+    f.observer().accept(Result.filtered());
+    f.observer().accept(Result.filtered());
+    f.observer().accept(Result.failed(new RuntimeException("a")));
+    f.observer().accept(Result.failed(new RuntimeException("b")));
+    f.observer().accept(Result.failed(new RuntimeException("c")));
+    final var metrics = f.collect();
+    assertEquals(1L, valueOf(metrics, "kpipe.pipeline.passed"));
+    assertEquals(2L, valueOf(metrics, "kpipe.pipeline.filtered"));
+    assertEquals(3L, valueOf(metrics, "kpipe.pipeline.failed"));
   }
 
   @Test
-  void bindSchemaRegistryCacheReturnsSameInstanceForFluentChaining() {
-    final var observer = new PipelineMetricsObserver(OpenTelemetry.noop(), "test");
-    final var chained = observer.bindSchemaRegistryCache(() -> 10L, () -> 2L, () -> 7L);
-    assertSame(observer, chained);
+  void nullResultIsIgnored() {
+    final var f = fixture("test");
+    f.observer().accept(null);
+    // No metric points expected — collecting may yield empty data, but should not throw.
+    assertDoesNotThrow(f::collect);
+  }
+
+  @Test
+  void pipelineAttributeIsAttached() {
+    final var f = fixture("my-pipeline");
+    f.observer().accept(Result.passed("value"));
+    final var point = f
+      .collect()
+      .stream()
+      .filter(m -> m.getName().equals("kpipe.pipeline.passed"))
+      .findFirst()
+      .orElseThrow()
+      .getLongSumData()
+      .getPoints()
+      .iterator()
+      .next();
+    assertEquals("my-pipeline", point.getAttributes().get(PIPELINE_KEY));
+  }
+
+  @Test
+  void nullPipelineNameOmitsAttribute() {
+    final var f = fixture(null);
+    f.observer().accept(Result.passed("value"));
+    final var point = f
+      .collect()
+      .stream()
+      .filter(m -> m.getName().equals("kpipe.pipeline.passed"))
+      .findFirst()
+      .orElseThrow()
+      .getLongSumData()
+      .getPoints()
+      .iterator()
+      .next();
+    assertNull(
+      point.getAttributes().get(PIPELINE_KEY),
+      "null pipelineName must omit the attribute entirely, not write the literal 'null'"
+    );
+  }
+
+  @Test
+  void bindSchemaRegistryCacheRegistersThreeGaugesAndReadsFromSuppliers() {
+    final var f = fixture("sr-test");
+    final var hits = new AtomicLong(7);
+    final var misses = new AtomicLong(3);
+    final var size = new AtomicLong(10);
+    final var returned = f.observer().bindSchemaRegistryCache(hits::get, misses::get, size::get);
+    assertSame(f.observer(), returned, "bindSchemaRegistryCache must return `this` for fluent chaining");
+
+    final var metrics = f.collect();
+    assertEquals(7L, gaugeValue(metrics, "kpipe.schema_registry.cache.hits"));
+    assertEquals(3L, gaugeValue(metrics, "kpipe.schema_registry.cache.misses"));
+    assertEquals(10L, gaugeValue(metrics, "kpipe.schema_registry.cache.size"));
+
+    // Suppliers are read on each collection — bumping the values must surface on the next read.
+    hits.set(15);
+    misses.set(4);
+    size.set(11);
+    final var second = f.collect();
+    assertEquals(15L, gaugeValue(second, "kpipe.schema_registry.cache.hits"));
+    assertEquals(4L, gaugeValue(second, "kpipe.schema_registry.cache.misses"));
+    assertEquals(11L, gaugeValue(second, "kpipe.schema_registry.cache.size"));
   }
 
   @Test
   void bindSchemaRegistryCacheRejectsNullSuppliers() {
-    final var observer = new PipelineMetricsObserver(OpenTelemetry.noop(), "test");
-    assertThrows(NullPointerException.class, () -> observer.bindSchemaRegistryCache(null, () -> 0L, () -> 0L));
-    assertThrows(NullPointerException.class, () -> observer.bindSchemaRegistryCache(() -> 0L, null, () -> 0L));
-    assertThrows(NullPointerException.class, () -> observer.bindSchemaRegistryCache(() -> 0L, () -> 0L, null));
+    final var f = fixture("test");
+    assertThrows(NullPointerException.class, () -> f.observer().bindSchemaRegistryCache(null, () -> 0L, () -> 0L));
+    assertThrows(NullPointerException.class, () -> f.observer().bindSchemaRegistryCache(() -> 0L, null, () -> 0L));
+    assertThrows(NullPointerException.class, () -> f.observer().bindSchemaRegistryCache(() -> 0L, () -> 0L, null));
   }
 
-  @Test
-  void allThreeVariantsCanBeRecordedFromOneObserver() {
-    final var observer = new PipelineMetricsObserver(OpenTelemetry.noop(), "mixed");
-    observer.accept(Result.passed("a"));
-    observer.accept(Result.filtered());
-    observer.accept(Result.failed(new RuntimeException()));
-    observer.accept(Result.passed("b"));
-    // The OTel noop provider doesn't expose the recorded values, so we just verify the
-    // observer doesn't reject any variant or maintain bogus internal state.
+  private static long gaugeValue(final Collection<MetricData> metrics, final String name) {
+    return metrics
+      .stream()
+      .filter(m -> m.getName().equals(name))
+      .findFirst()
+      .orElseThrow(() -> new AssertionError("gauge not registered: " + name))
+      .getLongGaugeData()
+      .getPoints()
+      .iterator()
+      .next()
+      .getValue();
   }
 }

--- a/lib/kpipe-tracing-otel/src/main/java/io/github/eschizoid/kpipe/tracing/otel/OtelTracer.java
+++ b/lib/kpipe-tracing-otel/src/main/java/io/github/eschizoid/kpipe/tracing/otel/OtelTracer.java
@@ -125,7 +125,7 @@ public final class OtelTracer implements Tracer {
 
     private final Span span;
     private final Scope scope;
-    private boolean closed = false;
+    private volatile boolean closed = false;
 
     OtelSpanScope(final Span span, final Scope scope) {
       this.span = span;


### PR DESCRIPTION
## Summary

Outputs of the metrics/tracing deep-dive. Two changes, single PR — both live in the same domain and neither warrants its own review cycle.

### 1. Real-SDK-backed OTel metrics tests

`OtelConsumerMetricsTest`, `OtelProducerMetricsTest`, `PipelineMetricsObserverTest` were **noop-only smoke tests**: they constructed each impl against `OpenTelemetry.noop()` and asserted `assertDoesNotThrow(() -> metrics.recordX())`. With a noop SDK no metric is actually emitted, so the tests would have passed even if someone deleted every `counter.add(...)` call or changed a metric name.

Rewritten against `InMemoryMetricReader` from `opentelemetry-sdk-testing`. Each test now asserts on captured metric data:

- **Name matches** the documented identifier (`kpipe.consumer.messages.*`, `kpipe.pipeline.*`, etc. — the §10 list).
- **Value** is the right increment / histogram sum.
- **Attributes** are attached correctly (`pipeline`, `topic`, `circuit_breaker.state`).
- **Null `pipelineName` omits the attribute** rather than writing the literal string \"null\".
- **Topic-attribute cache merges repeated topics** into one point — the hot-path zero-allocation contract.
- **Inflight gauge** actually reads from its supplier on collection.
- **`bindSchemaRegistryCache`** wires three live gauges and re-reads the suppliers on each collection (covers the SR-cache observability path).
- **Counters are independent** — recording `Passed` must not tick `Filtered` (catches a swapped-arm regression).

### 2. `OtelSpanScope.closed` is now `volatile`

Plain `boolean` was safe today because spans are created + closed on the same virtual thread (one VT per record), but a future change to async completion would race on the idempotency guard and could double-end the span. Free defensive change; cost is one memory fence on first close.

## Test plan

- [x] `./gradlew :lib:kpipe-metrics-otel:test` — 28 new tests, all green
- [x] `./gradlew :lib:kpipe-tracing-otel:test` — existing tracer tests still green (volatile change didn't break anything)
- [x] `./gradlew spotlessCheck` clean
- [x] CI green

## Why one PR for two things

Two findings from the same investigation, both small, both in the OTel impls. Splitting would be ceremony.
