### PR TITLE
test(producer): pin Tracer header injection through DLQ

### DIFF
--- a/lib/kpipe-producer/src/test/java/io/github/eschizoid/kpipe/producer/KPipeProducerTest.java
+++ b/lib/kpipe-producer/src/test/java/io/github/eschizoid/kpipe/producer/KPipeProducerTest.java
@@ -14,6 +14,7 @@ import org.apache.kafka.clients.producer.Callback;
 import org.apache.kafka.clients.producer.Producer;
 import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.kafka.clients.producer.RecordMetadata;
+import org.apache.kafka.common.header.Headers;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
@@ -115,6 +116,46 @@ class KPipeProducerTest {
         assertEquals(TOPIC, new String(headers.lastHeader("x-dlq-source-topic").value()));
         assertEquals("2", new String(headers.lastHeader("x-dlq-source-partition").value()));
         assertEquals("42", new String(headers.lastHeader("x-dlq-source-offset").value()));
+        return true;
+      })
+    );
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  void dlqRecordCarriesTracerInjectedHeaders() {
+    when(mockProducer.send(any(ProducerRecord.class))).thenReturn(
+      CompletableFuture.completedFuture(mock(RecordMetadata.class))
+    );
+
+    // Tiny stub Tracer that stamps a known header during injection. Using an anonymous impl (not
+    // Mockito) keeps the contract under test honest: if a future refactor drops the
+    // tracer.injectContextInto(...) call, this test breaks.
+    final var stampingTracer = new Tracer() {
+      @Override
+      public SpanScope startConsumerSpan(final ConsumerRecord<?, byte[]> record) {
+        return SpanScope.noop();
+      }
+
+      @Override
+      public void injectContextInto(final Headers headers) {
+        headers.add("x-tracer-stamp", "yes".getBytes());
+      }
+    };
+
+    final var record = new ConsumerRecord<>(TOPIC, 0, 0L, "k".getBytes(), "v".getBytes());
+    new KPipeProducer<>(mockProducer, false, null, stampingTracer).sendToDlq(
+      DLQ_TOPIC,
+      record,
+      TOPIC,
+      new RuntimeException("boom")
+    );
+
+    verify(mockProducer).send(
+      argThat(r -> {
+        final var stamp = r.headers().lastHeader("x-tracer-stamp");
+        assertNotNull(stamp, "Tracer.injectContextInto must run against the outbound DLQ record's headers");
+        assertEquals("yes", new String(stamp.value()));
         return true;
       })
     );


### PR DESCRIPTION
## Summary

Closes a criticality-5 coverage gap: a future refactor that drops the `tracer.injectContextInto(headers)` call in `KPipeProducer.sendToDlq` would silently strip trace context from DLQ records without any existing test failing.

- Adds `dlqRecordCarriesTracerInjectedHeaders` to `KPipeProducerTest`.
- Wires a tiny anonymous `Tracer` stub (not Mockito) that stamps `x-tracer-stamp: yes` during `injectContextInto`.
- Asserts the stamp lands on the captured outbound `ProducerRecord`'s headers after a `sendToDlq` call.

Existing `shouldSendDlqRecordWithAllHeaders` covers the static `x-dlq-*` enrichment headers but never exercises the tracer injection branch; using a hand-written stub keeps the contract enforced by behaviour rather than by Mockito argument matching.

No production-code change. Production already invokes the tracer correctly at `KPipeProducer.java:183` — this PR just pins that invariant under test.

## Test plan

- [x] `./gradlew :lib:kpipe-producer:test` — green (24 tests in `KPipeProducerTest`, was 23).
- [x] New test exercises a real anonymous `Tracer` implementation, not a mock.
- [x] No production code touched.