### PR TITLE
fix(ci): restore jgit auth in release workflow after actions/checkout v7

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -37,6 +37,17 @@ jobs:
           git config --global user.email "mariano.gonzalez.mx@gmail.com"
           git config --global user.name "Mariano Gonzalez"
 
+      # actions/checkout v5+ stores GITHUB_TOKEN in `git config http.extraheader`
+      # instead of embedding it in the origin URL. Native `git` honors extraheader;
+      # the jgit version pinned via `force(libs.jgit)` in build.gradle.kts does not.
+      # Axion-release pushes the release tag through jgit, so it falls back to
+      # anonymous and GitHub rejects the push as "not authorized". Embedding the
+      # token directly in the remote URL restores the v4-era behavior for the
+      # jgit-driven push without bumping the release-toolchain trio.
+      - name: Configure git remote auth for jgit
+        run: |
+          git remote set-url origin "https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}.git"
+
       - name: Setup GPG
         uses: crazy-max/ghaction-import-gpg@v7
         with:


### PR DESCRIPTION
## Summary

Restores the release pipeline after the recent `actions/checkout@v4 → @v7` bump (#172).

## Failure observed

[Release run 27775308182](https://github.com/eschizoid/kpipe/actions/runs/27775308182/job/82185833668) failed on the `:release` task:

```
Pushing all to remote: origin
Exception occurred during push: org.eclipse.jgit.api.errors.TransportException:
  https://github.com/eschizoid/kpipe: not authorized
```

## Root cause

- `actions/checkout@v4` embedded `GITHUB_TOKEN` directly in the origin URL: `https://x-access-token:TOKEN@github.com/owner/repo.git`. Any tool pushing through `origin` got authenticated.
- `actions/checkout@v5+` switched to storing the token in `git config http.extraheader` instead. Native `git` honors extraheader; **jgit doesn't**.
- The project's `build.gradle.kts` forces `libs.jgit` (6.10.0) onto the buildscript classpath via `resolutionStrategy { force(libs.jgit) }`, so axion-release's tag push happens through jgit 6.10 — which can't read extraheader.
- Jreleaser is unaffected because it reads `JRELEASER_GITHUB_TOKEN` env directly and bypasses git auth entirely.

## Fix

Add a `Configure git remote auth for jgit` step that re-embeds the token in the origin URL with `git remote set-url`, restoring the v4-era auth shape for the jgit-driven push.

## Why not bump the toolchain instead

- **jreleaser bump**: not in the failure path; failure is in `:release`, well before jreleaser runs.
- **axion-release bump alone**: doesn't help — `force(libs.jgit)` overrides whatever jgit axion bundles. You'd have to bump axion AND remove the force AND let axion's bundled jgit win.
- **jgit alone (6.10 → 7.x)**: would also work (jgit 7 reads extraheader), but touches the release-toolchain trio we've held pinned by hand. Workflow fix is surgical and reversible.

## Test plan

- [ ] Merge to main
- [ ] Re-run the Release workflow with `releaseType: patch`
- [ ] Confirm the `:release` task completes (tag is created and pushed)
- [ ] Confirm `:lib:publishAllLibModules` and `:lib:jreleaserFullRelease` complete as before