### PR TITLE
fix(consumer): document and assert single-writer invariant for commandQueue drain (closes #163)

### DIFF
--- a/lib/kpipe-consumer/src/main/java/io/github/eschizoid/kpipe/consumer/KafkaOffsetManager.java
+++ b/lib/kpipe-consumer/src/main/java/io/github/eschizoid/kpipe/consumer/KafkaOffsetManager.java
@@ -60,13 +60,37 @@ public class KafkaOffsetManager<K> implements OffsetManager<K> {
 
   private final Consumer<K, byte[]> kafkaConsumer;
   private final AtomicReference<OffsetState> state = new AtomicReference<>(OffsetState.CREATED);
+
+  /// Shared command queue between `KPipeConsumer` and this manager.
+  ///
+  /// **Single-writer invariant.** All writes to this queue happen from the Kafka consumer thread
+  /// — `KPipeConsumer.consumerLoop` enqueues `Pause` / `Resume` / `Close` commands, and
+  /// `performCommit` enqueues `CommitOffsets`. The rebalance callback `onPartitionsRevoked`
+  /// (which calls `drainCommandQueueForRevokedPartitions`) is invoked by `Consumer.poll(...)`
+  /// on that same consumer thread, so the poll-then-readd drain in
+  /// `drainCommandQueueForRevokedPartitions` is atomic with respect to any writer.
+  ///
+  /// If a future change introduces an off-thread `CommitOffsets` writer (async commit hook, an
+  /// ad-hoc commit from another module, etc.), the drain becomes racy: a new command landing
+  /// between the last `poll()` returning `null` and `addAll(remaining)` completing would jump
+  /// the queue and bypass revoked-partition filtering — the consumer thread would then commit
+  /// against the new owner of a revoked partition. To enforce the invariant we capture the
+  /// consumer thread on the first listener callback and assert subsequent callbacks run on the
+  /// same thread (see `assertOnConsumerThread`).
   private final Queue<ConsumerCommand> commandQueue;
+
   private final Map<String, CompletableFuture<Boolean>> commitFutures = new ConcurrentHashMap<>();
   private final Map<TopicPartition, ConcurrentSkipListSet<Long>> pendingOffsets = new ConcurrentHashMap<>();
   private final Map<TopicPartition, Long> highestProcessedOffsets = new ConcurrentHashMap<>();
   private final Duration commitInterval;
   private volatile ScheduledExecutorService scheduler;
   private volatile ScheduledFuture<?> scheduledCommitTask;
+
+  /// Captured on the first rebalance callback to enforce the single-writer invariant documented
+  /// on `commandQueue`. `volatile` for visibility across the consumer thread and any test
+  /// thread that violates the invariant. Only ever written once: from `null` to the first
+  /// thread that runs `onPartitionsRevoked` / `onPartitionsAssigned`.
+  private volatile Thread consumerThread;
 
   /// Creates a new KafkaOffsetManager instance.
   ///
@@ -436,6 +460,7 @@ public class KafkaOffsetManager<K> implements OffsetManager<K> {
     return new ConsumerRebalanceListener() {
       @Override
       public void onPartitionsRevoked(final Collection<TopicPartition> partitions) {
+        assertOnConsumerThread();
         if (state.get() == OffsetState.STOPPED) return;
         LOGGER.log(Level.INFO, "Partitions revoked: %s".formatted(partitions));
 
@@ -467,6 +492,7 @@ public class KafkaOffsetManager<K> implements OffsetManager<K> {
 
       @Override
       public void onPartitionsAssigned(final Collection<TopicPartition> partitions) {
+        assertOnConsumerThread();
         if (state.get() == OffsetState.STOPPED) return;
         LOGGER.log(Level.INFO, "Partitions assigned: %s".formatted(partitions));
         partitions.forEach(partition -> {
@@ -482,10 +508,40 @@ public class KafkaOffsetManager<K> implements OffsetManager<K> {
     };
   }
 
+  /// Captures the consumer thread on the first invocation and asserts subsequent invocations
+  /// run on the same thread. Enforces the single-writer invariant on `commandQueue` for
+  /// `drainCommandQueueForRevokedPartitions` — see the field Javadoc. `assert` so the check
+  /// costs nothing in production (no `-ea`); tests run with assertions enabled and will fail
+  /// loudly if a future change starts firing the listener off-thread.
+  ///
+  /// The first-touch capture is intentional: there is no clean seam for `KPipeConsumer` to
+  /// hand us its thread before `Consumer.poll(...)` first dispatches the listener, so we treat
+  /// "whoever ran first" as the source of truth and pin every subsequent caller to that thread.
+  private void assertOnConsumerThread() {
+    final var captured = consumerThread;
+    if (captured == null) {
+      consumerThread = Thread.currentThread();
+      return;
+    }
+    assert captured == Thread.currentThread()
+      : "rebalance callback ran on %s but was previously bound to %s — commandQueue single-writer invariant violated".formatted(
+          Thread.currentThread(),
+          captured
+        );
+  }
+
   /// Filters offset-commit commands so any references to revoked partitions are dropped before
   /// the partitions reappear under a new owner. Non-commit commands pass through untouched.
   /// Drains the queue by polling, transforms each command, and re-enqueues whatever remains in
   /// order.
+  ///
+  /// **Single-writer invariant required.** The poll-then-readd sequence is *not* atomic with
+  /// respect to a concurrent `commandQueue.offer(...)`. It is safe today because every writer
+  /// is the Kafka consumer thread, and `Consumer.poll(...)` dispatches `onPartitionsRevoked`
+  /// on that same thread — see the `commandQueue` field Javadoc. Introducing an off-thread
+  /// `CommitOffsets` writer would let a new command land between the loop's last `poll()`
+  /// returning `null` and `addAll(remaining)` completing, bypassing revoked-partition
+  /// filtering. The runtime check sits in `assertOnConsumerThread`.
   private void drainCommandQueueForRevokedPartitions(final Collection<TopicPartition> partitions) {
     if (commandQueue == null || commandQueue.isEmpty()) return;
 

--- a/lib/kpipe-consumer/src/test/java/io/github/eschizoid/kpipe/consumer/KafkaOffsetManagerTest.java
+++ b/lib/kpipe-consumer/src/test/java/io/github/eschizoid/kpipe/consumer/KafkaOffsetManagerTest.java
@@ -9,6 +9,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.*;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Supplier;
 import java.util.stream.Stream;
 import org.apache.kafka.clients.consumer.Consumer;
@@ -416,6 +417,61 @@ class KafkaOffsetManagerTest {
         offsetCaptor.getValue().get(PARTITION).offset(),
         "onPartitionsLost must flush the offsets the previous owner finished"
       );
+    }
+  }
+
+  /// Guards the single-writer invariant documented on `KafkaOffsetManager.commandQueue`: every
+  /// rebalance callback must run on the same thread the listener was first bound to (the Kafka
+  /// consumer thread in production). Without this, the poll-then-readd drain in
+  /// `drainCommandQueueForRevokedPartitions` becomes racy against concurrent `CommitOffsets`
+  /// writers and revoked-partition entries can slip back into the queue.
+  ///
+  /// Tests in this nested class rely on JVM assertions being enabled (`-ea`). Gradle's `Test`
+  /// task enables them by default, so `./gradlew :lib:kpipe-consumer:test` exercises the check.
+  @Nested
+  class SingleWriterInvariantTests {
+
+    /// Calls the listener from one thread to bind the invariant, then from a different thread
+    /// — the second call must trip the `assert` in `assertOnConsumerThread`.
+    @Test
+    void rebalanceCallbackFromDifferentThreadTripsAssertion() throws Exception {
+      final var listener = offsetManager.createRebalanceListener();
+
+      // First call from the JUnit thread captures it as the bound consumer thread.
+      listener.onPartitionsRevoked(List.of(PARTITION));
+
+      // Second call from a different thread must trigger the AssertionError.
+      final var thrown = new AtomicReference<Throwable>();
+      final var off = new Thread(() -> {
+        try {
+          listener.onPartitionsRevoked(List.of(PARTITION));
+        } catch (final Throwable t) {
+          thrown.set(t);
+        }
+      }, "off-thread-rebalancer");
+      off.start();
+      off.join(2_000);
+
+      final var actual = thrown.get();
+      assertNotNull(actual, "off-thread rebalance must throw — assertions disabled?");
+      assertInstanceOf(AssertionError.class, actual, "expected AssertionError, got: " + actual);
+      assertTrue(
+        actual.getMessage().contains("single-writer invariant violated"),
+        "assertion message should call out the invariant: " + actual.getMessage()
+      );
+    }
+
+    /// Repeated callbacks on the same thread must pass — the bound-thread check only fires on a
+    /// mismatch.
+    @Test
+    void repeatedCallbacksOnSameThreadDoNotTrip() {
+      final var listener = offsetManager.createRebalanceListener();
+      assertDoesNotThrow(() -> {
+        listener.onPartitionsRevoked(List.of(PARTITION));
+        listener.onPartitionsAssigned(List.of(PARTITION));
+        listener.onPartitionsRevoked(List.of(PARTITION));
+        listener.onPartitionsLost(List.of(PARTITION));
+      });
     }
   }
 


### PR DESCRIPTION
## The race

`KafkaOffsetManager.drainCommandQueueForRevokedPartitions` drains `commandQueue` in a polling loop, filters revoked-partition entries out of each `CommitOffsets`, then re-adds the survivors via `commandQueue.addAll(remaining)`. The sequence is **not atomic** — anything writing a `CommitOffsets` between the last `poll()` returning `null` and `addAll(...)` completing would jump the queue and bypass revoked-partition filtering. The consumer thread would then commit against the new owner of the revoked partition.

## Why it is dormant today

The only `CommitOffsets` writer is `KafkaOffsetManager.performCommit`, called from the consumer thread, and `onPartitionsRevoked` runs on that same thread (dispatched by `Consumer.poll(...)`). So there is no concurrent writer racing the drain — but the single-writer invariant was neither documented nor enforced. A future contributor could quietly introduce an off-thread commit (async commit hook, ad-hoc commit from another module) and silently break revoke correctness.

## Why option (1) over option (2)

The ticket lists three options:

1. **Document + assert** — cheapest, doesn't fix the race, just guards against silently introducing it.
2. **Lock the drain** — real fix, adds a lock on the rebalance path.
3. **Restructure** — doesn't actually fix the intra-rebalance writer case.

Option (1) matches the "the race is theoretical today" reality. Option (2) would add a `ReentrantLock` taken on every commit enqueue *and* on the rebalance path for a race that no current writer can hit. The lock would also force every `performCommit` to contend with rebalance callbacks even though they're already serialized by being on the same thread. The right time to upgrade to (2) is when an off-thread writer becomes a real need — at which point this PR's assert will tell us loudly that the invariant has been broken.

## What changes

- **Javadoc on `commandQueue`** spells out the single-writer invariant: all writes happen from the Kafka consumer thread; `onPartitionsRevoked` runs on the same thread, so the drain is atomic with respect to writes. Explains exactly what kind of change would break it.
- **Javadoc on `drainCommandQueueForRevokedPartitions`** repeats the invariant at the method level so anyone reading the drain code sees why the poll-then-readd is safe today.
- **`assertOnConsumerThread()`** captures `Thread.currentThread()` on the first rebalance callback (stored in a `volatile Thread` field) and `assert`s subsequent callbacks run on that same thread. Bound to both `onPartitionsRevoked` and `onPartitionsAssigned`. `assert` is a no-op in production (no `-ea`) and trips loudly under Gradle's `Test` task (assertions on by default).
- **Two new tests** in `SingleWriterInvariantTests`:
  - `rebalanceCallbackFromDifferentThreadTripsAssertion` — binds the listener from the JUnit thread, then invokes from a different thread and expects an `AssertionError`.
  - `repeatedCallbacksOnSameThreadDoNotTrip` — calls all three callbacks from the same thread, expects no throw.

## Trade-off: first-touch capture

There is no clean seam for `KPipeConsumer` to hand the manager its consumer thread before `Consumer.poll(...)` first dispatches the listener. Adding a `registerConsumerThread(Thread)` method would expand the surface for one debug-mode check. Instead, the assertion treats "whoever ran first" as the source of truth and pins every subsequent caller to that thread. In production, that first call comes from the Kafka consumer thread.

## What would need to change if off-thread writers arrive

If we ever introduce an async commit hook (e.g., a metric-driven commit fired from a scheduled executor), the assert won't fire — it only checks the rebalance path. We would need to:

1. Upgrade to option (2): take a snapshot under a lock, swap the queue, process, restore.
2. Or refactor commit enqueue to go through a single point that the rebalance drain can coordinate with.

The Javadoc explicitly calls this out so the next contributor knows the failure mode they need to address.

## Test plan

- [x] `./gradlew :lib:kpipe-consumer:test --tests "io.github.eschizoid.kpipe.consumer.KafkaOffsetManagerTest"` passes (all 38 tests, including the 2 new ones)
- [x] Full `:lib:kpipe-consumer:test` passes except for one pre-existing Testcontainers / Docker init failure (`KPipeProducerIntegrationTest > initializationError`) unrelated to this change
- [ ] CI green