### PR TITLE
test: pin three coverage follow-ups (onPartitionsAssigned, noop singleton-identity, WARN content)

### DIFF
--- a/lib/kpipe-consumer/src/test/java/io/github/eschizoid/kpipe/consumer/KafkaOffsetManagerTest.java
+++ b/lib/kpipe-consumer/src/test/java/io/github/eschizoid/kpipe/consumer/KafkaOffsetManagerTest.java
@@ -461,6 +461,37 @@ class KafkaOffsetManagerTest {
       );
     }
 
+    /// Mirror of [#rebalanceCallbackFromDifferentThreadTripsAssertion] for the
+    /// `onPartitionsAssigned` half of the listener. The first same-thread call binds the consumer
+    /// thread; the second call from a different thread must trip the invariant.
+    @Test
+    void partitionsAssignedFromDifferentThreadTripsAssertion() throws Exception {
+      final var listener = offsetManager.createRebalanceListener();
+
+      // First call from the JUnit thread captures it as the bound consumer thread.
+      listener.onPartitionsAssigned(List.of(PARTITION));
+
+      // Second call from a different thread must trigger the AssertionError.
+      final var thrown = new AtomicReference<Throwable>();
+      final var off = new Thread(() -> {
+        try {
+          listener.onPartitionsAssigned(List.of(PARTITION));
+        } catch (final Throwable t) {
+          thrown.set(t);
+        }
+      }, "off-thread-rebalancer");
+      off.start();
+      off.join(2_000);
+
+      final var actual = thrown.get();
+      assertNotNull(actual, "off-thread rebalance must throw — assertions disabled?");
+      assertInstanceOf(AssertionError.class, actual, "expected AssertionError, got: " + actual);
+      assertTrue(
+        actual.getMessage().contains("single-writer invariant violated"),
+        "assertion message should call out the invariant: " + actual.getMessage()
+      );
+    }
+
     /// Repeated callbacks on the same thread must pass — the bound-thread check only fires on a
     /// mismatch.
     @Test

--- a/lib/kpipe-consumer/src/test/java/io/github/eschizoid/kpipe/consumer/KeyOrderedDispatcherTest.java
+++ b/lib/kpipe-consumer/src/test/java/io/github/eschizoid/kpipe/consumer/KeyOrderedDispatcherTest.java
@@ -892,6 +892,13 @@ class KeyOrderedDispatcherTest {
         saturationWarnings.size(),
         () -> "exactly one saturation WARN per dispatcher; got " + saturationWarnings.size()
       );
+      // Pin the message content so a future reword that drops the saturation signal entirely
+      // (e.g. generic "dispatch stalled") still fails this test. Loose `contains` survives
+      // benign wording tweaks like "saturated" / "saturation" / "queues saturating".
+      assertTrue(
+        saturationWarnings.getFirst().getMessage().toLowerCase().contains("saturat"),
+        () -> "saturation WARN must mention the saturation condition; got: " + saturationWarnings.getFirst().getMessage()
+      );
     } finally {
       julLogger.removeHandler(handler);
       julLogger.setLevel(originalLevel);

--- a/lib/kpipe-tracing-otel/src/test/java/io/github/eschizoid/kpipe/tracing/otel/OtelTracerTest.java
+++ b/lib/kpipe-tracing-otel/src/test/java/io/github/eschizoid/kpipe/tracing/otel/OtelTracerTest.java
@@ -3,8 +3,10 @@ package io.github.eschizoid.kpipe.tracing.otel;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import io.github.eschizoid.kpipe.producer.tracing.Tracer;
 import io.opentelemetry.api.trace.StatusCode;
 import io.opentelemetry.api.trace.propagation.W3CTraceContextPropagator;
 import io.opentelemetry.context.propagation.ContextPropagators;
@@ -137,12 +139,22 @@ class OtelTracerTest {
   @Test
   void noopTracerInjectionAndExtractionAreSilentNoops() {
     // Sanity — the noop default doesn't allocate, doesn't throw, and produces no span.
-    final var noop = io.github.eschizoid.kpipe.producer.tracing.Tracer.noop();
+    final var noop = Tracer.noop();
     final var record = new ConsumerRecord<>("t", 0, 0L, null, new byte[0]);
     try (final var scope = noop.startConsumerSpan(record)) {
       noop.injectContextInto(new RecordHeaders());
       scope.recordException(new RuntimeException("ignored"));
     }
     assertEquals(0, spanExporter.getFinishedSpanItems().size());
+
+    // Singleton-identity pins: Tracer.noop() / SpanScope.noop() must return the enum INSTANCE,
+    // not a fresh allocation. KPipeConsumer invokes both per record on the hot path; a
+    // regression that returned `new Noop()` would silently allocate on every poll.
+    assertSame(Tracer.noop(), Tracer.noop(), "Tracer.noop() must return the shared singleton, not a fresh allocation");
+    assertSame(
+      Tracer.SpanScope.noop(),
+      Tracer.SpanScope.noop(),
+      "SpanScope.noop() must return the shared singleton, not a fresh allocation"
+    );
   }
 }


### PR DESCRIPTION
## Summary

Three small test-coverage follow-ups surfaced by recent code reviews. Each one closes a specific regression-detection gap with the lightest possible test.

- **Gap 1 (PR #168 review, criticality 5).** `KafkaOffsetManagerTest.SingleWriterInvariantTests` already covers the off-thread `onPartitionsRevoked` path but not the symmetric `onPartitionsAssigned` path. Added a sibling `partitionsAssignedFromDifferentThreadTripsAssertion` with identical shape: first same-thread call binds the consumer-thread reference, second call from a different thread must trip the `AssertionError`.
- **Gap 2 (PR #170 review, criticality 3).** After the `Tracer` / `SpanScope` enum inline, nothing pinned that `Tracer.noop() == Tracer.noop()` and `SpanScope.noop() == SpanScope.noop()`. A regression returning `new Noop()` instead of `INSTANCE` would silently allocate per-record on `KPipeConsumer`'s hot path. Added two `assertSame` lines to the existing `noopTracerInjectionAndExtractionAreSilentNoops` test in `OtelTracerTest` (the natural home given the test already exercises the noop branch).
- **Gap 3 (PR #167 review, criticality 4).** `saturationLogsWarningExactlyOnceAcrossRepeatedStalls` in `KeyOrderedDispatcherTest` asserted `count == 1` but not the message content. A reword that drops the "saturation" signal entirely would still pass. Added a loose lowercase `contains("saturat")` assertion — survives wording tweaks like "saturated" / "saturation" / "queues saturating" but catches a regression that genericizes the message.

## Test plan

- [x] `./gradlew :lib:kpipe-consumer:test :lib:kpipe-producer:test :lib:kpipe-tracing-otel:test` — all green
- [x] No new dependencies; only test-tree changes