### PR TITLE
ci: ignore release toolchain in Dependabot (jgit + axion + jreleaser)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,6 +11,13 @@ updates:
         update-types:
           - "minor"
           - "patch"
+    # The release toolchain (jgit + axion-release + jreleaser) is pinned by hand —
+    # getting them to cooperate took real effort, so we hold bumps until they're
+    # validated together. Bump manually when needed.
+    ignore:
+      - dependency-name: "org.jreleaser*"
+      - dependency-name: "pl.allegro.tech.build.axion-release*"
+      - dependency-name: "org.eclipse.jgit*"
     labels:
       - "dependencies"
       - "gradle"


### PR DESCRIPTION
## Summary

Adds an `ignore` rule to the Gradle Dependabot config for the three release-toolchain dependencies:

- `org.eclipse.jgit*` (currently `6.10.0.202406032230-r`)
- `pl.allegro.tech.build.axion-release*` (currently `1.18.7`)
- `org.jreleaser*` (currently `1.19.0`)

## Why

Getting these three to cooperate on the publish path took real effort. Bumping any one in isolation has bitten us before. Better to bump them together, manually, after validating the combination — rather than have Dependabot re-open the same PR every Monday only for us to revert these three lines.

Direct trigger: #177 (the first weekly group PR) tried to bump axion 1.18.7 → 1.21.2 and jreleaser 1.19.0 → 1.24.0; both were reverted by hand during conflict resolution.

## Test plan

- [ ] Merge to main
- [ ] Confirm next Monday's batch (or next forced re-run) omits jgit / axion / jreleaser from the grouped PR