### PR TITLE
chore(schema-registry): delete unused CachedSchemaResolver.invalidateAll()

### DIFF
--- a/lib/kpipe-schema-registry-confluent/src/main/java/io/github/eschizoid/kpipe/schemaregistry/confluent/CachedSchemaResolver.java
+++ b/lib/kpipe-schema-registry-confluent/src/main/java/io/github/eschizoid/kpipe/schemaregistry/confluent/CachedSchemaResolver.java
@@ -81,13 +81,6 @@ public final class CachedSchemaResolver implements SchemaResolver, AutoCloseable
     return cache.size();
   }
 
-  /// Drops every cached entry. Provided for disaster-recovery scenarios (SR migration where
-  /// previously-stable IDs map to different schemas). Not part of normal operation — schema IDs
-  /// are immutable in routine SR use.
-  public void invalidateAll() {
-    cache.clear();
-  }
-
   @Override
   public void close() {
     if (delegate instanceof AutoCloseable closeable) {

--- a/lib/kpipe-schema-registry-confluent/src/test/java/io/github/eschizoid/kpipe/schemaregistry/confluent/CachedSchemaResolverTest.java
+++ b/lib/kpipe-schema-registry-confluent/src/test/java/io/github/eschizoid/kpipe/schemaregistry/confluent/CachedSchemaResolverTest.java
@@ -105,21 +105,6 @@ class CachedSchemaResolverTest {
   }
 
   @Test
-  void invalidateAllDropsEverything() {
-    final var counter = new CountingResolver();
-    final var cached = new CachedSchemaResolver(counter);
-    cached.lookupById(1);
-    cached.lookupById(2);
-    assertEquals(2, cached.size());
-
-    cached.invalidateAll();
-
-    assertEquals(0, cached.size());
-    cached.lookupById(1);
-    assertEquals(3, counter.calls.get(), "invalidateAll forces a re-fetch");
-  }
-
-  @Test
   void rejectsNullDelegate() {
     assertThrows(NullPointerException.class, () -> new CachedSchemaResolver(null));
   }


### PR DESCRIPTION
## Summary

Hard-deletes the public `CachedSchemaResolver.invalidateAll()` method and its single unit test.

## Public API removal

This is a **public API removal**. Per this repo's no-deprecation policy (delete + migrate in the same PR, never `@Deprecated`), the method is gone in one shot — no deprecation cycle, no `@deprecated` Javadoc, no `since = "..."`. The rationale for the policy: deprecation cycles bloat the surface, train users to ignore warnings, and rot in place when the promised "removal in next major" never happens.

## Reasoning: the cache's own design makes `invalidateAll()` moot

`CachedSchemaResolver` is intentionally a no-TTL, no-LRU, unbounded by-ID cache. That design is correct **only because Confluent SR schema IDs are immutable by contract** — once ID 42 maps to a given schema, that mapping never changes. `computeIfAbsent` atomicizes load+store, concurrent misses on the same ID collapse to one HTTP call, and the cache lives for the JVM lifetime.

`invalidateAll()` existed as a disaster-recovery surface for a hypothetical SR migration where previously-stable IDs map to different schemas. But that scenario directly contradicts the cache's own correctness premise — if IDs are mutable, the whole "cache forever by ID" design is wrong, not just stale. There is no realistic path where a user both:

- keeps the same JVM running, AND
- legitimately needs to flip every cache entry mid-flight.

## Migration story for external users

If you somehow land in the pathological "SR IDs got reassigned" state: **restart the consumer**. The in-process cache is dropped wholesale on JVM restart. That's the correct recovery anyway — anything else assumes the cache's immutable-ID invariant holds while simultaneously claiming it doesn't.

## Pre-verification

```
$ grep -rn "invalidateAll" lib/ examples/ benchmarks/ --include="*.java" --include="*.kt"
lib/kpipe-schema-registry-confluent/src/test/java/.../CachedSchemaResolverTest.java:108:  void invalidateAllDropsEverything() {
lib/kpipe-schema-registry-confluent/src/test/java/.../CachedSchemaResolverTest.java:115:    cached.invalidateAll();
lib/kpipe-schema-registry-confluent/src/test/java/.../CachedSchemaResolverTest.java:119:    assertEquals(3, counter.calls.get(), "invalidateAll forces a re-fetch");
lib/kpipe-schema-registry-confluent/src/main/java/.../CachedSchemaResolver.java:87:  public void invalidateAll() {
```

Zero in-tree callers — only the definition and its one test. No migration code needed.

Post-edit grep is empty.

## Test plan

- [x] `./gradlew :lib:kpipe-schema-registry-confluent:test` → BUILD SUCCESSFUL
- [x] post-edit `grep -rn "invalidateAll" lib/ examples/ benchmarks/` returns no matches