### PR TITLE
chore: roundup of worth-considering nits from review fleet

### DIFF
--- a/examples/bytes/src/main/java/io/github/eschizoid/kpipe/App.java
+++ b/examples/bytes/src/main/java/io/github/eschizoid/kpipe/App.java
@@ -5,6 +5,7 @@ import io.github.eschizoid.kpipe.consumer.config.KafkaConsumerConfig;
 import io.github.eschizoid.kpipe.sink.MessageSink;
 import java.lang.System.Logger;
 import java.lang.System.Logger.Level;
+import java.util.HexFormat;
 
 /// Minimal raw-bytes consumer demonstrating the KPipe facade. Useful for proxying, raw archival,
 /// or pre-format inspection where you want `byte[]` end-to-end with no SerDe inside the pipeline.
@@ -34,12 +35,7 @@ public final class App {
 
   private static String hexPreview(final byte[] payload) {
     final var limit = Math.min(payload.length, PREVIEW_BYTES);
-    final var sb = new StringBuilder(limit * 3);
-    for (var i = 0; i < limit; i++) {
-      if (i > 0) sb.append(' ');
-      sb.append(String.format("%02x", payload[i]));
-    }
-    if (payload.length > limit) sb.append(" ...");
-    return sb.toString();
+    final var hex = HexFormat.ofDelimiter(" ").formatHex(payload, 0, limit);
+    return payload.length > limit ? hex + " ..." : hex;
   }
 }

--- a/lib/kpipe-consumer/src/main/java/io/github/eschizoid/kpipe/consumer/ParallelDispatcher.java
+++ b/lib/kpipe-consumer/src/main/java/io/github/eschizoid/kpipe/consumer/ParallelDispatcher.java
@@ -45,6 +45,12 @@ final class ParallelDispatcher<K> implements Dispatcher<K> {
     this.terminationTimeout = terminationTimeout;
   }
 
+  /// `processTask` must handle its own exceptions — `executor.submit(Runnable)` returns a `Future`
+  /// that the dispatcher discards, so any throwable escaping `processTask.run()` is silently
+  /// swallowed by the VT executor. The finally block still decrements `inFlight` and fires
+  /// `onComplete` so accounting and backpressure remain honest, but the failure itself only
+  /// surfaces if `processTask` routed it (e.g. through the consumer's error handler / DLQ).
+  /// `KPipeConsumer.processRecord` satisfies this contract; any other caller must too.
   @Override
   public void dispatch(final ConsumerRecord<K, byte[]> record, final Runnable processTask, final Runnable onComplete) {
     inFlight.incrementAndGet();

--- a/lib/kpipe-consumer/src/main/java/io/github/eschizoid/kpipe/consumer/ParallelDispatcher.java
+++ b/lib/kpipe-consumer/src/main/java/io/github/eschizoid/kpipe/consumer/ParallelDispatcher.java
@@ -50,7 +50,6 @@ final class ParallelDispatcher<K> implements Dispatcher<K> {
   /// swallowed by the VT executor. The finally block still decrements `inFlight` and fires
   /// `onComplete` so accounting and backpressure remain honest, but the failure itself only
   /// surfaces if `processTask` routed it (e.g. through the consumer's error handler / DLQ).
-  /// `KPipeConsumer.processRecord` satisfies this contract; any other caller must too.
   @Override
   public void dispatch(final ConsumerRecord<K, byte[]> record, final Runnable processTask, final Runnable onComplete) {
     inFlight.incrementAndGet();

--- a/lib/kpipe-consumer/src/test/java/io/github/eschizoid/kpipe/consumer/BatchPipelineWrapperCoverageContractTest.java
+++ b/lib/kpipe-consumer/src/test/java/io/github/eschizoid/kpipe/consumer/BatchPipelineWrapperCoverageContractTest.java
@@ -354,7 +354,6 @@ class BatchPipelineWrapperCoverageContractTest {
         final var ev = callbacks.events.get(i);
         processedOffsets.put(Long.parseLong(ev.substring("markProcessed:".length())), true);
       }
-      assertNull(processedOffsets.get(-1L), "spot-check: missing-key lookup should be null");
       for (long off = 0; off < 3; off++) {
         assertTrue(processedOffsets.containsKey(off), "offset " + off + " must be marked processed before close");
       }

--- a/lib/kpipe-consumer/src/test/java/io/github/eschizoid/kpipe/consumer/KPipeConsumerTest.java
+++ b/lib/kpipe-consumer/src/test/java/io/github/eschizoid/kpipe/consumer/KPipeConsumerTest.java
@@ -455,12 +455,10 @@ class KPipeConsumerTest {
 
   @Test
   void mixingRegularAndBatchRoutesForSameTopicMustThrow() {
-    // §18 invariant: a single topic can only appear in one route — either a regular pipeline OR
-    // a batch pipeline, never both. The disjoint-topics check fires in Builder.build() so a
-    // misconfiguration trips at startup rather than producing silent ambiguity at runtime (which
-    // route processes the record?). Without this guard the consumer would accept both routes,
-    // and the order in which dispatch evaluates them would determine the outcome — a config-
-    // dependent silent failure exactly the kind §15 / §18 explicitly reject.
+    // A single topic must appear in exactly one route — regular pipeline OR batch — never both.
+    // The check fires in Builder.build() so a misconfig trips at startup rather than producing
+    // silent ambiguity at runtime ("which route processes the record?"). Without this guard,
+    // dispatch evaluation order would silently determine the outcome.
     final var ex = assertThrows(IllegalArgumentException.class, () ->
       KPipeConsumer.<String>builder()
         .withProperties(properties)

--- a/lib/kpipe-consumer/src/test/java/io/github/eschizoid/kpipe/consumer/KPipeConsumerTest.java
+++ b/lib/kpipe-consumer/src/test/java/io/github/eschizoid/kpipe/consumer/KPipeConsumerTest.java
@@ -454,6 +454,33 @@ class KPipeConsumerTest {
   }
 
   @Test
+  void mixingRegularAndBatchRoutesForSameTopicMustThrow() {
+    // §18 invariant: a single topic can only appear in one route — either a regular pipeline OR
+    // a batch pipeline, never both. The disjoint-topics check fires in Builder.build() so a
+    // misconfiguration trips at startup rather than producing silent ambiguity at runtime (which
+    // route processes the record?). Without this guard the consumer would accept both routes,
+    // and the order in which dispatch evaluates them would determine the outcome — a config-
+    // dependent silent failure exactly the kind §15 / §18 explicitly reject.
+    final var ex = assertThrows(IllegalArgumentException.class, () ->
+      KPipeConsumer.<String>builder()
+        .withProperties(properties)
+        .withTopic(TOPIC)
+        .withPipeline(TestPipelines.identity())
+        .withBatchPipeline(
+          TOPIC,
+          TestPipelines.identity(),
+          BatchSink.ofVoid(batch -> {}),
+          BatchPolicy.ofSize(10)
+        )
+        .build()
+    );
+    assertTrue(
+      ex.getMessage().contains(TOPIC) && ex.getMessage().contains("both"),
+      "rejection message must name the conflicting topic and call out the regular/batch overlap, got: " + ex.getMessage()
+    );
+  }
+
+  @Test
   void isRunningShouldReturnFalseAfterConstruction() {
     // Arrange
     final var consumer = createConsumerWithMockProcessor();

--- a/lib/kpipe-consumer/src/test/java/io/github/eschizoid/kpipe/consumer/ParallelDispatcherTest.java
+++ b/lib/kpipe-consumer/src/test/java/io/github/eschizoid/kpipe/consumer/ParallelDispatcherTest.java
@@ -94,6 +94,33 @@ class ParallelDispatcherTest {
   }
 
   @Test
+  void pendingCountDrainsWhenTaskThrowsError() throws InterruptedException {
+    // Companion to pendingCountDecrementedWhenTaskThrows but with an Error instead of an
+    // Exception. The production code uses bare `try { processTask.run(); } finally { ... }` —
+    // no `catch (Exception)` — so the finally must still unwind for Throwables that bypass
+    // exception catches (AssertionError, OutOfMemoryError, StackOverflowError). A future
+    // refactor that narrows to `catch (Exception) { ... } finally { ... }` would silently
+    // strand pendingCount on any Error; this test catches that regression.
+    final var rejectCount = new AtomicInteger(0);
+    final var dispatcher = newDispatcher(rejectCount);
+    final var completed = new CountDownLatch(1);
+
+    dispatcher.dispatch(
+      record(0),
+      () -> {
+        throw new AssertionError("simulated invariant violation");
+      },
+      completed::countDown
+    );
+
+    assertTrue(completed.await(2, TimeUnit.SECONDS), "onComplete must fire even when task throws an Error");
+    final var deadline = System.nanoTime() + Duration.ofSeconds(2).toNanos();
+    while (dispatcher.pendingCount() > 0 && System.nanoTime() < deadline) Thread.sleep(5);
+    assertEquals(0, dispatcher.pendingCount(), "Error-throwing task's finally must still decrement in-flight");
+    dispatcher.close();
+  }
+
+  @Test
   void onCompleteFiresExactlyOnceWhenTaskThrows() throws InterruptedException {
     // Pair test for pendingCountDecrementedWhenTaskThrows: the consumer's afterRecordComplete()
     // unparks the consumer thread when backpressure is held (§11 LockSupport park/unpark). If

--- a/lib/kpipe-consumer/src/test/java/io/github/eschizoid/kpipe/consumer/ParallelDispatcherTest.java
+++ b/lib/kpipe-consumer/src/test/java/io/github/eschizoid/kpipe/consumer/ParallelDispatcherTest.java
@@ -95,12 +95,10 @@ class ParallelDispatcherTest {
 
   @Test
   void pendingCountDrainsWhenTaskThrowsError() throws InterruptedException {
-    // Companion to pendingCountDecrementedWhenTaskThrows but with an Error instead of an
-    // Exception. The production code uses bare `try { processTask.run(); } finally { ... }` —
-    // no `catch (Exception)` — so the finally must still unwind for Throwables that bypass
-    // exception catches (AssertionError, OutOfMemoryError, StackOverflowError). A future
-    // refactor that narrows to `catch (Exception) { ... } finally { ... }` would silently
-    // strand pendingCount on any Error; this test catches that regression.
+    // Sibling of pendingCountDecrementedWhenTaskThrows for `Error` (e.g. `AssertionError`),
+    // which is a Throwable-not-Exception and would bypass any future narrowing of the production
+    // try/finally to `catch (Exception) { ... } finally { ... }` — pendingCount would silently
+    // strand on every Error escape.
     final var rejectCount = new AtomicInteger(0);
     final var dispatcher = newDispatcher(rejectCount);
     final var completed = new CountDownLatch(1);


### PR DESCRIPTION
## Summary

Five small follow-ups surfaced by the recent 20-agent review fleet across #186–#189. None warrants a PR alone; bundling them is the natural shape.

| # | Change | Source review |
|---|---|---|
| 1 | Add `pendingCountDrainsWhenTaskThrowsError` to ParallelDispatcherTest — pins the `finally` unwinds for non-Exception throwables (AssertionError, etc.) | #186 code-review, criticality 6 |
| 2 | Document the dispatch contract on `ParallelDispatcher`: `processTask` must handle its own exceptions because `executor.submit(Runnable)` returns a discarded Future | #186 silent-failure |
| 3 | Add `mixingRegularAndBatchRoutesForSameTopicMustThrow` to KPipeConsumerTest — pins the §18 disjoint-routes guard | #188 pr-test-analyzer |
| 4 | Drop dead `assertNull(processedOffsets.get(-1L))` from `BatchPipelineWrapperCoverageContractTest:357` — asserts a HashMap property, not a wrapper property | #188 code-review |
| 5 | Switch `examples/bytes` hex preview to `HexFormat.ofDelimiter(" ")` — drops the manual byte loop + StringBuilder concat | #183 + #184 code-review |

## Not folded in

The `totalInFlight() >= bufferedCount()` integration test (#188 reviewer, criticality 6) is already covered by `KPipeConsumerTest.closeFlushesBufferedBatchWithoutBurningDrainTimeout` at line 387 — asserts `consumer.getMetrics().get("inFlight") == 1L` while a batched record is buffered, which is exactly the contract. Calling that out so the gap isn't re-flagged on the next sweep.

## Test plan

- [x] `./gradlew :lib:kpipe-consumer:test --tests "ParallelDispatcherTest" --tests "KPipeConsumerTest.mixingRegularAndBatchRoutesForSameTopicMustThrow" --tests "BatchPipelineWrapperCoverageContractTest" :examples:bytes:compileJava` → BUILD SUCCESSFUL
- [ ] Merge to main