### PR TITLE
ci: add Dependabot config for Gradle + GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,37 @@
+version: 2
+updates:
+  - package-ecosystem: "gradle"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 10
+    groups:
+      gradle-minor-patch:
+        update-types:
+          - "minor"
+          - "patch"
+    labels:
+      - "dependencies"
+      - "gradle"
+    commit-message:
+      prefix: "deps"
+      include: "scope"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 5
+    groups:
+      actions-minor-patch:
+        update-types:
+          - "minor"
+          - "patch"
+    labels:
+      - "dependencies"
+      - "github-actions"
+    commit-message:
+      prefix: "ci"
+      include: "scope"


### PR DESCRIPTION
## Summary

Adds `.github/dependabot.yml` to enable automated weekly dependency PRs from Dependabot for:

- **Gradle** dependencies (`/build.gradle`, lib + examples + benchmarks)
- **GitHub Actions** versions in `.github/workflows/*.yml`

## Config choices

- **Weekly Monday cadence** — keeps the noise manageable.
- **Group minor + patch updates** per ecosystem into one combined PR — reduces churn for routine bumps.
- **Major updates open as individual PRs** — keeps human review on potentially-breaking changes.
- **PR limits**: 10 for Gradle (broader surface), 5 for Actions.
- **Conventional-commit prefixes**: `deps(...)` for Gradle, `ci(...)` for Actions — slot cleanly into the repo's existing prefix style.
- **Labels**: `dependencies` plus an ecosystem tag.

Free for public repositories. Security updates can be enabled separately via repo settings → Security → "Dependabot security updates".

## Test plan

- [ ] Merge to main
- [ ] Confirm Dependabot's first run appears in the Insights → Dependency graph → Dependabot tab within ~24 hours
- [ ] Verify first batch of grouped minor/patch PRs land on the next Monday with the expected commit-message prefixes