### PR TITLE
chore(consumer): drop dead CircuitBreakerController.shouldProbe + fix docs

### DIFF
--- a/lib/kpipe-consumer/src/main/java/io/github/eschizoid/kpipe/consumer/CircuitBreakerController.java
+++ b/lib/kpipe-consumer/src/main/java/io/github/eschizoid/kpipe/consumer/CircuitBreakerController.java
@@ -15,14 +15,16 @@ import java.util.Objects;
 /// is to hand-roll here; if KPipe later grows rate-limit / bulkhead / slow-call detection /
 /// jittered retries, revisit and migrate at once.
 ///
-/// **State machine** (driven by [KPipeConsumer], not by this controller):
+/// **State machine** (driven by [KPipeConsumer] and `ConsumerHealthController`, not by this
+/// controller):
 ///
 ///   * `CLOSED` — outcomes feed a rolling window; on every failure the consumer asks
 ///     [#shouldTrip] whether to flip to `OPEN`. The check returns true when both the failure
 ///     rate has crossed `failureThreshold` and the window has at least `windowSize` samples
 ///     (no tripping on a single failure with an empty window).
-///   * `OPEN` — consumer is paused. A timer asks [#shouldProbe] on each tick; once
-///     `openDuration` has elapsed the consumer flips to `HALF_OPEN` and resumes Kafka polling.
+///   * `OPEN` — consumer is paused. When the breaker trips, a one-shot task is scheduled to
+///     fire after `openDuration`; the task flips the state to `HALF_OPEN` and resumes Kafka
+///     polling. No periodic tick — `openDuration` is encoded in the scheduled delay itself.
 ///   * `HALF_OPEN` — the next record's outcome decides: success → `CLOSED` (window reset),
 ///     failure → `OPEN` (timer restarted).
 ///
@@ -55,16 +57,4 @@ public record CircuitBreakerController(double failureThreshold, int windowSize, 
     return failureRate >= failureThreshold;
   }
 
-  /// In `OPEN` state, returns `true` iff `openDuration` has elapsed since the breaker tripped.
-  /// `openedAtNanos` is `System.nanoTime()` from the trip; a `0L` sentinel (never tripped) always
-  /// returns `false`.
-  ///
-  /// @param openedAtNanos `System.nanoTime()` captured at the trip, or `0L` if never tripped
-  /// @param nowNanos      the current `System.nanoTime()`
-  /// @return `true` if `openDuration` has elapsed and the consumer should transition
-  ///     OPEN → HALF_OPEN
-  public boolean shouldProbe(final long openedAtNanos, final long nowNanos) {
-    if (openedAtNanos == 0L) return false;
-    return (nowNanos - openedAtNanos) >= openDuration.toNanos();
-  }
 }

--- a/lib/kpipe-consumer/src/test/java/io/github/eschizoid/kpipe/consumer/CircuitBreakerControllerTest.java
+++ b/lib/kpipe-consumer/src/test/java/io/github/eschizoid/kpipe/consumer/CircuitBreakerControllerTest.java
@@ -8,9 +8,10 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.time.Duration;
 import org.junit.jupiter.api.Test;
 
-/// Contract tests for [CircuitBreakerController]. Verifies the validation invariants and the two
-/// pure-function predicates (`shouldTrip`, `shouldProbe`) that drive [KPipeConsumer]'s state
-/// transitions.
+/// Contract tests for [CircuitBreakerController]. Verifies the validation invariants and the
+/// `shouldTrip` predicate that drives the CLOSED → OPEN transition. The OPEN → HALF_OPEN
+/// transition is driven by a one-shot scheduled task (no predicate) and is exercised end-to-end
+/// in `KPipeCircuitBreakerIntegrationTest`.
 class CircuitBreakerControllerTest {
 
   @Test
@@ -61,22 +62,4 @@ class CircuitBreakerControllerTest {
     assertFalse(controller.shouldTrip(10, 0.4), "40% failure rate should not trip a 50% threshold");
   }
 
-  @Test
-  void shouldProbeFalseUntilDurationElapsed() {
-    final var controller = new CircuitBreakerController(0.5, 100, Duration.ofMillis(500));
-    final var openedAt = System.nanoTime();
-
-    assertFalse(controller.shouldProbe(openedAt, openedAt + 1_000_000L), "1ms after open shouldn't probe");
-    assertTrue(
-      controller.shouldProbe(openedAt, openedAt + Duration.ofMillis(500).toNanos()),
-      "exactly at duration should probe"
-    );
-    assertTrue(controller.shouldProbe(openedAt, openedAt + Duration.ofSeconds(1).toNanos()), "after duration: probe");
-  }
-
-  @Test
-  void shouldProbeFalseForSentinelOpenedAt() {
-    final var controller = new CircuitBreakerController(0.5, 100, Duration.ofSeconds(1));
-    assertFalse(controller.shouldProbe(0L, System.nanoTime()), "never-tripped sentinel must return false");
-  }
 }


### PR DESCRIPTION
## Summary

Two-part cleanup surfaced by the CircuitBreaker wiring investigation that ran alongside #186–#188:

1. **Delete the stranded `CircuitBreakerController.shouldProbe(long, long)` helper** and its two unit tests. Audit found zero production callers. The Javadoc claimed "a timer asks `shouldProbe` on each tick" — but no such tick exists in production. The real OPEN → HALF_OPEN transition fires via `scheduler.schedule(this::tryHalfOpen, openDuration, …)` in `ConsumerHealthController.trip()`, so the delay itself encodes the threshold (no predicate, no polling).
2. **Rewrite the class Javadoc's OPEN-state description** to describe the actual one-shot-scheduler design.
3. **Add a "Circuit breaker" row to the §17 capability table** in `.claude/CLAUDE.md` — the table was missing it entirely, despite the feature being public on both the fluent facade (`Stream.withCircuitBreaker(...)` / `MultiBuilder.withCircuitBreaker(...)`) and the explicit Builder (`Builder.withCircuitBreaker(CircuitBreakerController)`).

## Why this is safe

The investigation explicitly verified:

- `shouldProbe` callers in production: **zero**. Test-only callers: 4 assertions across 2 test methods, both in `CircuitBreakerControllerTest`.
- `recordOutcome` callers in production: `KPipeConsumer.java:1647` (success path) + `KPipeConsumer.java:1765` (failure path). The full circuit-breaker pause path is wired and exercised by `KPipeCircuitBreakerIntegrationTest`.

This PR only touches the helper, not the wiring.

## Test plan

- [x] `./gradlew :lib:kpipe-consumer:test --tests "*CircuitBreaker*"` → BUILD SUCCESSFUL
- [ ] Merge to main
- [ ] `KPipeCircuitBreakerIntegrationTest` continues to pass on next push