### PR TITLE
test(producer): pin KafkaMessageSink error paths

### DIFF
--- a/lib/kpipe-producer/src/test/java/io/github/eschizoid/kpipe/producer/sink/KafkaMessageSinkTest.java
+++ b/lib/kpipe-producer/src/test/java/io/github/eschizoid/kpipe/producer/sink/KafkaMessageSinkTest.java
@@ -6,6 +6,7 @@ import static org.mockito.Mockito.*;
 
 import org.apache.kafka.clients.producer.Callback;
 import org.apache.kafka.clients.producer.Producer;
+import org.apache.kafka.common.KafkaException;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
@@ -66,5 +67,60 @@ class KafkaMessageSinkTest {
     sink.accept(null);
 
     verifyNoInteractions(mockProducer);
+  }
+
+  /// Pins the §12 no-silent-failures contract for the synchronous `send(...)` exception path.
+  ///
+  /// When the underlying Kafka `Producer.send` throws a `KafkaException` synchronously (e.g.
+  /// serialization failure, authorization failure, buffer exhaustion with `max.block.ms=0`), the
+  /// sink must propagate that exception rather than catch-and-log. The async-callback failure path
+  /// is the only "log and swallow" path the sink documents — synchronous `send` throws are surfaced
+  /// so upstream pipeline error handling (`withSinkErrorHandling`) can see them.
+  @Test
+  void acceptPropagatesProducerExceptionAsRuntime() {
+    final var failure = new KafkaException("synchronous send failure");
+    when(mockProducer.send(any(), any(Callback.class))).thenThrow(failure);
+
+    final KafkaMessageSink<String> sink = KafkaMessageSink.of(mockProducer, TOPIC, String::getBytes, null);
+
+    final var thrown = assertThrows(KafkaException.class, () -> sink.accept("payload"));
+    assertSame(failure, thrown, "the original KafkaException must propagate unwrapped");
+  }
+
+  /// Pins the closed-producer behaviour: per Kafka's contract, `Producer.send` on a closed producer
+  /// throws `IllegalStateException("Cannot perform operation after producer has been closed")`.
+  ///
+  /// The sink does not pre-check producer state — it relies on Kafka's own exception. The
+  /// invariant being pinned here is that the sink does NOT swallow this exception; it propagates so
+  /// the pipeline's error handler can route or fail loudly (§12).
+  @Test
+  void acceptOnClosedProducerThrows() {
+    final var closed = new IllegalStateException("Cannot perform operation after producer has been closed");
+    when(mockProducer.send(any(), any(Callback.class))).thenThrow(closed);
+
+    final KafkaMessageSink<String> sink = KafkaMessageSink.of(mockProducer, TOPIC, String::getBytes, null);
+
+    final var thrown = assertThrows(IllegalStateException.class, () -> sink.accept("payload"));
+    assertSame(closed, thrown, "the closed-producer ISE must propagate unwrapped");
+  }
+
+  /// Verifies the static factory `KafkaMessageSink.of(...)` builds a sink whose keyMapper is null,
+  /// which produces a `ProducerRecord` with a null key. Kafka accepts null keys (partition
+  /// assignment falls back to the configured partitioner — round-robin / sticky for the default).
+  @Test
+  void ofStaticFactoryWithNullKeyAccepted() {
+    final KafkaMessageSink<String> sink = KafkaMessageSink.of(mockProducer, TOPIC, String::getBytes, null);
+
+    sink.accept("payload");
+
+    verify(mockProducer, times(1)).send(
+      argThat(record -> {
+        assertEquals(TOPIC, record.topic());
+        assertNull(record.key(), "of(...) must produce a null-keyed record");
+        assertArrayEquals("payload".getBytes(), record.value());
+        return true;
+      }),
+      any(Callback.class)
+    );
   }
 }

--- a/lib/kpipe-producer/src/test/java/io/github/eschizoid/kpipe/producer/sink/KafkaMessageSinkTest.java
+++ b/lib/kpipe-producer/src/test/java/io/github/eschizoid/kpipe/producer/sink/KafkaMessageSinkTest.java
@@ -69,15 +69,14 @@ class KafkaMessageSinkTest {
     verifyNoInteractions(mockProducer);
   }
 
-  /// Pins the §12 no-silent-failures contract for the synchronous `send(...)` exception path.
-  ///
   /// When the underlying Kafka `Producer.send` throws a `KafkaException` synchronously (e.g.
   /// serialization failure, authorization failure, buffer exhaustion with `max.block.ms=0`), the
-  /// sink must propagate that exception rather than catch-and-log. The async-callback failure path
-  /// is the only "log and swallow" path the sink documents — synchronous `send` throws are surfaced
-  /// so upstream pipeline error handling (`withSinkErrorHandling`) can see them.
+  /// sink must propagate the exception unwrapped rather than catch-and-log. The async-callback
+  /// failure path is the only "log and swallow" path the sink documents — synchronous `send`
+  /// throws are surfaced so upstream pipeline error handling (`withSinkErrorHandling`) can see
+  /// them.
   @Test
-  void acceptPropagatesProducerExceptionAsRuntime() {
+  void acceptPropagatesProducerExceptionUnwrapped() {
     final var failure = new KafkaException("synchronous send failure");
     when(mockProducer.send(any(), any(Callback.class))).thenThrow(failure);
 
@@ -92,7 +91,7 @@ class KafkaMessageSinkTest {
   ///
   /// The sink does not pre-check producer state — it relies on Kafka's own exception. The
   /// invariant being pinned here is that the sink does NOT swallow this exception; it propagates so
-  /// the pipeline's error handler can route or fail loudly (§12).
+  /// the pipeline's error handler can route or fail loudly.
   @Test
   void acceptOnClosedProducerThrows() {
     final var closed = new IllegalStateException("Cannot perform operation after producer has been closed");


### PR DESCRIPTION
## Summary

Closes a criticality-6 coverage gap on `KafkaMessageSink`: the existing tests only covered happy paths. This PR adds three tests that pin the error-path contract — no production code changes.

## Invariants pinned

- **`acceptPropagatesProducerExceptionAsRuntime`** — when the underlying Kafka `Producer.send(record, callback)` throws a `KafkaException` synchronously (serialization failure, authorization failure, buffer exhaustion with `max.block.ms=0`, etc.), the sink **must propagate the exception unwrapped**, not catch-and-log. The async-callback failure path is the only "log and swallow" path the sink documents (per the class javadoc); synchronous throws are surfaced so upstream sink error handling (`MessageProcessorRegistry.withSinkErrorHandling`) can see them. Pins §12 (no-silent-failures doctrine).

- **`acceptOnClosedProducerThrows`** — per Kafka's `Producer` contract, calling `send(...)` on a closed producer throws `IllegalStateException("Cannot perform operation after producer has been closed")`. The sink does **not** pre-check producer state and does **not** swallow this exception — it propagates so pipeline error handlers can route or fail loudly.

- **`ofStaticFactoryWithNullKeyAccepted`** — the `KafkaMessageSink.of(producer, topic, valueMapper, tracer)` factory produces a sink whose key path is null. Verifies the resulting `ProducerRecord` has a `null` key (Kafka allows null keys; partition assignment falls back to the configured partitioner — round-robin / sticky for the default).

## Test plan

- [x] `./gradlew :lib:kpipe-producer:test` — 7 tests in `KafkaMessageSinkTest` all green
- [x] Full producer module test suite — green
- [x] No production code changes — pure test addition