### PR TITLE
chore(format-avro): delete dead AvroFormat.isRegistryBacked()

### DIFF
--- a/lib/kpipe-format-avro/src/main/java/io/github/eschizoid/kpipe/format/avro/AvroFormat.java
+++ b/lib/kpipe-format-avro/src/main/java/io/github/eschizoid/kpipe/format/avro/AvroFormat.java
@@ -93,13 +93,6 @@ public final class AvroFormat implements MessageFormat<GenericRecord> {
     return new AvroFormat(resolver);
   }
 
-  /// Returns true if this format reads the Confluent wire envelope per record.
-  ///
-  /// @return true in Schema-Registry mode, false in static mode
-  public boolean isRegistryBacked() {
-    return resolver != null;
-  }
-
   /// Returns the schema this codec is bound to in static mode.
   ///
   /// @return the bound schema in static mode; null in Schema-Registry mode

--- a/lib/kpipe-format-avro/src/test/java/io/github/eschizoid/kpipe/format/avro/AvroFormatRegistryTest.java
+++ b/lib/kpipe-format-avro/src/test/java/io/github/eschizoid/kpipe/format/avro/AvroFormatRegistryTest.java
@@ -1,7 +1,6 @@
 package io.github.eschizoid.kpipe.format.avro;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -170,14 +169,6 @@ class AvroFormatRegistryTest {
   @Test
   void registryBackedSchemaIsNull() {
     assertNull(AvroFormat.withRegistry(new FakeResolver()).schema());
-  }
-
-  @Test
-  void isRegistryBackedReflectsMode() {
-    final var staticFormat = AvroFormat.of(USER_V1);
-    final var registryFormat = AvroFormat.withRegistry(new FakeResolver());
-    assertFalse(staticFormat.isRegistryBacked());
-    assertTrue(registryFormat.isRegistryBacked());
   }
 
   @Test


### PR DESCRIPTION
## Summary

`AvroFormat.isRegistryBacked()` is dead production code. Flagged by the wider deletion-test audit as **test-load-only** — the only caller was a single unit test (`isRegistryBackedReflectsMode`) that existed solely to assert the method's return value. No production code, no examples, no benchmarks reference it.

Per the no-deprecation policy: delete the method and migrate (in this case, delete) all callers in the same PR. No `@Deprecated`, no Javadoc tombstone — just gone.

## Pre-verification grep (zero non-deletion-set callers)

```
$ grep -rn "isRegistryBacked" lib/ examples/ benchmarks/ --include="*.java" --include="*.kt"
lib/kpipe-format-avro/src/test/java/io/github/eschizoid/kpipe/format/avro/AvroFormatRegistryTest.java:176:  void isRegistryBackedReflectsMode() {
lib/kpipe-format-avro/src/test/java/io/github/eschizoid/kpipe/format/avro/AvroFormatRegistryTest.java:179:    assertFalse(staticFormat.isRegistryBacked());
lib/kpipe-format-avro/src/test/java/io/github/eschizoid/kpipe/format/avro/AvroFormatRegistryTest.java:180:    assertTrue(registryFormat.isRegistryBacked());
lib/kpipe-format-avro/src/main/java/io/github/eschizoid/kpipe/format/avro/AvroFormat.java:99:  public boolean isRegistryBacked() {
```

All four hits live in the deletion set (the method itself + the one test method that exercises it). Post-deletion grep returns zero matches.

## What's deleted

- `AvroFormat.isRegistryBacked()` — the accessor returning whether the format was constructed via `withRegistry(...)`.
- `AvroFormatRegistryTest.isRegistryBackedReflectsMode` — the lone caller, asserting the method's return value.
- The now-unused `assertFalse` static import in the test file.

## What still enforces the mode invariants

The static-vs-registry mode distinction stays guarded by the existing throw-on-misuse behavior:

- `AvroFormat.consoleSink()` throws when registry-backed (unchanged)
- `AvroFormat.serialize()` throws when registry-backed (unchanged)

Users who need to branch on mode at runtime had no legitimate reason to — the format itself rejects the wrong-mode operations. The accessor only existed to make the test runnable.

## Test plan

- [x] `./gradlew :lib:kpipe-format-avro:test` → BUILD SUCCESSFUL
- [x] Post-deletion grep returns zero matches across `lib/`, `examples/`, `benchmarks/`