### PR TITLE
docs(examples): add KPipe.bytes example (refs #166)

### DIFF
--- a/examples/bytes/build.gradle.kts
+++ b/examples/bytes/build.gradle.kts
@@ -1,0 +1,11 @@
+import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar
+
+tasks.named<ShadowJar>("shadowJar") {
+  manifest {
+    attributes(
+      "Main-Class" to "io.github.eschizoid.kpipe.App",
+    )
+  }
+}
+
+description = "KPipe - Kafka Consumer Application Using Raw Bytes"

--- a/examples/bytes/src/main/java/io/github/eschizoid/kpipe/App.java
+++ b/examples/bytes/src/main/java/io/github/eschizoid/kpipe/App.java
@@ -1,0 +1,45 @@
+package io.github.eschizoid.kpipe;
+
+import io.github.eschizoid.kpipe.consumer.config.AppConfig;
+import io.github.eschizoid.kpipe.consumer.config.KafkaConsumerConfig;
+import io.github.eschizoid.kpipe.sink.MessageSink;
+import java.lang.System.Logger;
+import java.lang.System.Logger.Level;
+
+/// Minimal raw-bytes consumer demonstrating the KPipe facade. Useful for proxying, raw archival,
+/// or pre-format inspection where you want `byte[]` end-to-end with no SerDe inside the pipeline.
+/// Each record is logged with its length and a short hex preview via a custom [MessageSink].
+public final class App {
+
+  private static final Logger LOGGER = System.getLogger(App.class.getName());
+  private static final int PREVIEW_BYTES = 16;
+
+  private App() {}
+
+  static void main() {
+    final var config = AppConfig.fromEnv();
+    final var props = KafkaConsumerConfig.createConsumerConfig(config.bootstrapServers(), config.consumerGroup());
+
+    final MessageSink<byte[]> hexPreviewSink = payload ->
+      LOGGER.log(Level.INFO, "bytes len={0} preview={1}", payload.length, hexPreview(payload));
+
+    try (final var handle = KPipe.bytes(config.topic(), props).toCustom(hexPreviewSink).start()) {
+      LOGGER.log(Level.INFO, "Bytes consumer started for topic {0}", config.topic());
+      handle.awaitShutdown();
+    } catch (final Exception e) {
+      LOGGER.log(Level.ERROR, "Fatal error in bytes consumer", e);
+      System.exit(1);
+    }
+  }
+
+  private static String hexPreview(final byte[] payload) {
+    final var limit = Math.min(payload.length, PREVIEW_BYTES);
+    final var sb = new StringBuilder(limit * 3);
+    for (var i = 0; i < limit; i++) {
+      if (i > 0) sb.append(' ');
+      sb.append(String.format("%02x", payload[i]));
+    }
+    if (payload.length > limit) sb.append(" ...");
+    return sb.toString();
+  }
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -15,6 +15,7 @@ include("lib:kpipe-format-protobuf")
 include("lib:kpipe-api")
 
 include("examples")
+include("examples:bytes")
 include("examples:json")
 include("examples:avro")
 include("examples:protobuf")


### PR DESCRIPTION
## Summary

The audit in #166 flagged that `KPipe.bytes(topic, props)` was the only bundled format on the fluent facade without a corresponding `examples/` module. JSON, Avro, Protobuf, and the multi/demo paths all had complete reference apps; the raw-bytes path did not.

This PR adds `examples/bytes` to close that gap.

## What the example teaches

- `KPipe.bytes(topic, props).toCustom(MessageSink<byte[]>).start()` — the simplest possible end-to-end raw-bytes consumer.
- Demonstrates that the pipeline can stay in `byte[]` end-to-end with no format SerDe — useful for proxying, raw archival, or pre-format inspection where the consumer doesn't care about the payload structure.
- The custom `MessageSink<byte[]>` logs each record's length plus a short hex preview, mirroring what `bytesConsoleSink()` does internally but inlined so the reader can see how `toCustom(...)` plugs in.

## Structure

Copied from `examples/json/`:
- `examples/bytes/build.gradle.kts` — same shape as the json module, minus the JSON format dep (raw `byte[]` needs no format module — `MessageFormat.bytes()` lives in `kpipe-core`, transitively pulled by `kpipe-api`).
- `examples/bytes/src/main/java/io/github/eschizoid/kpipe/App.java` — `AppConfig.fromEnv()` + `KafkaConsumerConfig` + a 5-line `MessageSink<byte[]>` lambda.
- `settings.gradle.kts` — registers `examples:bytes`.

Refs #166 (does not close — that issue tracks broader audit follow-ups).