### PR TITLE
test(consumer): pin ParallelDispatcher pendingCount + onComplete race paths

### DIFF
--- a/lib/kpipe-consumer/src/test/java/io/github/eschizoid/kpipe/consumer/ParallelDispatcherTest.java
+++ b/lib/kpipe-consumer/src/test/java/io/github/eschizoid/kpipe/consumer/ParallelDispatcherTest.java
@@ -65,6 +65,152 @@ class ParallelDispatcherTest {
   }
 
   @Test
+  void pendingCountDecrementedWhenTaskThrows() throws InterruptedException {
+    // Guards the criticality-9 race in §20: ParallelDispatcher owns the in-flight counter that
+    // drives PARALLEL-mode backpressure (§5). If the task body throws and the finally block did
+    // NOT decrement, pendingCount() would climb monotonically per failed record — the watermark
+    // would latch at HIGH and the consumer would pause forever (deadlock). Conversely, double
+    // decrement would underflow toward negative and the consumer would never pause (false-
+    // negative backpressure). The production code wraps processTask.run() in try/finally so
+    // interrupt-style and exception-style exits both decrement exactly once; this test pins it.
+    final var rejectCount = new AtomicInteger(0);
+    final var dispatcher = newDispatcher(rejectCount);
+    final var completed = new CountDownLatch(1);
+
+    dispatcher.dispatch(
+      record(0),
+      () -> {
+        throw new RuntimeException("boom");
+      },
+      completed::countDown
+    );
+
+    assertTrue(completed.await(2, TimeUnit.SECONDS), "onComplete must fire even when task throws");
+    final var deadline = System.nanoTime() + Duration.ofSeconds(2).toNanos();
+    while (dispatcher.pendingCount() > 0 && System.nanoTime() < deadline) Thread.sleep(5);
+    assertEquals(0, dispatcher.pendingCount(), "throwing task's finally must still decrement in-flight");
+    assertEquals(0, rejectCount.get(), "a throwing task body is not a rejection");
+    dispatcher.close();
+  }
+
+  @Test
+  void onCompleteFiresExactlyOnceWhenTaskThrows() throws InterruptedException {
+    // Pair test for pendingCountDecrementedWhenTaskThrows: the consumer's afterRecordComplete()
+    // unparks the consumer thread when backpressure is held (§11 LockSupport park/unpark). If
+    // onComplete fired twice on the throw path (e.g. once in a catch and once in finally), the
+    // consumer would re-evaluate twice per failed record — wasteful but tolerable. If it fired
+    // ZERO times, the consumer would never wake and the pipeline would stall on the first
+    // exception. Exactly-once is the contract.
+    final var rejectCount = new AtomicInteger(0);
+    final var dispatcher = newDispatcher(rejectCount);
+    final var completeCount = new AtomicInteger(0);
+    final var completed = new CountDownLatch(1);
+
+    dispatcher.dispatch(
+      record(0),
+      () -> {
+        throw new IllegalStateException("processing failed");
+      },
+      () -> {
+        completeCount.incrementAndGet();
+        completed.countDown();
+      }
+    );
+
+    assertTrue(completed.await(2, TimeUnit.SECONDS), "onComplete must fire");
+    // Give any spurious second invocation a window to land before asserting.
+    Thread.sleep(100);
+    assertEquals(1, completeCount.get(), "onComplete must fire exactly once when task throws");
+    final var deadline = System.nanoTime() + Duration.ofSeconds(2).toNanos();
+    while (dispatcher.pendingCount() > 0 && System.nanoTime() < deadline) Thread.sleep(5);
+    assertEquals(0, dispatcher.pendingCount(), "in-flight must drain to 0 after throwing task");
+    dispatcher.close();
+  }
+
+  @Test
+  void dispatchAfterCloseHitsRejectHandler() throws InterruptedException {
+    // Explicit pin for the post-close rejection path. closeShutsDownExecutorEvenWithNoDispatches
+    // already exercises the reject handler via a never-dispatched dispatcher; this test adds the
+    // stronger contract: the task body itself MUST NOT execute on rejection, and pendingCount()
+    // must roll back from the speculative increment in dispatch(). If the increment were not
+    // rolled back, every shutdown-race rejection would leak a count, and shutdownGracefully()
+    // would burn its full timeout waiting on a ghost.
+    final var rejectCount = new AtomicInteger(0);
+    final var dispatcher = newDispatcher(rejectCount);
+    final var taskRan = new AtomicInteger(0);
+    final var onCompleteRan = new AtomicInteger(0);
+
+    dispatcher.close();
+
+    dispatcher.dispatch(record(0), taskRan::incrementAndGet, onCompleteRan::incrementAndGet);
+
+    assertEquals(1, rejectCount.get(), "dispatch after close must hit the reject handler");
+    assertEquals(0, taskRan.get(), "rejected task body must NOT execute");
+    assertEquals(0, onCompleteRan.get(), "rejected dispatch must NOT invoke onComplete (the consumer takes the reject path instead)");
+    assertEquals(0, dispatcher.pendingCount(), "rejected dispatch must roll back the speculative increment");
+  }
+
+  @Test
+  void concurrentDispatchAndCloseDoesNotLeakPending() throws InterruptedException {
+    // Stress the race window between dispatch() and close(): close() flips the executor to
+    // shut-down mid-flight while N dispatcher threads call dispatch() concurrently. Each
+    // dispatch ends in one of two terminal accounting states — task started + finally drained,
+    // OR rejected + counter rolled back. There is no third "leaked" state. The invariant: after
+    // all dispatcher threads return and close() has completed, pendingCount() must drain to 0,
+    // AND (started + rejected) must equal total. A leak shows up either as a non-zero pendingCount
+    // (decrement missing) or as a started + rejected != total mismatch (silent drop).
+    final var rejectCount = new AtomicInteger(0);
+    final var dispatcher = newDispatcher(rejectCount, Duration.ofSeconds(2));
+    final var totalDispatches = 200;
+    final var started = new AtomicInteger(0);
+    final var allDispatchersDone = new CountDownLatch(totalDispatches);
+    final var go = new CountDownLatch(1);
+
+    for (int i = 0; i < totalDispatches; i++) {
+      final var offset = i;
+      Thread
+        .ofVirtual()
+        .start(() -> {
+          try {
+            go.await();
+            dispatcher.dispatch(record(offset), started::incrementAndGet, () -> {});
+          } catch (final InterruptedException e) {
+            Thread.currentThread().interrupt();
+          } finally {
+            allDispatchersDone.countDown();
+          }
+        });
+    }
+
+    // Close from another thread, mid-flight. close() blocks until awaitTermination returns or
+    // times out, so spawning it on a VT keeps the test thread free to release `go`.
+    final var closeReturned = new CountDownLatch(1);
+    Thread
+      .ofVirtual()
+      .start(() -> {
+        try {
+          dispatcher.close();
+        } finally {
+          closeReturned.countDown();
+        }
+      });
+
+    go.countDown();
+
+    assertTrue(allDispatchersDone.await(10, TimeUnit.SECONDS), "all dispatcher threads must return");
+    assertTrue(closeReturned.await(10, TimeUnit.SECONDS), "close() must return");
+
+    final var deadline = System.nanoTime() + Duration.ofSeconds(5).toNanos();
+    while (dispatcher.pendingCount() > 0 && System.nanoTime() < deadline) Thread.sleep(10);
+    assertEquals(0, dispatcher.pendingCount(), "pendingCount must drain to 0 after concurrent dispatch+close");
+    assertEquals(
+      totalDispatches,
+      started.get() + rejectCount.get(),
+      "every dispatch must terminate as either started-and-finished or rejected; no silent leaks"
+    );
+  }
+
+  @Test
   void pendingCountDrainsToZeroWhenCloseInterruptsRunningTask() throws InterruptedException {
     // close() calls shutdownNow() when awaitTermination times out. The concern: an interrupted
     // task never runs its finally, leaving inFlight stuck > 0. That's a real risk for a POOLED


### PR DESCRIPTION
## Summary

Closes the criticality-9 coverage gap on `ParallelDispatcher`. The dispatcher's `AtomicLong inFlight` is the single source of truth for PARALLEL-mode backpressure (see CLAUDE.md §5 and §20). A leak (missing decrement) silently latches the consumer at HIGH watermark → pause-forever deadlock. A double-decrement underflows toward negative → pause-never overload. Neither is visible from logs — both are silent-failure modes worth pinning with explicit tests.

Pre-existing coverage in `ParallelDispatcherTest` covered the happy path and the close-interrupts-running-task path. Four new tests close the gaps around `processTask` throwing and concurrent close.

## Invariants pinned

- **`pendingCountDecrementedWhenTaskThrows`** — a throwing task body still drains the in-flight counter. Catches the failure mode where a `try { processTask.run(); } finally { inFlight.decrementAndGet(); }` was ever refactored into a `try/catch` that skipped the finally on the exception path.
- **`onCompleteFiresExactlyOnceWhenTaskThrows`** — `onComplete` fires exactly once on the throw path. The consumer's `afterRecordComplete()` unparks the consumer thread when backpressure is held (§11); zero invocations stall the pipeline on the first exception, double invocations spuriously double-wake.
- **`dispatchAfterCloseHitsRejectHandler`** — post-`close()` dispatches route to the reject handler, the task body does NOT execute, `onComplete` is NOT invoked (the consumer takes its reject path instead), and the speculative `inFlight.incrementAndGet()` in `dispatch()` is rolled back. Without rollback, every shutdown-race rejection would leak a count and `shutdownGracefully()` would burn its full timeout waiting on a ghost.
- **`concurrentDispatchAndCloseDoesNotLeakPending`** — stress: 200 concurrent dispatches racing against `close()`. Asserts `pendingCount() == 0` after settle AND `started + rejected == total` (no silent drops). A third "leaked" state shows up either as non-zero `pendingCount` or as `started + rejected < total`.

## Style notes

- Virtual-thread tests use `Thread.ofVirtual()` + `CountDownLatch` per project conventions (no `CompletableFuture`).
- `///` Javadoc, `final var` locals, `System.Logger` only — consistent with the existing 3 tests in the file.
- No production code touched — pure test addition.

## Test plan

- [x] `./gradlew :lib:kpipe-consumer:test --tests "io.github.eschizoid.kpipe.consumer.ParallelDispatcherTest"` — 7/7 green
- [x] CI green on PR
- [x] Copilot review pass with no new comments