### PR TITLE
chore(format-json): tighten JsonFormat no-arg ctor to private

### DIFF
--- a/lib/kpipe-format-json/src/main/java/io/github/eschizoid/kpipe/format/json/JsonFormat.java
+++ b/lib/kpipe-format-json/src/main/java/io/github/eschizoid/kpipe/format/json/JsonFormat.java
@@ -30,9 +30,9 @@ public final class JsonFormat implements MessageFormat<Map<String, Object>> {
     JSONFactory.getDefaultObjectReaderProvider().setAutoTypeBeforeHandler(null);
   }
 
-  /// Constructs a new JsonFormat instance.
-  public JsonFormat() {
-    // Default constructor
+  /// Private constructor — use [JsonFormat#INSTANCE] to obtain the shared singleton.
+  private JsonFormat() {
+    // Singleton — JsonFormat is stateless; construction is reserved for the INSTANCE field.
   }
 
   /// Creates a new [JsonConsoleSink] for `Map<String, Object>` payloads.


### PR DESCRIPTION
## Summary

`JsonFormat` is a stateless singleton exposed via `JsonFormat.INSTANCE`. Its public no-arg constructor was only ever called by the `INSTANCE` static-field initializer at line 24 — nothing user-facing constructs it. `AvroFormat` and `ProtobufFormat` both take constructor args, so `JsonFormat` was the odd one out exposing a public default ctor that was never meant to be called directly.

Tighten the modifier to `private` and update the Javadoc to point users at `JsonFormat.INSTANCE`.

This is a public-surface narrowing with zero callers — no migration needed (no-deprecation policy: delete + migrate in same PR, no `@Deprecated`).

## Caller verification

```
$ grep -rn "new JsonFormat()" lib/ examples/ benchmarks/ --include="*.java" --include="*.kt"
lib/kpipe-format-json/src/main/java/io/github/eschizoid/kpipe/format/json/JsonFormat.java:24:  public static final JsonFormat INSTANCE = new JsonFormat();
```

Only the `INSTANCE` field — no tests, examples, or benchmarks construct `JsonFormat` directly. The Java access-modifier check at compile time is the safety net: any external `new JsonFormat()` would fail compile after this change.

## Test plan

- [x] `./gradlew :lib:kpipe-format-json:test :lib:kpipe-format-json:compileTestJava` → BUILD SUCCESSFUL
- [x] No callers of `new JsonFormat()` outside the `INSTANCE` field