### PR TITLE
chore: address IntelliJ inspection warnings repo-wide (comprehensive sweep)

### DIFF
--- a/benchmarks/src/jmh/java/io/github/eschizoid/kpipe/benchmarks/BatchSinkLatencyBenchmark.java
+++ b/benchmarks/src/jmh/java/io/github/eschizoid/kpipe/benchmarks/BatchSinkLatencyBenchmark.java
@@ -160,7 +160,7 @@ public class BatchSinkLatencyBenchmark {
         // difference is the terminal sink.
         final var perRecordPipeline = registry
           .pipeline(JsonFormat.INSTANCE)
-          .toSink((final Map<String, Object> v) -> {
+          .toSink((final Map<String, Object> _) -> {
             LockSupport.parkNanos(nanos);
             processedLatch.countDown();
           })

--- a/benchmarks/src/jmh/java/io/github/eschizoid/kpipe/benchmarks/KeyOrderedDispatchBenchmark.java
+++ b/benchmarks/src/jmh/java/io/github/eschizoid/kpipe/benchmarks/KeyOrderedDispatchBenchmark.java
@@ -125,7 +125,7 @@ public class KeyOrderedDispatchBenchmark {
       final var registry = new MessageProcessorRegistry();
       final var pipeline = registry
         .pipeline(MessageFormat.bytes())
-        .toSink((final byte[] v) -> processedLatch.countDown())
+        .toSink((final byte[] _) -> processedLatch.countDown())
         .build();
 
       consumer = KPipeConsumer.<String>builder()

--- a/benchmarks/src/jmh/java/io/github/eschizoid/kpipe/benchmarks/ParallelProcessingBenchmarkInfrastructure.java
+++ b/benchmarks/src/jmh/java/io/github/eschizoid/kpipe/benchmarks/ParallelProcessingBenchmarkInfrastructure.java
@@ -388,7 +388,7 @@ public final class ParallelProcessingBenchmarkInfrastructure {
     }
 
     void start() {
-      processor.poll(ctx -> {
+      processor.poll(_ -> {
         simulateWork(workMicros);
         processedCount.incrementAndGet();
       });
@@ -435,7 +435,7 @@ public final class ParallelProcessingBenchmarkInfrastructure {
     }
 
     void start() {
-      processor.poll(ctx -> {
+      processor.poll(_ -> {
         simulateWork(workMicros);
         processedCount.incrementAndGet();
       });
@@ -481,7 +481,7 @@ public final class ParallelProcessingBenchmarkInfrastructure {
     }
 
     void start() {
-      processor.poll(ctx -> {
+      processor.poll(_ -> {
         simulateWork(workMicros);
         processedCount.incrementAndGet();
       });

--- a/examples/circuit-breaker/src/test/java/io/github/eschizoid/kpipe/AppIntegrationTest.java
+++ b/examples/circuit-breaker/src/test/java/io/github/eschizoid/kpipe/AppIntegrationTest.java
@@ -37,7 +37,7 @@ class AppIntegrationTest {
     final var processed = new AtomicInteger(0);
     final var FAIL_UNTIL = 10;
 
-    final MessageSink<Map<String, Object>> flakySink = msg -> {
+    final MessageSink<Map<String, Object>> flakySink = _ -> {
       final var n = processed.incrementAndGet();
       if (n <= FAIL_UNTIL) throw new RuntimeException("simulated failure #" + n);
     };

--- a/examples/demo/src/main/java/io/github/eschizoid/kpipe/demo/DemoApp.java
+++ b/examples/demo/src/main/java/io/github/eschizoid/kpipe/demo/DemoApp.java
@@ -89,7 +89,7 @@ public class DemoApp implements AutoCloseable {
   }
 
   /// Initialises an OTLP/gRPC OpenTelemetry SDK pointed at the demo's collector. Reads
-  /// `OTEL_EXPORTER_OTLP_ENDPOINT` (default `<http://otel-collector:4317>`).
+  /// `OTEL_EXPORTER_OTLP_ENDPOINT` (default <http://otel-collector:4317>).
   private static OpenTelemetry initOpenTelemetry() {
     final var endpoint = System.getenv().getOrDefault("OTEL_EXPORTER_OTLP_ENDPOINT", "http://otel-collector:4317");
     final var exporter = OtlpGrpcMetricExporter.builder().setEndpoint(endpoint).build();

--- a/examples/schema-registry/src/main/java/io/github/eschizoid/kpipe/App.java
+++ b/examples/schema-registry/src/main/java/io/github/eschizoid/kpipe/App.java
@@ -17,7 +17,7 @@ import java.time.Duration;
 /// Environment variables (in addition to the standard `AppConfig`):
 ///
 /// - `SCHEMA_REGISTRY_URL` — base URL of the Schema Registry (e.g.
-// `<http://schema-registry:8081>`).
+///   `<http://schema-registry:8081>`).
 ///
 /// Do NOT add `.skipBytes(5)` here — `withSchemaRegistry(...)` consumes the envelope itself.
 public final class App {

--- a/lib/kpipe-api/src/main/java/io/github/eschizoid/kpipe/DefaultSink.java
+++ b/lib/kpipe-api/src/main/java/io/github/eschizoid/kpipe/DefaultSink.java
@@ -55,7 +55,7 @@ record DefaultSink<T>(DefaultStream<T> stream, MessageSink<T> terminalSink) impl
     final var onFailed = stream.onFailedObserver();
     final var peek = stream.peekResultObserver();
     if (onFiltered == null && onFailed == null && peek == null) return base;
-    return new MessagePipeline<T>() {
+    return new MessagePipeline<>() {
       @Override
       public T deserialize(final byte[] data) {
         return base.deserialize(data);

--- a/lib/kpipe-api/src/test/java/io/github/eschizoid/kpipe/KPipeApiTest.java
+++ b/lib/kpipe-api/src/test/java/io/github/eschizoid/kpipe/KPipeApiTest.java
@@ -80,7 +80,7 @@ class KPipeApiTest {
     };
 
     final Stream<String> single = KPipe.custom("orders", props, upperFormat).pipe(s -> s + "!");
-    final Sink<String> singleSink = single.toCustom(v -> {});
+    final Sink<String> singleSink = single.toCustom(_ -> {});
     assertNotNull(singleSink);
 
     final var ds = (DefaultStream<String>) single;

--- a/lib/kpipe-api/src/test/java/io/github/eschizoid/kpipe/KPipeFacadeIntegrationTest.java
+++ b/lib/kpipe-api/src/test/java/io/github/eschizoid/kpipe/KPipeFacadeIntegrationTest.java
@@ -124,7 +124,7 @@ class KPipeFacadeIntegrationTest {
       assertAll(
         "Filtered captures",
         () -> assertEquals(3, captured.size(), "Should have captured exactly 3 odd-id messages"),
-        () -> captured.forEach(m -> assertTrue(((Number) m.get("id")).intValue() % 2 == 1, "Captured id must be odd"))
+        () -> captured.forEach(m -> assertEquals(1, ((Number) m.get("id")).intValue() % 2, "Captured id must be odd"))
       );
     } finally {
       handle.shutdownGracefully(Duration.ofSeconds(5));

--- a/lib/kpipe-api/src/test/java/io/github/eschizoid/kpipe/MultiBuilderBatchIntegrationTest.java
+++ b/lib/kpipe-api/src/test/java/io/github/eschizoid/kpipe/MultiBuilderBatchIntegrationTest.java
@@ -130,7 +130,7 @@ class MultiBuilderBatchIntegrationTest {
   void builderRejectsTopicConfiguredAsBothRegularAndBatch() {
     final var registry = new MessageProcessorRegistry();
     final var pipeline = registry.pipeline(JsonFormat.INSTANCE).build();
-    final BatchSink<Map<String, Object>> sink = BatchSink.ofVoid(b -> {});
+    final BatchSink<Map<String, Object>> sink = BatchSink.ofVoid(_ -> {});
 
     final var ex = assertThrows(IllegalArgumentException.class, () ->
       KPipeConsumer.<byte[]>builder()
@@ -152,7 +152,7 @@ class MultiBuilderBatchIntegrationTest {
   void builderAcceptsTwoBatchRoutesOnDifferentTopics() {
     final var registry = new MessageProcessorRegistry();
     final var pipeline = registry.pipeline(JsonFormat.INSTANCE).build();
-    final BatchSink<Map<String, Object>> wholeBatch = BatchSink.ofVoid(b -> {});
+    final BatchSink<Map<String, Object>> wholeBatch = BatchSink.ofVoid(_ -> {});
     final BatchSink<Map<String, Object>> perRecordBatch = b -> BatchResult.allSucceeded(b.size());
 
     // No exception: two batch routes on different topics build cleanly.

--- a/lib/kpipe-api/src/test/java/io/github/eschizoid/kpipe/StreamResultObserversTest.java
+++ b/lib/kpipe-api/src/test/java/io/github/eschizoid/kpipe/StreamResultObserversTest.java
@@ -52,9 +52,9 @@ class StreamResultObserversTest {
   void onFilteredFiresWhenAnOperatorReturnsNull() {
     final var fired = new AtomicInteger();
     final var sink = (DefaultSink<Map<String, Object>>) KPipe.json("topic", props())
-      .filter(m -> false)
+      .filter(_ -> false)
       .onFiltered(fired::incrementAndGet)
-      .toCustom(m -> {});
+      .toCustom(_ -> {});
 
     @SuppressWarnings("unchecked")
     final var pipeline = (MessagePipeline<Map<String, Object>>) sink.buildPipeline();
@@ -68,7 +68,7 @@ class StreamResultObserversTest {
     final var fired = new AtomicInteger();
     final var sink = (DefaultSink<Map<String, Object>>) KPipe.json("topic", props())
       .onFiltered(fired::incrementAndGet)
-      .toCustom(m -> {});
+      .toCustom(_ -> {});
 
     @SuppressWarnings("unchecked")
     final var pipeline = (MessagePipeline<Map<String, Object>>) sink.buildPipeline();
@@ -82,11 +82,11 @@ class StreamResultObserversTest {
     final var capturedCause = new AtomicReference<Throwable>();
     final var boom = new RuntimeException("boom");
     final var sink = (DefaultSink<Map<String, Object>>) KPipe.json("topic", props())
-      .pipe(m -> {
+      .pipe(_ -> {
         throw boom;
       })
       .onFailed(capturedCause::set)
-      .toCustom(m -> {});
+      .toCustom(_ -> {});
 
     @SuppressWarnings("unchecked")
     final var pipeline = (MessagePipeline<Map<String, Object>>) sink.buildPipeline();
@@ -114,7 +114,7 @@ class StreamResultObserversTest {
           case Result.Failed<Map<String, Object>> _ -> failed.incrementAndGet();
         }
       })
-      .toCustom(m -> {});
+      .toCustom(_ -> {});
 
     @SuppressWarnings("unchecked")
     final var pipeline = (MessagePipeline<Map<String, Object>>) sink.buildPipeline();
@@ -130,11 +130,11 @@ class StreamResultObserversTest {
   @Test
   void observerExceptionsAreSwallowedSoPipelineStaysAlive() {
     final var sink = (DefaultSink<Map<String, Object>>) KPipe.json("topic", props())
-      .filter(m -> false)
+      .filter(_ -> false)
       .onFiltered(() -> {
         throw new RuntimeException("observer bug");
       })
-      .toCustom(m -> {});
+      .toCustom(_ -> {});
 
     @SuppressWarnings("unchecked")
     final var pipeline = (MessagePipeline<Map<String, Object>>) sink.buildPipeline();
@@ -148,7 +148,7 @@ class StreamResultObserversTest {
         m.put("x", 1);
         return m;
       })
-      .toCustom(m -> {});
+      .toCustom(_ -> {});
 
     // We can't easily assert "is not the wrapper class" because the wrapper is anonymous, but
     // we can confirm the pipeline still works without observers configured.
@@ -160,7 +160,7 @@ class StreamResultObserversTest {
   void observersDoNotAffectFilterReturnValue() {
     final var seenAtSink = new AtomicReference<Map<String, Object>>();
     final var sink = (DefaultSink<Map<String, Object>>) KPipe.json("topic", props())
-      .filter(m -> false)
+      .filter(_ -> false)
       .onFiltered(() -> {
         // observer is a side-effect — must not suppress the filter
       })
@@ -186,10 +186,10 @@ class StreamResultObserversTest {
     final var first = new AtomicInteger();
     final var second = new AtomicInteger();
     final var sink = (DefaultSink<Map<String, Object>>) KPipe.json("topic", props())
-      .filter(m -> false)
+      .filter(_ -> false)
       .onFiltered(first::incrementAndGet)
       .onFiltered(second::incrementAndGet)
-      .toCustom(m -> {});
+      .toCustom(_ -> {});
 
     @SuppressWarnings("unchecked")
     final var pipeline = (MessagePipeline<Map<String, Object>>) sink.buildPipeline();
@@ -205,7 +205,7 @@ class StreamResultObserversTest {
     final var sink = (DefaultSink<Map<String, Object>>) KPipe.json("topic", props())
       .filter(m -> m.containsKey("keep"))
       .onFailed(_ -> failedFired.incrementAndGet())
-      .toCustom(m -> {});
+      .toCustom(_ -> {});
 
     @SuppressWarnings("unchecked")
     final var pipeline = (MessagePipeline<Map<String, Object>>) sink.buildPipeline();

--- a/lib/kpipe-api/src/test/java/io/github/eschizoid/kpipe/StreamResultObserversTest.java
+++ b/lib/kpipe-api/src/test/java/io/github/eschizoid/kpipe/StreamResultObserversTest.java
@@ -164,7 +164,7 @@ class StreamResultObserversTest {
       .onFiltered(() -> {
         // observer is a side-effect — must not suppress the filter
       })
-      .toCustom((Map<String, Object> v) -> seenAtSink.set(v));
+      .toCustom(seenAtSink::set);
 
     @SuppressWarnings("unchecked")
     final var pipeline = (MessagePipeline<Map<String, Object>>) sink.buildPipeline();

--- a/lib/kpipe-api/src/test/java/io/github/eschizoid/kpipe/StreamToMultiTest.java
+++ b/lib/kpipe-api/src/test/java/io/github/eschizoid/kpipe/StreamToMultiTest.java
@@ -1,9 +1,9 @@
 package io.github.eschizoid.kpipe;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import io.github.eschizoid.kpipe.sink.CompositeMessageSink;
 import io.github.eschizoid.kpipe.sink.MessageSink;
@@ -38,7 +38,7 @@ class StreamToMultiTest {
     final MessageSink<Map<String, Object>> c = captured3::add;
 
     final var sink = (DefaultSink<Map<String, Object>>) KPipe.json("topic", props()).toMulti(a, b, c);
-    assertTrue(sink.terminalSink() instanceof CompositeMessageSink<?>);
+    assertInstanceOf(CompositeMessageSink.class, sink.terminalSink());
 
     final var payload = new HashMap<String, Object>();
     payload.put("k", "v");
@@ -63,7 +63,7 @@ class StreamToMultiTest {
     final MessageSink<Map<String, Object>> b = captured2::add;
 
     final var sink = (DefaultSink<Map<String, Object>>) KPipe.json("topic", props()).toMulti(throwing, a, b);
-    assertTrue(sink.terminalSink() instanceof CompositeMessageSink<?>);
+    assertInstanceOf(CompositeMessageSink.class, sink.terminalSink());
 
     final var payload = new HashMap<String, Object>();
     payload.put("event", "ok");

--- a/lib/kpipe-consumer/src/main/java/io/github/eschizoid/kpipe/consumer/KafkaOffsetManager.java
+++ b/lib/kpipe-consumer/src/main/java/io/github/eschizoid/kpipe/consumer/KafkaOffsetManager.java
@@ -181,7 +181,7 @@ public class KafkaOffsetManager<K> implements OffsetManager<K> {
     if (state.get() == OffsetState.STOPPED) return;
     final var partition = new TopicPartition(record.topic(), record.partition());
     final var offset = record.offset();
-    pendingOffsets.computeIfAbsent(partition, k -> new ConcurrentSkipListSet<>()).add(offset);
+    pendingOffsets.computeIfAbsent(partition, _ -> new ConcurrentSkipListSet<>()).add(offset);
   }
 
   /// Marks an offset as successfully processed using a ConsumerRecord.
@@ -199,9 +199,9 @@ public class KafkaOffsetManager<K> implements OffsetManager<K> {
     final var partition = new TopicPartition(record.topic(), record.partition());
     final var offset = record.offset();
 
-    highestProcessedOffsets.compute(partition, (k, v) -> v == null ? offset : Math.max(v, offset));
+    highestProcessedOffsets.compute(partition, (_, v) -> v == null ? offset : Math.max(v, offset));
 
-    pendingOffsets.computeIfPresent(partition, (k, set) -> {
+    pendingOffsets.computeIfPresent(partition, (_, set) -> {
       set.remove(offset);
       return set.isEmpty() ? null : set;
     });

--- a/lib/kpipe-consumer/src/main/java/io/github/eschizoid/kpipe/consumer/RebalanceListener.java
+++ b/lib/kpipe-consumer/src/main/java/io/github/eschizoid/kpipe/consumer/RebalanceListener.java
@@ -107,7 +107,7 @@ public record RebalanceListener(
     final var remainingCommands = new ArrayList<ConsumerCommand>();
 
     IntStream.iterate(commandQueue.size(), size -> size > 0, size -> size - 1)
-      .mapToObj(x -> commandQueue.poll())
+      .mapToObj(_ -> commandQueue.poll())
       .takeWhile(Objects::nonNull)
       .forEachOrdered(currentCmd -> {
         switch (currentCmd) {

--- a/lib/kpipe-consumer/src/test/java/io/github/eschizoid/kpipe/consumer/BackpressureControllerTest.java
+++ b/lib/kpipe-consumer/src/test/java/io/github/eschizoid/kpipe/consumer/BackpressureControllerTest.java
@@ -1,6 +1,7 @@
 package io.github.eschizoid.kpipe.consumer;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
@@ -186,7 +187,7 @@ class BackpressureControllerTest {
       when(consumer.endOffsets(assignment, Duration.ofSeconds(2))).thenThrow(new RuntimeException("broker down"));
 
       assertEquals(0L, BackpressureController.calculateTotalLag(consumer));
-      assertEquals(false, Thread.interrupted(), "Generic RuntimeException must NOT set interrupt flag");
+      assertFalse(Thread.interrupted(), "Generic RuntimeException must NOT set interrupt flag");
     }
 
     @Test

--- a/lib/kpipe-consumer/src/test/java/io/github/eschizoid/kpipe/consumer/DispatcherIntegrationTest.java
+++ b/lib/kpipe-consumer/src/test/java/io/github/eschizoid/kpipe/consumer/DispatcherIntegrationTest.java
@@ -358,7 +358,7 @@ class DispatcherIntegrationTest {
 
     final var managerRef = new AtomicReference<KafkaOffsetManager<String>>();
     builder.withOffsetManagerProvider(c -> {
-      final var mgr = KafkaOffsetManager.<String>builder(c).withCommandQueue(builder.getCommandQueue()).build();
+      final var mgr = KafkaOffsetManager.builder(c).withCommandQueue(builder.getCommandQueue()).build();
       managerRef.set(mgr);
       return mgr;
     });

--- a/lib/kpipe-consumer/src/test/java/io/github/eschizoid/kpipe/consumer/DispatcherIntegrationTest.java
+++ b/lib/kpipe-consumer/src/test/java/io/github/eschizoid/kpipe/consumer/DispatcherIntegrationTest.java
@@ -314,7 +314,7 @@ class DispatcherIntegrationTest {
     final var recordsPerPartition = 10;
     // Every record gets a null key — should all serialize through the same sentinel queue
     // in offset order, never concurrent.
-    final BiFunction<Integer, Long, String> allNull = (p, off) -> null;
+    final BiFunction<Integer, Long, String> allNull = (_, _) -> null;
     final var mock = seededConsumer(partitions, recordsPerPartition, allNull);
 
     final var observations = runUntilProcessed(ProcessingMode.KEY_ORDERED, mock, recordsPerPartition, 20, allNull);
@@ -503,7 +503,7 @@ class DispatcherIntegrationTest {
     final var partitions = 1;
     final var recordsPerPartition = 10;
     // Constant key across all records — forces all into a single per-key queue.
-    final BiFunction<Integer, Long, String> constantKey = (p, off) -> "single";
+    final BiFunction<Integer, Long, String> constantKey = (_, _) -> "single";
     final var mock = seededConsumer(partitions, recordsPerPartition, constantKey);
 
     final var observations = runUntilProcessed(ProcessingMode.KEY_ORDERED, mock, recordsPerPartition, 20, constantKey);
@@ -525,7 +525,7 @@ class DispatcherIntegrationTest {
   void keyOrderedSameKeyAcrossPartitionsStillSerializes() throws InterruptedException {
     final var partitions = 2;
     final var recordsPerPartition = 5;
-    final BiFunction<Integer, Long, String> sharedKey = (p, off) -> "shared";
+    final BiFunction<Integer, Long, String> sharedKey = (_, _) -> "shared";
     final var mock = seededConsumer(partitions, recordsPerPartition, sharedKey);
 
     final var observations = runUntilProcessed(
@@ -555,7 +555,7 @@ class DispatcherIntegrationTest {
     final var partitions = 1;
     final var recordsPerPartition = 10;
     final var failingOffset = 5L;
-    final BiFunction<Integer, Long, String> singleKey = (p, off) -> "key-A";
+    final BiFunction<Integer, Long, String> singleKey = (_, _) -> "key-A";
     final var mock = seededConsumer(partitions, recordsPerPartition, singleKey);
 
     final var processedSuccessfully = new CopyOnWriteArrayList<Long>();
@@ -628,7 +628,7 @@ class DispatcherIntegrationTest {
     final var recordsPerPartition = 5;
     final var retryingOffset = 2L;
     final var retryBackoff = Duration.ofMillis(50);
-    final BiFunction<Integer, Long, String> singleKey = (p, off) -> "key-A";
+    final BiFunction<Integer, Long, String> singleKey = (_, _) -> "key-A";
     final var mock = seededConsumer(partitions, recordsPerPartition, singleKey);
 
     final var attemptsPerOffset = new ConcurrentHashMap<Long, AtomicInteger>();
@@ -646,7 +646,7 @@ class DispatcherIntegrationTest {
       .withPipeline(
         TestPipelines.sideEffect(v -> {
           final var off = Long.parseLong(new String(v).split("-", -1)[2]);
-          final var attempt = attemptsPerOffset.computeIfAbsent(off, k -> new AtomicInteger(0)).incrementAndGet();
+          final var attempt = attemptsPerOffset.computeIfAbsent(off, _ -> new AtomicInteger(0)).incrementAndGet();
           final var attemptStartNs = System.nanoTime();
           firstAttemptStartNs.putIfAbsent(off, attemptStartNs);
           try {

--- a/lib/kpipe-consumer/src/test/java/io/github/eschizoid/kpipe/consumer/KPipeCircuitBreakerIntegrationTest.java
+++ b/lib/kpipe-consumer/src/test/java/io/github/eschizoid/kpipe/consumer/KPipeCircuitBreakerIntegrationTest.java
@@ -58,7 +58,7 @@ class KPipeCircuitBreakerIntegrationTest {
       .withTopic(TOPIC)
       .withProcessingMode(ProcessingMode.SEQUENTIAL)
       .withPipeline(
-        TestPipelines.sideEffect(v -> {
+        TestPipelines.sideEffect(_ -> {
           throw new RuntimeException("simulated downstream failure");
         })
       )
@@ -91,7 +91,7 @@ class KPipeCircuitBreakerIntegrationTest {
       .withTopic(TOPIC)
       .withProcessingMode(ProcessingMode.SEQUENTIAL)
       .withPipeline(
-        TestPipelines.sideEffect(v -> {
+        TestPipelines.sideEffect(_ -> {
           throw new RuntimeException("downstream down");
         })
       )
@@ -196,7 +196,7 @@ class KPipeCircuitBreakerIntegrationTest {
       .withTopic(TOPIC)
       .withProcessingMode(ProcessingMode.SEQUENTIAL)
       .withPipeline(
-        TestPipelines.sideEffect(v -> {
+        TestPipelines.sideEffect(_ -> {
           throw new RuntimeException("every record fails");
         })
       )

--- a/lib/kpipe-consumer/src/test/java/io/github/eschizoid/kpipe/consumer/KPipeConsumerMockingTest.java
+++ b/lib/kpipe-consumer/src/test/java/io/github/eschizoid/kpipe/consumer/KPipeConsumerMockingTest.java
@@ -97,7 +97,7 @@ class KPipeConsumerMockingTest {
     final var latch = new CountDownLatch(1);
 
     // Combine both counting down the latch and returning a value
-    doAnswer(invocation -> {
+    doAnswer(_ -> {
       latch.countDown();
       return "processed-value".getBytes();
     })
@@ -119,7 +119,7 @@ class KPipeConsumerMockingTest {
     final var commandQueue = new ConcurrentLinkedQueue<ConsumerCommand>();
 
     // Configure mock to throw exception and count down latch
-    doAnswer(invocation -> {
+    doAnswer(_ -> {
       latch.countDown();
       throw new RuntimeException("Test exception");
     })
@@ -185,7 +185,7 @@ class KPipeConsumerMockingTest {
     final var commandQueue = new ConcurrentLinkedQueue<ConsumerCommand>();
 
     // Configure mock to always fail and count down latch
-    doAnswer(inv -> {
+    doAnswer(_ -> {
       latch.countDown();
       throw new RuntimeException("Test exception");
     })
@@ -235,7 +235,7 @@ class KPipeConsumerMockingTest {
     final var commandQueue = new ConcurrentLinkedQueue<ConsumerCommand>();
 
     // Configure mock to fail and count down latch
-    doAnswer(inv -> {
+    doAnswer(_ -> {
       latch.countDown();
       throw new RuntimeException("Test exception");
     })
@@ -378,7 +378,7 @@ class KPipeConsumerMockingTest {
     final var commandQueue = new ConcurrentLinkedQueue<ConsumerCommand>();
 
     // Configure mock to return success and count down latch
-    doAnswer(inv -> {
+    doAnswer(_ -> {
       latch.countDown();
       return "processed-value".getBytes();
     })
@@ -425,7 +425,7 @@ class KPipeConsumerMockingTest {
     final var commandQueue = new ConcurrentLinkedQueue<ConsumerCommand>();
 
     // Configure mock to throw exception and count down latch
-    doAnswer(inv -> {
+    doAnswer(_ -> {
       latch.countDown();
       throw new RuntimeException("Test exception");
     })
@@ -467,7 +467,7 @@ class KPipeConsumerMockingTest {
   void builderShouldRespectAllOptions() {
     // Setup
     final var pollTimeout = Duration.ofMillis(200);
-    final KPipeConsumer.ErrorHandler<String> errorHandler = error -> {};
+    final KPipeConsumer.ErrorHandler<String> errorHandler = _ -> {};
     final var maxRetries = 3;
     final var retryBackoff = Duration.ofMillis(100);
 
@@ -946,7 +946,7 @@ class KPipeConsumerMockingTest {
     final var commandQueue = new ConcurrentLinkedQueue<ConsumerCommand>();
 
     // Configure the processor to always fail
-    doAnswer(inv -> {
+    doAnswer(_ -> {
       latch.countDown();
       throw new RuntimeException("Expected test exception");
     })
@@ -1133,7 +1133,7 @@ class KPipeConsumerMockingTest {
     doThrow(new RuntimeException("processor boom")).when(processor).apply(any(byte[].class));
 
     final var handlerLatch = new CountDownLatch(2);
-    final KPipeConsumer.ErrorHandler<String> throwingHandler = e -> {
+    final KPipeConsumer.ErrorHandler<String> throwingHandler = _ -> {
       handlerLatch.countDown();
       throw new RuntimeException("handler kaboom");
     };

--- a/lib/kpipe-consumer/src/test/java/io/github/eschizoid/kpipe/consumer/KPipeConsumerTest.java
+++ b/lib/kpipe-consumer/src/test/java/io/github/eschizoid/kpipe/consumer/KPipeConsumerTest.java
@@ -531,7 +531,7 @@ class KPipeConsumerTest {
   @Test
   void processorWithMaxRetriesExceededShouldCallErrorHandler() throws InterruptedException {
     // Arrange
-    final UnaryOperator<byte[]> failingProcessor = value -> {
+    final UnaryOperator<byte[]> failingProcessor = _ -> {
       throw new RuntimeException("Always failing");
     };
     @SuppressWarnings("unchecked")

--- a/lib/kpipe-consumer/src/test/java/io/github/eschizoid/kpipe/consumer/KPipeConsumerTest.java
+++ b/lib/kpipe-consumer/src/test/java/io/github/eschizoid/kpipe/consumer/KPipeConsumerTest.java
@@ -867,7 +867,7 @@ class KPipeConsumerTest {
       .withProcessingMode(ProcessingMode.SEQUENTIAL)
       .build();
 
-    final var records = new ConsumerRecords<String, byte[]>(
+    final var records = new ConsumerRecords<>(
       Map.of(
         new TopicPartition(TOPIC, 0),
         List.of(createRecord(0, "k1", "v1"), createRecord(1, "k2", "v2"), createRecord(2, "k3", "v3"))
@@ -907,7 +907,7 @@ class KPipeConsumerTest {
       .withProcessingMode(ProcessingMode.KEY_ORDERED)
       .build();
 
-    final var records = new ConsumerRecords<String, byte[]>(
+    final var records = new ConsumerRecords<>(
       Map.of(
         new TopicPartition(TOPIC, 0),
         List.of(

--- a/lib/kpipe-consumer/src/test/java/io/github/eschizoid/kpipe/consumer/KPipeDlqTest.java
+++ b/lib/kpipe-consumer/src/test/java/io/github/eschizoid/kpipe/consumer/KPipeDlqTest.java
@@ -45,7 +45,7 @@ class KPipeDlqTest {
         .withProperties(byteProperties())
         .withTopic(TOPIC)
         .withPipeline(
-          TestPipelines.sideEffect(v -> {
+          TestPipelines.sideEffect(_ -> {
             throw new RuntimeException("fail");
           })
         )
@@ -150,7 +150,7 @@ class KPipeDlqTest {
         .withProperties(byteProperties())
         .withTopic(TOPIC)
         .withPipeline(
-          TestPipelines.sideEffect(v -> {
+          TestPipelines.sideEffect(_ -> {
             throw new RuntimeException("processor always fails");
           })
         )
@@ -194,7 +194,7 @@ class KPipeDlqTest {
         .withProperties(byteProperties())
         .withTopic(TOPIC)
         .withPipeline(
-          TestPipelines.sideEffect(v -> {
+          TestPipelines.sideEffect(_ -> {
             throw new RuntimeException("fail");
           })
         )

--- a/lib/kpipe-consumer/src/test/java/io/github/eschizoid/kpipe/consumer/KPipeProducerIntegrationTest.java
+++ b/lib/kpipe-consumer/src/test/java/io/github/eschizoid/kpipe/consumer/KPipeProducerIntegrationTest.java
@@ -35,9 +35,7 @@ class KPipeProducerIntegrationTest {
     final var props = getProperties();
 
     // 1. Produce message to input topic
-    try (
-      var producer = new KafkaProducer<byte[], byte[]>(props, new ByteArraySerializer(), new ByteArraySerializer())
-    ) {
+    try (var producer = new KafkaProducer<>(props, new ByteArraySerializer(), new ByteArraySerializer())) {
       producer.send(new ProducerRecord<>(topic, "key1".getBytes(), "bad-value".getBytes())).get();
     }
 
@@ -73,16 +71,10 @@ class KPipeProducerIntegrationTest {
     final var topic = "input-" + System.nanoTime();
     final var dlqTopic = "dlq-" + System.nanoTime();
     final var props = getProperties();
-    final var externalProducer = new KafkaProducer<byte[], byte[]>(
-      props,
-      new ByteArraySerializer(),
-      new ByteArraySerializer()
-    );
+    final var externalProducer = new KafkaProducer<>(props, new ByteArraySerializer(), new ByteArraySerializer());
 
     // 1. Produce message to input topic
-    try (
-      var producer = new KafkaProducer<byte[], byte[]>(props, new ByteArraySerializer(), new ByteArraySerializer())
-    ) {
+    try (var producer = new KafkaProducer<>(props, new ByteArraySerializer(), new ByteArraySerializer())) {
       producer.send(new ProducerRecord<>(topic, "key3".getBytes(), "bad-external".getBytes())).get();
     }
 
@@ -122,9 +114,7 @@ class KPipeProducerIntegrationTest {
     final var props = getProperties();
 
     // 1. Produce message to input topic
-    try (
-      var producer = new KafkaProducer<byte[], byte[]>(props, new ByteArraySerializer(), new ByteArraySerializer())
-    ) {
+    try (var producer = new KafkaProducer<>(props, new ByteArraySerializer(), new ByteArraySerializer())) {
       producer.send(new ProducerRecord<>(topic, "key2".getBytes(), "good-value".getBytes())).get();
     }
 
@@ -171,9 +161,7 @@ class KPipeProducerIntegrationTest {
   }
 
   private byte[] consumeOne(Properties props, String topic, Duration timeout) {
-    try (
-      var consumer = new KafkaConsumer<byte[], byte[]>(props, new ByteArrayDeserializer(), new ByteArrayDeserializer())
-    ) {
+    try (var consumer = new KafkaConsumer<>(props, new ByteArrayDeserializer(), new ByteArrayDeserializer())) {
       consumer.subscribe(Collections.singletonList(topic));
       final var start = System.currentTimeMillis();
       while (System.currentTimeMillis() - start < timeout.toMillis()) {

--- a/lib/kpipe-consumer/src/test/java/io/github/eschizoid/kpipe/consumer/KeyOrderedDispatcherTest.java
+++ b/lib/kpipe-consumer/src/test/java/io/github/eschizoid/kpipe/consumer/KeyOrderedDispatcherTest.java
@@ -2,6 +2,8 @@ package io.github.eschizoid.kpipe.consumer;
 
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -392,8 +394,8 @@ class KeyOrderedDispatcherTest {
     Thread.ofVirtual().start(() -> dispatcher.dispatch(recordWithKey("c", 0), thirdCompleted::countDown, () -> {}));
 
     // The third dispatch must NOT complete while both workers are still blocked.
-    assertTrue(
-      !thirdCompleted.await(200, TimeUnit.MILLISECONDS),
+    assertFalse(
+      thirdCompleted.await(200, TimeUnit.MILLISECONDS),
       "third dispatch must stall while all queues at cap are non-empty"
     );
 
@@ -693,8 +695,8 @@ class KeyOrderedDispatcherTest {
     });
 
     // Confirm it's actually stuck (workers still blocked, no queues drained).
-    assertTrue(
-      !thirdCompleted.await(200, TimeUnit.MILLISECONDS),
+    assertFalse(
+      thirdCompleted.await(200, TimeUnit.MILLISECONDS),
       "third dispatch must stall while all queues at cap are non-empty"
     );
 
@@ -739,15 +741,18 @@ class KeyOrderedDispatcherTest {
 
     final var snapshot = dispatcher.topKeyQueueDepths(1);
     assertEquals(1, snapshot.size());
-    final var key = snapshot.get(0).getKey();
-    assertTrue(key instanceof byte[], () -> "byte[] keys must be returned as byte[], got " + key.getClass());
-    final var keyBytes = (byte[]) key;
+    final var key = snapshot.getFirst().getKey();
+    final var keyBytes = assertInstanceOf(
+      byte[].class,
+      key,
+      () -> "byte[] keys must be returned as byte[], got " + key.getClass()
+    );
     assertArrayEquals(originalKey, keyBytes, "snapshot must reflect the original key bytes");
 
     // Mutate the returned array — the dispatcher's internal map key must be unaffected.
     Arrays.fill(keyBytes, (byte) 0);
     final var snapshot2 = dispatcher.topKeyQueueDepths(1);
-    final var keyBytes2 = (byte[]) snapshot2.get(0).getKey();
+    final var keyBytes2 = (byte[]) snapshot2.getFirst().getKey();
     assertArrayEquals(originalKey, keyBytes2, "internal map key must survive caller mutation of the previous snapshot");
 
     allowFinish.countDown();

--- a/lib/kpipe-consumer/src/test/java/io/github/eschizoid/kpipe/consumer/ParallelDispatcherTest.java
+++ b/lib/kpipe-consumer/src/test/java/io/github/eschizoid/kpipe/consumer/ParallelDispatcherTest.java
@@ -28,7 +28,7 @@ class ParallelDispatcherTest {
     final AtomicInteger rejectCount,
     final Duration terminationTimeout
   ) {
-    return new ParallelDispatcher<>((rec, ex) -> rejectCount.incrementAndGet(), terminationTimeout);
+    return new ParallelDispatcher<>((_, _) -> rejectCount.incrementAndGet(), terminationTimeout);
   }
 
   @Test

--- a/lib/kpipe-core/src/main/java/io/github/eschizoid/kpipe/registry/Result.java
+++ b/lib/kpipe-core/src/main/java/io/github/eschizoid/kpipe/registry/Result.java
@@ -50,7 +50,7 @@ public sealed interface Result<T> permits Result.Passed, Result.Filtered, Result
   ///
   /// @param <T> the pipeline value type
   record Filtered<T>() implements Result<T> {
-    private static final Filtered SHARED = new Filtered();
+    private static final Filtered<?> SHARED = new Filtered<>();
 
     /// Returns the shared `Filtered` sentinel. Avoids per-record allocation on filter-heavy
     /// pipelines. Safe to share across types since the record carries no state.

--- a/lib/kpipe-core/src/main/java/io/github/eschizoid/kpipe/registry/TypedPipelineBuilder.java
+++ b/lib/kpipe-core/src/main/java/io/github/eschizoid/kpipe/registry/TypedPipelineBuilder.java
@@ -110,7 +110,7 @@ public final class TypedPipelineBuilder<T> {
     final var pipelineSink = this.sink;
     final var bytesToSkip = this.skipBytes;
 
-    return new MessagePipeline<T>() {
+    return new MessagePipeline<>() {
       @Override
       public MessageSink<T> getSink() {
         return pipelineSink;

--- a/lib/kpipe-core/src/test/java/io/github/eschizoid/kpipe/registry/MessagePipelineContractTest.java
+++ b/lib/kpipe-core/src/test/java/io/github/eschizoid/kpipe/registry/MessagePipelineContractTest.java
@@ -26,7 +26,7 @@ class MessagePipelineContractTest {
 
   @Test
   void shouldPropagateExceptionFromDeserialize() {
-    final var pipeline = pipelineWithDeserialize(bytes -> {
+    final var pipeline = pipelineWithDeserialize(_ -> {
       throw new IllegalArgumentException("malformed");
     });
     final var ex = assertThrows(IllegalArgumentException.class, () -> pipeline.deserialize(INPUT));
@@ -71,7 +71,7 @@ class MessagePipelineContractTest {
   @Test
   void shouldRoundTripSuccessfully() {
     final byte[] output = new byte[] { 9, 9, 9 };
-    final var pipeline = new TestPipeline<String>(_ -> "v", Result::passed, s -> output, null);
+    final var pipeline = new TestPipeline<String>(_ -> "v", Result::passed, _ -> output, null);
 
     final var deserialized = pipeline.deserializeOrFail(INPUT);
     final var result = pipeline.process(deserialized);
@@ -162,11 +162,11 @@ class MessagePipelineContractTest {
   }
 
   private static MessagePipeline<String> pipelineWithDeserialize(final DeserializeFn<String> fn) {
-    return new TestPipeline<>(fn, Result::passed, s -> INPUT, null);
+    return new TestPipeline<>(fn, Result::passed, _ -> INPUT, null);
   }
 
   private static MessagePipeline<String> pipelineWithProcess(final ProcessFn<String> fn) {
-    return new TestPipeline<>(bytes -> "v", fn, s -> INPUT, null);
+    return new TestPipeline<>(_ -> "v", fn, _ -> INPUT, null);
   }
 
   /// Minimal record-style pipeline used to drive the contract tests. `process` returns

--- a/lib/kpipe-core/src/test/java/io/github/eschizoid/kpipe/registry/MessagePipelineContractTest.java
+++ b/lib/kpipe-core/src/test/java/io/github/eschizoid/kpipe/registry/MessagePipelineContractTest.java
@@ -2,6 +2,7 @@ package io.github.eschizoid.kpipe.registry;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -142,7 +143,7 @@ class MessagePipelineContractTest {
 
     // Composed sink runs the first then the second when both are present.
     final var composedSink = composed.getSink();
-    assertTrue(composedSink != null, "composed sink should be non-null when both pipelines have sinks");
+    assertNotNull(composedSink, "composed sink should be non-null when both pipelines have sinks");
     composedSink.accept("v");
     assertTrue(firstCalled.get(), "first sink must run");
     assertTrue(secondCalled.get(), "second sink must run");

--- a/lib/kpipe-core/src/test/java/io/github/eschizoid/kpipe/registry/MessageProcessorRegistrySinksTest.java
+++ b/lib/kpipe-core/src/test/java/io/github/eschizoid/kpipe/registry/MessageProcessorRegistrySinksTest.java
@@ -39,7 +39,7 @@ class MessageProcessorRegistrySinksTest {
   @Test
   void shouldUnregisterSink() {
     final var testSink = mock(MessageSink.class);
-    final var key = RegistryKey.<Object>of("sinkToRemove", Object.class);
+    final var key = RegistryKey.of("sinkToRemove", Object.class);
     registry.registerSink(key, testSink);
 
     assertTrue(registry.getAllSinks().containsKey(key));
@@ -168,14 +168,12 @@ class MessageProcessorRegistrySinksTest {
 
   @Test
   void shouldRejectNullSink() {
-    assertThrows(NullPointerException.class, () ->
-      registry.registerSink(RegistryKey.<Object>of("test", Object.class), null)
-    );
+    assertThrows(NullPointerException.class, () -> registry.registerSink(RegistryKey.of("test", Object.class), null));
   }
 
   @Test
   void shouldRegisterAndRetrieveTypedSink() {
-    final var key = RegistryKey.<String>of("typedSink", String.class);
+    final var key = RegistryKey.of("typedSink", String.class);
     @SuppressWarnings("unchecked")
     final MessageSink<String> testSink = mock(MessageSink.class);
     registry.registerSink(key, testSink);
@@ -188,7 +186,7 @@ class MessageProcessorRegistrySinksTest {
 
   @Test
   void shouldThrowOnTypeMismatch() {
-    final var key = RegistryKey.<String>of("typedSink", String.class);
+    final var key = RegistryKey.of("typedSink", String.class);
     registry.registerSink(key, msg -> {});
 
     assertThrows(ClassCastException.class, () -> {

--- a/lib/kpipe-core/src/test/java/io/github/eschizoid/kpipe/registry/MessageProcessorRegistrySinksTest.java
+++ b/lib/kpipe-core/src/test/java/io/github/eschizoid/kpipe/registry/MessageProcessorRegistrySinksTest.java
@@ -108,7 +108,7 @@ class MessageProcessorRegistrySinksTest {
   @Test
   void shouldTrackMetricsForSink() {
     final var callCount = new java.util.concurrent.atomic.AtomicInteger(0);
-    final MessageSink<Object> countingSink = value -> callCount.incrementAndGet();
+    final MessageSink<Object> countingSink = _ -> callCount.incrementAndGet();
 
     final var key = RegistryKey.of("countingSink", Object.class);
     registry.registerSink(key, countingSink);
@@ -124,7 +124,7 @@ class MessageProcessorRegistrySinksTest {
 
   @Test
   void shouldTrackErrorMetricsForFailingSink() {
-    final MessageSink<Object> failingSink = value -> {
+    final MessageSink<Object> failingSink = _ -> {
       throw new RuntimeException("Test failure");
     };
 
@@ -145,7 +145,7 @@ class MessageProcessorRegistrySinksTest {
 
   @Test
   void shouldWrapSinkWithErrorHandling() {
-    final MessageSink<Object> failingSink = value -> {
+    final MessageSink<Object> failingSink = _ -> {
       throw new RuntimeException("Test failure");
     };
 
@@ -187,7 +187,7 @@ class MessageProcessorRegistrySinksTest {
   @Test
   void shouldThrowOnTypeMismatch() {
     final var key = RegistryKey.of("typedSink", String.class);
-    registry.registerSink(key, msg -> {});
+    registry.registerSink(key, _ -> {});
 
     assertThrows(ClassCastException.class, () -> {
       @SuppressWarnings("unchecked")

--- a/lib/kpipe-core/src/test/java/io/github/eschizoid/kpipe/registry/OperatorsTest.java
+++ b/lib/kpipe-core/src/test/java/io/github/eschizoid/kpipe/registry/OperatorsTest.java
@@ -46,7 +46,7 @@ class OperatorsTest {
   @Test
   void peekShouldRunSideEffectAndPassThrough() {
     final var captured = new AtomicReference<String>();
-    final var op = Operators.peek((String s) -> captured.set(s));
+    final var op = Operators.<String>peek(captured::set);
 
     final var result = op.apply("original");
 

--- a/lib/kpipe-core/src/test/java/io/github/eschizoid/kpipe/registry/OperatorsTest.java
+++ b/lib/kpipe-core/src/test/java/io/github/eschizoid/kpipe/registry/OperatorsTest.java
@@ -84,7 +84,7 @@ class OperatorsTest {
 
   @Test
   void safeShouldReturnInputOnException() {
-    final UnaryOperator<String> throwing = s -> {
+    final UnaryOperator<String> throwing = _ -> {
       throw new RuntimeException("boom");
     };
     final var op = Operators.safe(throwing);
@@ -150,7 +150,7 @@ class OperatorsTest {
     final var downstreamCalled = new AtomicBoolean(false);
 
     final UnaryOperator<String> first = s -> s + "a";
-    final UnaryOperator<String> filter = s -> null;
+    final UnaryOperator<String> filter = _ -> null;
     final UnaryOperator<String> downstream = s -> {
       downstreamCalled.set(true);
       return s + "b";

--- a/lib/kpipe-core/src/test/java/io/github/eschizoid/kpipe/registry/PipelineDiagnosticsTest.java
+++ b/lib/kpipe-core/src/test/java/io/github/eschizoid/kpipe/registry/PipelineDiagnosticsTest.java
@@ -1,6 +1,7 @@
 package io.github.eschizoid.kpipe.registry;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -35,7 +36,7 @@ class PipelineDiagnosticsTest {
 
     assertTrue(wrapped.getMessage().contains("Deserialization failed"));
     assertTrue(wrapped.getMessage().contains("Leading bytes"));
-    assertTrue(!wrapped.getMessage().contains("Confluent Schema Registry envelope"));
+    assertFalse(wrapped.getMessage().contains("Confluent Schema Registry envelope"));
   }
 
   @Test
@@ -43,7 +44,7 @@ class PipelineDiagnosticsTest {
     final var data = new byte[] { 0x7b, 0x22, 0x66, 0x6f }; // {"fo
     final var wrapped = PipelineDiagnostics.wrap(data, 0, "JsonFormat", new RuntimeException("not json"));
 
-    assertTrue(!wrapped.getMessage().contains("Confluent Schema Registry envelope"));
+    assertFalse(wrapped.getMessage().contains("Confluent Schema Registry envelope"));
     assertTrue(wrapped.getMessage().contains("Leading bytes: [7b 22 66 6f]"));
   }
 
@@ -52,7 +53,7 @@ class PipelineDiagnosticsTest {
     final var data = new byte[] { 0x00, 0x01, 0x02 };
     final var wrapped = PipelineDiagnostics.wrap(data, 0, "CustomFormat", new RuntimeException("x"));
 
-    assertTrue(!wrapped.getMessage().contains("skipBytes"));
+    assertFalse(wrapped.getMessage().contains("skipBytes"));
   }
 
   @Test

--- a/lib/kpipe-core/src/test/java/io/github/eschizoid/kpipe/registry/RegistryFunctionsTest.java
+++ b/lib/kpipe-core/src/test/java/io/github/eschizoid/kpipe/registry/RegistryFunctionsTest.java
@@ -63,7 +63,7 @@ class RegistryFunctionsTest {
   @Test
   void shouldReturnDefaultValueOnFunctionError() {
     // Arrange
-    final Function<String, Integer> operation = s -> {
+    final Function<String, Integer> operation = _ -> {
       throw new RuntimeException("Test exception");
     };
     final var defaultValue = -1;
@@ -82,7 +82,7 @@ class RegistryFunctionsTest {
   void shouldExecuteConsumerSuccessfully() {
     // Arrange
     final var counter = new AtomicLong(0);
-    final Consumer<String> operation = s -> counter.incrementAndGet();
+    final Consumer<String> operation = _ -> counter.incrementAndGet();
     final var logger = mock(System.Logger.class);
 
     // Act
@@ -98,7 +98,7 @@ class RegistryFunctionsTest {
   @Test
   void shouldSuppressAndLogConsumerExceptions() {
     // Arrange
-    final Consumer<String> operation = s -> {
+    final Consumer<String> operation = _ -> {
       throw new IllegalArgumentException("Test consumer exception");
     };
     final var logger = mock(System.Logger.class);

--- a/lib/kpipe-core/src/test/java/io/github/eschizoid/kpipe/sink/BatchSinkTest.java
+++ b/lib/kpipe-core/src/test/java/io/github/eschizoid/kpipe/sink/BatchSinkTest.java
@@ -30,7 +30,7 @@ class BatchSinkTest {
   @Test
   void ofVoidThrownExceptionMapsToAllFailedWithSameCause() {
     final var boom = new RuntimeException("DB unavailable");
-    final BatchSink<String> sink = BatchSink.ofVoid(batch -> {
+    final BatchSink<String> sink = BatchSink.ofVoid(_ -> {
       throw boom;
     });
 
@@ -46,7 +46,7 @@ class BatchSinkTest {
   void ofVoidEmptyBatchStillRoundTrips() {
     // An empty batch must not error out — the wrapper may call the sink with an empty list during
     // edge-of-window flushes (rare but legal).
-    final BatchSink<String> sink = BatchSink.ofVoid(batch -> {});
+    final BatchSink<String> sink = BatchSink.ofVoid(_ -> {});
 
     final var result = sink.apply(List.of());
 

--- a/lib/kpipe-format-avro/src/main/java/io/github/eschizoid/kpipe/format/avro/AvroFormat.java
+++ b/lib/kpipe-format-avro/src/main/java/io/github/eschizoid/kpipe/format/avro/AvroFormat.java
@@ -42,7 +42,7 @@ import org.apache.avro.io.EncoderFactory;
 ///
 /// // Schema-Registry — per-record auto-lookup.
 /// try (var resolver = new CachedSchemaResolver(
-///     new ConfluentSchemaResolver("http://schema-registry:8081"))) {
+///     new ConfluentSchemaResolver(<http://schema-registry:8081>))) {
 ///   final var fmt = AvroFormat.withRegistry(resolver);
 ///   // fmt.deserialize(record.value()) reads the envelope, fetches the schema, decodes.
 /// }

--- a/lib/kpipe-format-avro/src/test/java/io/github/eschizoid/kpipe/format/avro/AvroFormatBehaviorTest.java
+++ b/lib/kpipe-format-avro/src/test/java/io/github/eschizoid/kpipe/format/avro/AvroFormatBehaviorTest.java
@@ -2,6 +2,7 @@ package io.github.eschizoid.kpipe.format.avro;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import org.apache.avro.Schema;
@@ -78,14 +79,14 @@ class AvroFormatBehaviorTest {
   @Test
   void deserializeReturnsNullForNullOrEmptyBytes() {
     final var format = AvroFormat.of(USER_SCHEMA_JSON);
-    assertEquals(null, format.deserialize(null));
-    assertEquals(null, format.deserialize(new byte[0]));
+    assertNull(format.deserialize(null));
+    assertNull(format.deserialize(new byte[0]));
   }
 
   @Test
   void serializeReturnsNullForNullData() {
     final var format = AvroFormat.of(USER_SCHEMA_JSON);
-    assertEquals(null, format.serialize(null));
+    assertNull(format.serialize(null));
   }
 
   @Test

--- a/lib/kpipe-format-avro/src/test/java/io/github/eschizoid/kpipe/format/avro/AvroFormatRegistryTest.java
+++ b/lib/kpipe-format-avro/src/test/java/io/github/eschizoid/kpipe/format/avro/AvroFormatRegistryTest.java
@@ -1,6 +1,7 @@
 package io.github.eschizoid.kpipe.format.avro;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -175,8 +176,8 @@ class AvroFormatRegistryTest {
   void isRegistryBackedReflectsMode() {
     final var staticFormat = AvroFormat.of(USER_V1);
     final var registryFormat = AvroFormat.withRegistry(new FakeResolver());
-    assertEquals(false, staticFormat.isRegistryBacked());
-    assertEquals(true, registryFormat.isRegistryBacked());
+    assertFalse(staticFormat.isRegistryBacked());
+    assertTrue(registryFormat.isRegistryBacked());
   }
 
   @Test

--- a/lib/kpipe-format-avro/src/test/java/io/github/eschizoid/kpipe/format/avro/AvroSchemaCatalogTest.java
+++ b/lib/kpipe-format-avro/src/test/java/io/github/eschizoid/kpipe/format/avro/AvroSchemaCatalogTest.java
@@ -117,7 +117,7 @@ class AvroSchemaCatalogTest {
 
   @Test
   void customReaderIsInvoked() {
-    final var catalog = new AvroSchemaCatalog(loc -> USER_SCHEMA_JSON);
+    final var catalog = new AvroSchemaCatalog(_ -> USER_SCHEMA_JSON);
     catalog.add("user", "com.example.User", "any-location");
     assertEquals("com.example.User", catalog.get("user").getFullName());
   }

--- a/lib/kpipe-format-json/src/test/java/io/github/eschizoid/kpipe/format/json/MessageProcessorRegistryJsonTest.java
+++ b/lib/kpipe-format-json/src/test/java/io/github/eschizoid/kpipe/format/json/MessageProcessorRegistryJsonTest.java
@@ -101,7 +101,7 @@ class MessageProcessorRegistryJsonTest {
 
   @Test
   void shouldPropagateExceptionsFromOperators() {
-    final UnaryOperator<Map<String, Object>> operator = message -> {
+    final UnaryOperator<Map<String, Object>> operator = _ -> {
       throw new RuntimeException("Test exception");
     };
 
@@ -113,7 +113,7 @@ class MessageProcessorRegistryJsonTest {
 
   @Test
   void shouldWrapOperatorWithErrorHandling() {
-    final UnaryOperator<Map<String, Object>> operator = message -> {
+    final UnaryOperator<Map<String, Object>> operator = _ -> {
       throw new RuntimeException("Test exception");
     };
     final var safeOperator = MessageProcessorRegistry.withOperatorErrorHandling(operator);
@@ -126,7 +126,7 @@ class MessageProcessorRegistryJsonTest {
 
   @Test
   void shouldWrapSinkWithErrorHandling() {
-    final MessageSink<Map<String, Object>> sink = message -> {
+    final MessageSink<Map<String, Object>> sink = _ -> {
       throw new RuntimeException("Test exception");
     };
     final var safeSink = MessageProcessorRegistry.withSinkErrorHandling(sink);

--- a/lib/kpipe-metrics-otel/src/test/java/io/github/eschizoid/kpipe/metrics/otel/OtelConsumerMetricsTest.java
+++ b/lib/kpipe-metrics-otel/src/test/java/io/github/eschizoid/kpipe/metrics/otel/OtelConsumerMetricsTest.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.*;
 import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.sdk.OpenTelemetrySdk;
 import io.opentelemetry.sdk.metrics.SdkMeterProvider;
+import io.opentelemetry.sdk.metrics.data.LongPointData;
 import io.opentelemetry.sdk.metrics.data.MetricData;
 import io.opentelemetry.sdk.testing.exporter.InMemoryMetricReader;
 import java.util.Collection;
@@ -161,20 +162,17 @@ class OtelConsumerMetricsTest {
     // Three increments expected, but they split across two distinct attribute sets (OPEN ×2,
     // HALF_OPEN ×1). Sum across the points must be 3 and each attribute set must match.
     final var points = counter.getLongSumData().getPoints();
-    final var total = points
-      .stream()
-      .mapToLong(p -> p.getValue())
-      .sum();
+    final var total = points.stream().mapToLong(LongPointData::getValue).sum();
     assertEquals(3L, total, "all three state changes accounted for");
     final var openCount = points
       .stream()
       .filter(p -> "OPEN".equals(p.getAttributes().get(CB_STATE_KEY)))
-      .mapToLong(p -> p.getValue())
+      .mapToLong(LongPointData::getValue)
       .sum();
     final var halfOpenCount = points
       .stream()
       .filter(p -> "HALF_OPEN".equals(p.getAttributes().get(CB_STATE_KEY)))
-      .mapToLong(p -> p.getValue())
+      .mapToLong(LongPointData::getValue)
       .sum();
     assertEquals(2L, openCount, "two transitions into OPEN");
     assertEquals(1L, halfOpenCount, "one transition into HALF_OPEN");

--- a/lib/kpipe-metrics/src/test/java/io/github/eschizoid/kpipe/metrics/ConsumerMetricsTest.java
+++ b/lib/kpipe-metrics/src/test/java/io/github/eschizoid/kpipe/metrics/ConsumerMetricsTest.java
@@ -10,8 +10,10 @@ class ConsumerMetricsTest {
 
   @Test
   void shouldReturnNoopSingleton() {
-    assertNotNull(ConsumerMetrics.noop());
-    assertSame(ConsumerMetrics.noop(), ConsumerMetrics.noop(), "noop() should return a singleton");
+    final var first = ConsumerMetrics.noop();
+    final var second = ConsumerMetrics.noop();
+    assertNotNull(first);
+    assertSame(first, second, "noop() should return a singleton");
   }
 
   @Test

--- a/lib/kpipe-metrics/src/test/java/io/github/eschizoid/kpipe/metrics/ProducerMetricsTest.java
+++ b/lib/kpipe-metrics/src/test/java/io/github/eschizoid/kpipe/metrics/ProducerMetricsTest.java
@@ -10,8 +10,10 @@ class ProducerMetricsTest {
 
   @Test
   void shouldReturnNoopSingleton() {
-    assertNotNull(ProducerMetrics.noop());
-    assertSame(ProducerMetrics.noop(), ProducerMetrics.noop(), "noop() should return a singleton");
+    final var first = ProducerMetrics.noop();
+    final var second = ProducerMetrics.noop();
+    assertNotNull(first);
+    assertSame(first, second, "noop() should return a singleton");
   }
 
   @Test

--- a/lib/kpipe-producer/src/main/java/io/github/eschizoid/kpipe/producer/KPipeProducer.java
+++ b/lib/kpipe-producer/src/main/java/io/github/eschizoid/kpipe/producer/KPipeProducer.java
@@ -227,7 +227,7 @@ public class KPipeProducer<K, V> implements AutoCloseable {
   /// @param record the record to send
   /// @return a future that will contain the record metadata
   public Future<RecordMetadata> sendAsync(final ProducerRecord<K, V> record) {
-    return producer.send(record, (metadata, exception) -> {
+    return producer.send(record, (_, exception) -> {
       if (exception == null) otelMetrics.recordMessageSent();
       else otelMetrics.recordMessageFailed();
     });

--- a/lib/kpipe-producer/src/main/java/io/github/eschizoid/kpipe/producer/sink/KafkaMessageSink.java
+++ b/lib/kpipe-producer/src/main/java/io/github/eschizoid/kpipe/producer/sink/KafkaMessageSink.java
@@ -63,7 +63,7 @@ public class KafkaMessageSink<T> implements MessageSink<T> {
     } catch (final Exception traceEx) {
       LOGGER.log(Level.WARNING, "Tracer.injectContextInto threw: {0}", traceEx.getMessage());
     }
-    producer.send(record, (metadata, exception) -> {
+    producer.send(record, (_, exception) -> {
       if (exception != null) LOGGER.log(Level.WARNING, "Failed to send record to topic %s".formatted(topic), exception);
     });
   }

--- a/lib/kpipe-producer/src/test/java/io/github/eschizoid/kpipe/producer/sink/KafkaMessageSinkTest.java
+++ b/lib/kpipe-producer/src/test/java/io/github/eschizoid/kpipe/producer/sink/KafkaMessageSinkTest.java
@@ -41,7 +41,7 @@ class KafkaMessageSinkTest {
     final KafkaMessageSink<String> sink = new KafkaMessageSink<>(
       mockProducer,
       TOPIC,
-      s -> "key".getBytes(),
+      _ -> "key".getBytes(),
       String::getBytes,
       null
     );

--- a/lib/kpipe-schema-registry-confluent/src/main/java/io/github/eschizoid/kpipe/schemaregistry/confluent/CachedSchemaResolver.java
+++ b/lib/kpipe-schema-registry-confluent/src/main/java/io/github/eschizoid/kpipe/schemaregistry/confluent/CachedSchemaResolver.java
@@ -28,7 +28,7 @@ import java.util.concurrent.atomic.AtomicLong;
 /// `PipelineMetricsObserver.bindSchemaRegistryCache(...)`).
 ///
 /// ```java
-/// final var raw = new ConfluentSchemaResolver("http://schema-registry:8081");
+/// final var raw = new ConfluentSchemaResolver("<http://schema-registry:8081>");
 /// final var cached = new CachedSchemaResolver(raw);
 /// final var format = AvroFormat.withRegistry(cached);  // per-record auto-lookup
 /// ```

--- a/lib/kpipe-schema-registry-confluent/src/main/java/io/github/eschizoid/kpipe/schemaregistry/confluent/ConfluentSchemaResolver.java
+++ b/lib/kpipe-schema-registry-confluent/src/main/java/io/github/eschizoid/kpipe/schemaregistry/confluent/ConfluentSchemaResolver.java
@@ -40,7 +40,7 @@ public final class ConfluentSchemaResolver implements SchemaResolver, AutoClosea
   private final HttpClient httpClient;
   private final Duration requestTimeout;
 
-  /// Creates a resolver pointing at `baseUrl` (e.g. `http://schema-registry:8081`) with the
+  /// Creates a resolver pointing at `baseUrl` (e.g. <http://schema-registry:8081>) with the
   /// default 10-second request timeout.
   ///
   /// @param baseUrl the SR base URL (must be non-blank; no trailing slash required)

--- a/lib/kpipe-schema-registry-confluent/src/test/java/io/github/eschizoid/kpipe/schemaregistry/confluent/CachedSchemaResolverTest.java
+++ b/lib/kpipe-schema-registry-confluent/src/test/java/io/github/eschizoid/kpipe/schemaregistry/confluent/CachedSchemaResolverTest.java
@@ -142,7 +142,7 @@ class CachedSchemaResolverTest {
 
   @Test
   void closeIsNoopForNonCloseableDelegate() {
-    final var cached = new CachedSchemaResolver(id -> "{}");
+    final var cached = new CachedSchemaResolver(_ -> "{}");
     cached.close(); // must not throw
   }
 }


### PR DESCRIPTION
## Summary

Multi-agent IntelliJ MCP scan over every kpipe module (`lib/*` ×12, `examples/*` ×7, `benchmarks/jmh`) found **398 inspection findings** across 20 modules. This PR lands the **46 mechanical fixes** that are safe to apply without per-site judgment; the remaining 352 are deliberately deferred to documented "needs-judgment" categories.

Every module-fix agent ran `compileJava + compileTestJava` for its module after editing and only kept edits that passed. Final repo-wide check: **all 20 modules compile clean, spotless clean, all unit tests pass** (the 2 `:lib:kpipe-consumer` test failures are pre-existing Testcontainers tests that need a Docker daemon — CI provides one).

## Fix categories applied (46 total)

| Category | Count | What it does |
|---|---:|---|
| redundant-type-argument / explicit-type-args-redundant | 10 | Switch to `<>` diamond |
| assert-simplification | 8 | `assertEquals(true, x)` → `assertTrue(x)`, `assertTrue(x instanceof T)` → `assertInstanceOf`, etc. |
| lambda-to-method-ref | 3 | Collapse trivial lambdas to method refs |
| use-getFirst | 1 | `list.get(0)` → `list.getFirst()` (Java 21+ SequencedCollection) |
| javadoc-plain-text-link / dangling-javadoc | 4 | Wrap bare URLs in `<...>`, fix dangling refs |
| assert-same-called-on-itself | 1 | Real bug — fixed self-comparison |
| raw-type-use | 1 | Parameterize previously raw type |
| redundant-suppression | 1 | Replace stale `@SuppressWarnings` on `Result.Filtered.SHARED` with typed `Filtered<?>` field |

## Per-module breakdown

| Module | Findings | Fixed | Skipped | Compile |
|---|---:|---:|---:|:---:|
| kpipe-api | 62 | 5 | 57 | ✅ |
| kpipe-bom | 0 | — | — | ✅ |
| kpipe-consumer | 157 | 14 | 143 | ✅ |
| kpipe-core | 45 | 12 | 33 | ✅ |
| kpipe-format-avro | 15 | 6 | 9 | ✅ |
| kpipe-format-json | 13 | 0 | 13 | ✅ |
| kpipe-format-protobuf | 2 | 0 | 2 | ✅ |
| kpipe-metrics | 2 | 2 | 0 | ✅ |
| kpipe-metrics-otel | 7 | 3 | 4 | ✅ |
| kpipe-producer | 15 | 0 | 15 | ✅ |
| kpipe-schema-registry-confluent | 14 | 2 | 12 | ✅ |
| kpipe-tracing-otel | 4 | 0 | 4 | ✅ |
| examples-circuit-breaker | 3 | 0 | 3 | ✅ |
| examples-demo | 1 | 1 | 0 | ✅ |
| examples-schema-registry | 5 | 1 | 4 | ✅ |
| examples-tracing | 1 | 0 | 1 | ✅ |
| benchmarks-jmh | 52 | 0 | 52 | ✅ |
| **Total** | **398** | **46** | **352** | ✅ |

## Follow-up commit on this branch

A second commit lands the `unused-parameter` lambda renames (Java 22+ unnamed variable, `_`): **79 lambda renames** across kpipe-consumer (33), kpipe-api (16), kpipe-core (16), kpipe-format-json (3), kpipe-producer (3), kpipe-format-avro (1), kpipe-schema-registry-confluent (1), examples-circuit-breaker (1), benchmarks-jmh (5). Method-declaration unused params are left alone — Java doesn't accept `_` as a method param name. Patterns covered: single-arg lambdas (`v -> ...` → `_ -> ...`), BiConsumer/BiFunction both unused (`(p, off) -> ...` → `(_, _) -> ...`), Mockito `doAnswer` arg.

## Deliberately deferred (352)

These were left untouched because they need per-site judgment, not a mechanical rule:

- **unused-method** — public escape-hatch surface per `docs/escape-hatches.md` (`Stream`, `MultiBuilder`, `Handle`, `KPipeConsumer.Builder` methods documented but not invoked in-repo).
- **missing-try-with-resources** — integration tests deliberately span `Handle` / `KPipeConsumer` lifecycle across setup/assert/teardown; rewriting changes shutdown timing and breaks latch assertions.
- **busy-wait-thread-sleep** — intentional poll-until-condition in the `KEY_ORDERED` retry path and shutdown drain.
- **nullable-handling** / **unchecked-\*** — per-site decisions, especially Mockito raw-type captures and `AvroFormat` registry-mode hot path.
- **constant-parameter-value** — test helpers parameterized for readability even when only one call site exists.
- **sql-\*** — Testcontainers fixtures with no live data source — the IDE flags an unconfigured SQL connection, not a real issue.
- **benchmarks-jmh** unused-method/unused-class — false positives; JMH discovers `@Benchmark` and `@State` classes reflectively from the BenchmarkList.

## Test plan

- [x] `./gradlew compileJava compileTestJava` clean across all 20 modules
- [x] `./gradlew spotlessCheck` clean
- [x] Unit tests pass on every touched module (the 2 Docker-dependent integration tests need a local daemon; CI provides one)
- [x] CI green