### PR TITLE
test(schema-registry): pin CachedSchemaResolver failure-caching contract (§19)

### DIFF
--- a/lib/kpipe-schema-registry-confluent/src/test/java/io/github/eschizoid/kpipe/schemaregistry/confluent/CachedSchemaResolverTest.java
+++ b/lib/kpipe-schema-registry-confluent/src/test/java/io/github/eschizoid/kpipe/schemaregistry/confluent/CachedSchemaResolverTest.java
@@ -130,8 +130,8 @@ class CachedSchemaResolverTest {
     /// If the cache poisoned itself with a sentinel on failure, the second call would either
     /// throw again (sentinel re-raised) or skip the delegate entirely (sentinel served as a
     /// silent success). Either way the topic would be pinned into a permanent decode-error
-    /// state, violating the §19 "cache forever in-process" invariant which only applies AFTER a
-    /// successful lookup.
+    /// state. Confluent SR schema IDs are immutable, so the "cache forever" rule only applies
+    /// AFTER a successful lookup — failures must propagate without leaving residue.
     final var calls = new AtomicInteger();
     final var shouldFail = new AtomicReference<>(Boolean.TRUE);
     final SchemaResolver flaky = id -> {
@@ -163,9 +163,9 @@ class CachedSchemaResolverTest {
   @Test
   void concurrentMissOnSameIdCollapsesToOneDelegateCall() throws InterruptedException {
     /// Two virtual threads race a miss on the same id; the delegate is slow enough that the
-    /// second thread blocks inside `computeIfAbsent` waiting for the first. The §19 contract is
-    /// that `computeIfAbsent` collapses concurrent misses to a single delegate call — anything
-    /// else would amplify HTTP load to the registry under deserializer fan-in.
+    /// second thread blocks inside `computeIfAbsent` waiting for the first. `computeIfAbsent`
+    /// must collapse concurrent misses to a single delegate call — anything else would amplify
+    /// HTTP load to the registry under deserializer fan-in.
     final var delegateCalls = new AtomicInteger();
     final var inDelegate = new CountDownLatch(1);
     final var releaseDelegate = new CountDownLatch(1);

--- a/lib/kpipe-schema-registry-confluent/src/test/java/io/github/eschizoid/kpipe/schemaregistry/confluent/CachedSchemaResolverTest.java
+++ b/lib/kpipe-schema-registry-confluent/src/test/java/io/github/eschizoid/kpipe/schemaregistry/confluent/CachedSchemaResolverTest.java
@@ -1,13 +1,17 @@
 package io.github.eschizoid.kpipe.schemaregistry.confluent;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import io.github.eschizoid.kpipe.registry.SchemaResolver;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
 import org.junit.jupiter.api.Test;
 
 class CachedSchemaResolverTest {
@@ -118,6 +122,153 @@ class CachedSchemaResolverTest {
   @Test
   void rejectsNullDelegate() {
     assertThrows(NullPointerException.class, () -> new CachedSchemaResolver(null));
+  }
+
+  @Test
+  void failedLookupIsNotCachedAndIsRetriedOnNextCall() {
+    /// First call's delegate throws; second call's delegate succeeds.
+    /// If the cache poisoned itself with a sentinel on failure, the second call would either
+    /// throw again (sentinel re-raised) or skip the delegate entirely (sentinel served as a
+    /// silent success). Either way the topic would be pinned into a permanent decode-error
+    /// state, violating the §19 "cache forever in-process" invariant which only applies AFTER a
+    /// successful lookup.
+    final var calls = new AtomicInteger();
+    final var shouldFail = new AtomicReference<>(Boolean.TRUE);
+    final SchemaResolver flaky = id -> {
+      calls.incrementAndGet();
+      if (shouldFail.get()) {
+        throw new RuntimeException("transient SR failure for id=" + id);
+      }
+      return "{\"type\":\"record\",\"name\":\"S" + id + "\",\"fields\":[]}";
+    };
+    final var cached = new CachedSchemaResolver(flaky);
+
+    final var thrown = assertThrows(RuntimeException.class, () -> cached.lookupById(99));
+    assertTrue(thrown.getMessage().contains("transient SR failure"), "delegate exception must propagate verbatim");
+    assertEquals(1, calls.get(), "delegate must be invoked exactly once on the failing call");
+    assertEquals(0, cached.size(), "failed lookup must not leave any entry in the cache");
+
+    shouldFail.set(Boolean.FALSE);
+    final var schema = cached.lookupById(99);
+
+    assertEquals("{\"type\":\"record\",\"name\":\"S99\",\"fields\":[]}", schema);
+    assertEquals(2, calls.get(), "delegate must be re-invoked on retry — failure was not cached");
+    assertEquals(1, cached.size(), "successful retry must populate the cache");
+
+    cached.lookupById(99);
+    assertEquals(2, calls.get(), "after success, subsequent lookups serve from cache");
+    assertEquals(1, cached.hitCount());
+  }
+
+  @Test
+  void concurrentMissOnSameIdCollapsesToOneDelegateCall() throws InterruptedException {
+    /// Two virtual threads race a miss on the same id; the delegate is slow enough that the
+    /// second thread blocks inside `computeIfAbsent` waiting for the first. The §19 contract is
+    /// that `computeIfAbsent` collapses concurrent misses to a single delegate call — anything
+    /// else would amplify HTTP load to the registry under deserializer fan-in.
+    final var delegateCalls = new AtomicInteger();
+    final var inDelegate = new CountDownLatch(1);
+    final var releaseDelegate = new CountDownLatch(1);
+    final SchemaResolver slow = id -> {
+      delegateCalls.incrementAndGet();
+      inDelegate.countDown();
+      try {
+        releaseDelegate.await(5, TimeUnit.SECONDS);
+      } catch (final InterruptedException e) {
+        Thread.currentThread().interrupt();
+        throw new RuntimeException(e);
+      }
+      return "{\"type\":\"record\",\"name\":\"S" + id + "\",\"fields\":[]}";
+    };
+    final var cached = new CachedSchemaResolver(slow);
+    final var result1 = new AtomicReference<String>();
+    final var result2 = new AtomicReference<String>();
+    final var done = new CountDownLatch(2);
+
+    final var t1 = Thread.ofVirtual().start(() -> {
+      try {
+        result1.set(cached.lookupById(123));
+      } finally {
+        done.countDown();
+      }
+    });
+    /// Wait for t1 to be inside the delegate, then start t2 — guarantees t2 hits the
+    /// `computeIfAbsent` bucket while t1 still holds it.
+    assertTrue(inDelegate.await(5, TimeUnit.SECONDS), "first thread should enter delegate");
+    final var t2 = Thread.ofVirtual().start(() -> {
+      try {
+        result2.set(cached.lookupById(123));
+      } finally {
+        done.countDown();
+      }
+    });
+
+    releaseDelegate.countDown();
+    assertTrue(done.await(5, TimeUnit.SECONDS), "both threads should complete");
+    t1.join();
+    t2.join();
+
+    assertEquals(1, delegateCalls.get(), "concurrent misses on same id must collapse to one delegate call");
+    assertNotNull(result1.get());
+    assertEquals(result1.get(), result2.get(), "both threads must observe the same schema string");
+    assertEquals(1, cached.size());
+  }
+
+  @Test
+  void concurrentFailureOnSameIdDoesNotPoisonCache() throws InterruptedException {
+    /// N virtual threads concurrently race a miss on the same id where the delegate throws.
+    /// After all failures settle the delegate is flipped to success and one more call is made.
+    /// If a regression ever wrote a sentinel into the map BEFORE the delegate exception unwound
+    /// (e.g. a future "negative-cache" optimization), the recovery call would either throw or
+    /// skip the delegate. The success on the recovery call proves the cache stayed clean
+    /// through the failure storm.
+    final var threads = 16;
+    final var delegateCalls = new AtomicInteger();
+    final var shouldFail = new AtomicReference<>(Boolean.TRUE);
+    final SchemaResolver flaky = id -> {
+      delegateCalls.incrementAndGet();
+      if (shouldFail.get()) {
+        throw new RuntimeException("storm failure for id=" + id);
+      }
+      return "{\"type\":\"record\",\"name\":\"S" + id + "\",\"fields\":[]}";
+    };
+    final var cached = new CachedSchemaResolver(flaky);
+    final var start = new CountDownLatch(1);
+    final var done = new CountDownLatch(threads);
+    final var failuresObserved = new AtomicInteger();
+
+    for (int i = 0; i < threads; i++) {
+      Thread.ofVirtual().start(() -> {
+        try {
+          start.await();
+          try {
+            cached.lookupById(7);
+          } catch (final RuntimeException expected) {
+            failuresObserved.incrementAndGet();
+          }
+        } catch (final InterruptedException e) {
+          Thread.currentThread().interrupt();
+        } finally {
+          done.countDown();
+        }
+      });
+    }
+
+    start.countDown();
+    assertTrue(done.await(10, TimeUnit.SECONDS), "all racing threads should complete");
+
+    assertEquals(threads, failuresObserved.get(), "every racing thread must observe the failure (no silent sentinel)");
+    assertEquals(0, cached.size(), "failure storm must not have written any sentinel into the cache");
+
+    shouldFail.set(Boolean.FALSE);
+    final var recovered = cached.lookupById(7);
+
+    assertEquals("{\"type\":\"record\",\"name\":\"S7\",\"fields\":[]}", recovered);
+    assertEquals(1, cached.size(), "successful recovery must populate the cache normally");
+    /// One more lookup proves the success is now cached — no further delegate call.
+    final var callsAfterRecovery = delegateCalls.get();
+    cached.lookupById(7);
+    assertEquals(callsAfterRecovery, delegateCalls.get(), "post-recovery lookups must hit the cache");
   }
 
   @Test


### PR DESCRIPTION
## Summary

Closes the criticality-8 coverage gap in `CachedSchemaResolver` flagged
by the prior coverage audit: the failure-propagation path under
contention. The §19 "cache forever in-process" invariant in
`CLAUDE.md` only holds for **successful** lookups — a failed delegate
call must NOT poison the cache with a sentinel, or a transient SR
outage would pin a topic into a permanent decode-error state.

No production change. The current implementation relies on the
`ConcurrentHashMap.computeIfAbsent` contract (mapping-function throws →
no entry stored, exception propagates) and these tests now lock that in.

## Tests

- **`failedLookupIsNotCachedAndIsRetriedOnNextCall`** — delegate throws
  on the first call, succeeds on the second. Asserts the exception
  propagates verbatim, `cache.size()` stays 0 after the failure, and the
  retry actually re-invokes the delegate (proving no sentinel). Catches:
  a regression where `computeIfAbsent` was wrapped in a try/catch that
  silently stored an empty-string sentinel — the second call would
  either also throw or return `""` without hitting the delegate.

- **`concurrentMissOnSameIdCollapsesToOneDelegateCall`** — two virtual
  threads race a miss on the same id; the first is parked inside the
  delegate via a `CountDownLatch` so the second is guaranteed to enter
  `computeIfAbsent` while the bucket is held. Asserts exactly one
  delegate call and both threads see the same schema string. Catches: a
  regression to a check-then-act `get` / `put` shape that would let both
  threads issue the HTTP call.

- **`concurrentFailureOnSameIdDoesNotPoisonCache`** — 16 virtual threads
  race a failing delegate, then one recovery call with a successful
  delegate. Asserts every racing thread observes the failure, `size()`
  is 0 through the storm, the recovery call succeeds and now caches.
  Catches: a regression that races a cache-write before the delegate
  throw clears state (e.g. a misplaced `cache.put(id, ...)` outside the
  `computeIfAbsent` mapping function).

## §19 wire-up

Per the §19 invariants in `.claude/CLAUDE.md`:

> `computeIfAbsent` atomicizes load+store so concurrent misses on the same ID collapse to one HTTP call.

Test #2 is the direct executable proof of that line. Tests #1 and #3
are the implicit corollary: the "cache forever" claim is conditional on
"...after a successful resolve" — anything else (failure storms, partial
state) must leave the cache empty.

## Test plan

- [x] `./gradlew :lib:kpipe-schema-registry-confluent:test` — 11 tests pass (8 prior + 3 new), 0 failures.
- [x] All three new tests use virtual threads via `Thread.ofVirtual()` + `CountDownLatch` per project test doctrine.
- [x] No production change; the existing `CachedSchemaResolver` already satisfies the contract.