### PR TITLE
fix(api): MultiBuilder rejects silently-dropped per-route consumer-wide settings

### DIFF
--- a/lib/kpipe-api/src/main/java/io/github/eschizoid/kpipe/MultiBuilder.java
+++ b/lib/kpipe-api/src/main/java/io/github/eschizoid/kpipe/MultiBuilder.java
@@ -242,13 +242,14 @@ public final class MultiBuilder {
     return DefaultHandle.startAndWrap(consumerBuilder.build());
   }
 
-  /// Processing mode and the KEY_ORDERED LRU cap are consumer-wide settings — one
-  /// [KPipeConsumer] runs in exactly one mode with one cap. If a route configurator sets a
-  /// non-default value (`s -> s.withProcessingMode(...)` or
-  /// `s -> s.withKeyOrderedMaxKeys(...)`), the per-route setting would be silently dropped
-  /// because [#start()] builds a single consumer. Detect that here and fail loudly so the
-  /// user moves the call up to `MultiBuilder.withProcessingMode(...)` /
-  /// `MultiBuilder.withKeyOrderedMaxKeys(...)`.
+  /// Consumer-wide settings live on one [KPipeConsumer] (one consumer-group, one offset
+  /// manager, one poll loop), so a per-route configurator can only ever set them for itself —
+  /// [#start()] then drops them on the floor when it folds N routes into a single consumer.
+  /// Detect every such case here and fail loud so the misconfig surfaces at construction time
+  /// instead of as a silent missing-retry / missing-DLQ at runtime.
+  ///
+  /// Routes are expected to be terminal sinks built via `toCustom(...)` / `toBatch(...)` /
+  /// `toConsole()` etc.; unknown sink shapes are passed through (no false-positives).
   private static void rejectPerRouteConsumerWideSettings(final String topic, final Sink<?> sink) {
     final DefaultStream<?> stream;
     if (sink instanceof DefaultSink<?> ds) stream = ds.stream();
@@ -267,6 +268,48 @@ public final class MultiBuilder {
           stream.keyOrderedMaxKeys()
         ) +
         "Move the call to MultiBuilder.withKeyOrderedMaxKeys(...) instead."
+    );
+    if (stream.consumerMetrics() != null) throw new IllegalArgumentException(
+      perRouteRejection(topic, "withMetrics", "MultiBuilder.withMetrics(...)")
+    );
+    if (stream.tracer() != null) throw new IllegalArgumentException(
+      perRouteRejection(topic, "withTracer", "MultiBuilder.withTracer(...)")
+    );
+    if (stream.circuitBreaker() != null) throw new IllegalArgumentException(
+      perRouteRejection(topic, "withCircuitBreaker", "MultiBuilder.withCircuitBreaker(...)")
+    );
+    if (stream.maxRetries() > 0) throw new IllegalArgumentException(perRouteRejectionDeferred(topic, "withRetry"));
+    if (stream.backpressureHigh() != null) throw new IllegalArgumentException(
+      perRouteRejectionDeferred(topic, "withBackpressure")
+    );
+    if (stream.deadLetterTopic() != null) throw new IllegalArgumentException(
+      perRouteRejectionDeferred(topic, "withDeadLetterTopic")
+    );
+    if (stream.errorHandler() != null) throw new IllegalArgumentException(
+      perRouteRejectionDeferred(topic, "withErrorHandler")
+    );
+    if (stream.pollTimeout() != null) throw new IllegalArgumentException(
+      perRouteRejectionDeferred(topic, "withPollTimeout")
+    );
+  }
+
+  /// Builds the rejection message for a per-route setting that already has a symmetric
+  /// `MultiBuilder.with*` setter — point the user at it.
+  private static String perRouteRejection(final String topic, final String setting, final String mirror) {
+    return (
+      "Route '%s' sets %s on its Stream, but %s is a consumer-wide setting; ".formatted(topic, setting, setting) +
+      "set it on %s instead.".formatted(mirror)
+    );
+  }
+
+  /// Builds the rejection message for a per-route setting that does NOT yet have a symmetric
+  /// `MultiBuilder.with*` mirror. Point the user at the explicit `KPipeConsumer.Builder` escape
+  /// hatch and note the open follow-up.
+  private static String perRouteRejectionDeferred(final String topic, final String setting) {
+    return (
+      "Route '%s' sets %s on its Stream, but %s is a consumer-wide setting; ".formatted(topic, setting, setting) +
+      "configure via the explicit KPipeConsumer.Builder for the homogeneous case, " +
+      "or wait for the multi-builder mirror (open issue)."
     );
   }
 

--- a/lib/kpipe-api/src/main/java/io/github/eschizoid/kpipe/MultiBuilder.java
+++ b/lib/kpipe-api/src/main/java/io/github/eschizoid/kpipe/MultiBuilder.java
@@ -255,14 +255,14 @@ public final class MultiBuilder {
     if (sink instanceof DefaultSink<?> ds) stream = ds.stream();
     else if (sink instanceof DefaultBatchSink<?> dbs) stream = dbs.stream();
     else return;
-    if (stream.processingMode() != ProcessingMode.PARALLEL) throw new IllegalStateException(
+    if (stream.processingMode() != ProcessingMode.PARALLEL) throw new IllegalArgumentException(
       "Route '%s' sets withProcessingMode(%s) on its Stream, but processing mode is a consumer-wide setting. ".formatted(
           topic,
           stream.processingMode()
         ) +
         "Move the call to MultiBuilder.withProcessingMode(...) instead."
     );
-    if (stream.keyOrderedMaxKeys() != ProcessingMode.DEFAULT_KEY_ORDERED_MAX_KEYS) throw new IllegalStateException(
+    if (stream.keyOrderedMaxKeys() != ProcessingMode.DEFAULT_KEY_ORDERED_MAX_KEYS) throw new IllegalArgumentException(
       "Route '%s' sets withKeyOrderedMaxKeys(%d) on its Stream, but the LRU cap is a consumer-wide setting. ".formatted(
           topic,
           stream.keyOrderedMaxKeys()

--- a/lib/kpipe-api/src/test/java/io/github/eschizoid/kpipe/KPipeFacadeBuildTest.java
+++ b/lib/kpipe-api/src/test/java/io/github/eschizoid/kpipe/KPipeFacadeBuildTest.java
@@ -2,8 +2,12 @@ package io.github.eschizoid.kpipe;
 
 import static org.junit.jupiter.api.Assertions.*;
 
+import io.github.eschizoid.kpipe.consumer.CircuitBreakerController;
 import io.github.eschizoid.kpipe.consumer.ProcessingMode;
 import io.github.eschizoid.kpipe.format.json.JsonFormat;
+import io.github.eschizoid.kpipe.metrics.ConsumerMetrics;
+import io.github.eschizoid.kpipe.producer.tracing.Tracer;
+import java.time.Duration;
 import java.util.Map;
 import java.util.Properties;
 import java.util.concurrent.atomic.AtomicReference;
@@ -151,6 +155,129 @@ class KPipeFacadeBuildTest {
       KPipe.multi(props())
         .withProcessingMode(ProcessingMode.KEY_ORDERED)
         .withKeyOrderedMaxKeys(5_000)
+        .json("topic-a", s -> s.toCustom(_ -> {}))
+        .json("topic-b", s -> s.toCustom(_ -> {}))
+    );
+  }
+
+  // --- per-route consumer-wide-setting rejection ---
+  // Every public consumer-wide setting reachable from the per-route Stream is silently dropped
+  // by the original MultiBuilder.start() — it only invokes ds.buildPipeline() / addBatchRoute()
+  // and never replays the route's consumer-level config onto the underlying single
+  // KPipeConsumer.Builder. The tests below pin each setting to fail loud rather than disappear.
+
+  @Test
+  void multiBuilderRejectsPerRouteWithRetry() {
+    final var multi = KPipe.multi(props()).json("topic-a", s ->
+      s.withRetry(3, Duration.ofSeconds(1)).toCustom(_ -> {})
+    );
+    final var ex = assertThrows(IllegalArgumentException.class, multi::start);
+    assertTrue(ex.getMessage().contains("withRetry"), () -> "message should name withRetry: " + ex.getMessage());
+    assertTrue(
+      ex.getMessage().contains("'topic-a'"),
+      () -> "message should name the offending route: " + ex.getMessage()
+    );
+    assertTrue(
+      ex.getMessage().contains("KPipeConsumer.Builder"),
+      () -> "message should point users at the explicit-builder escape hatch: " + ex.getMessage()
+    );
+  }
+
+  @Test
+  void multiBuilderRejectsPerRouteWithBackpressure() {
+    final var multi = KPipe.multi(props()).json("topic-a", s -> s.withBackpressure(5_000, 1_000).toCustom(_ -> {}));
+    final var ex = assertThrows(IllegalArgumentException.class, multi::start);
+    assertTrue(
+      ex.getMessage().contains("withBackpressure"),
+      () -> "message should name withBackpressure: " + ex.getMessage()
+    );
+    assertTrue(ex.getMessage().contains("'topic-a'"), () -> "message should name the route: " + ex.getMessage());
+  }
+
+  @Test
+  void multiBuilderRejectsPerRouteWithDeadLetterTopic() {
+    final var multi = KPipe.multi(props()).json("topic-a", s -> s.withDeadLetterTopic("dlq").toCustom(_ -> {}));
+    final var ex = assertThrows(IllegalArgumentException.class, multi::start);
+    assertTrue(
+      ex.getMessage().contains("withDeadLetterTopic"),
+      () -> "message should name withDeadLetterTopic: " + ex.getMessage()
+    );
+    assertTrue(ex.getMessage().contains("'topic-a'"), () -> "message should name the route: " + ex.getMessage());
+  }
+
+  @Test
+  void multiBuilderRejectsPerRouteWithErrorHandler() {
+    final var multi = KPipe.multi(props()).json("topic-a", s -> s.withErrorHandler(_ -> {}).toCustom(_ -> {}));
+    final var ex = assertThrows(IllegalArgumentException.class, multi::start);
+    assertTrue(
+      ex.getMessage().contains("withErrorHandler"),
+      () -> "message should name withErrorHandler: " + ex.getMessage()
+    );
+    assertTrue(ex.getMessage().contains("'topic-a'"), () -> "message should name the route: " + ex.getMessage());
+  }
+
+  @Test
+  void multiBuilderRejectsPerRouteWithPollTimeout() {
+    final var multi = KPipe.multi(props()).json("topic-a", s ->
+      s.withPollTimeout(Duration.ofMillis(250)).toCustom(_ -> {})
+    );
+    final var ex = assertThrows(IllegalArgumentException.class, multi::start);
+    assertTrue(
+      ex.getMessage().contains("withPollTimeout"),
+      () -> "message should name withPollTimeout: " + ex.getMessage()
+    );
+    assertTrue(ex.getMessage().contains("'topic-a'"), () -> "message should name the route: " + ex.getMessage());
+  }
+
+  @Test
+  void multiBuilderRejectsPerRouteWithMetrics() {
+    final var multi = KPipe.multi(props()).json("topic-a", s -> s.withMetrics(ConsumerMetrics.noop()).toCustom(_ -> {}));
+    final var ex = assertThrows(IllegalArgumentException.class, multi::start);
+    assertTrue(ex.getMessage().contains("withMetrics"), () -> "message should name withMetrics: " + ex.getMessage());
+    assertTrue(
+      ex.getMessage().contains("MultiBuilder.withMetrics"),
+      () -> "message should point users at the consumer-level setter: " + ex.getMessage()
+    );
+    assertTrue(ex.getMessage().contains("'topic-a'"), () -> "message should name the route: " + ex.getMessage());
+  }
+
+  @Test
+  void multiBuilderRejectsPerRouteWithTracer() {
+    final var multi = KPipe.multi(props()).json("topic-a", s -> s.withTracer(Tracer.noop()).toCustom(_ -> {}));
+    final var ex = assertThrows(IllegalArgumentException.class, multi::start);
+    assertTrue(ex.getMessage().contains("withTracer"), () -> "message should name withTracer: " + ex.getMessage());
+    assertTrue(
+      ex.getMessage().contains("MultiBuilder.withTracer"),
+      () -> "message should point users at the consumer-level setter: " + ex.getMessage()
+    );
+    assertTrue(ex.getMessage().contains("'topic-a'"), () -> "message should name the route: " + ex.getMessage());
+  }
+
+  @Test
+  void multiBuilderRejectsPerRouteWithCircuitBreaker() {
+    final var breaker = new CircuitBreakerController(0.5, 100, Duration.ofSeconds(1));
+    final var multi = KPipe.multi(props()).json("topic-a", s -> s.withCircuitBreaker(breaker).toCustom(_ -> {}));
+    final var ex = assertThrows(IllegalArgumentException.class, multi::start);
+    assertTrue(
+      ex.getMessage().contains("withCircuitBreaker"),
+      () -> "message should name withCircuitBreaker: " + ex.getMessage()
+    );
+    assertTrue(
+      ex.getMessage().contains("MultiBuilder.withCircuitBreaker"),
+      () -> "message should point users at the consumer-level setter: " + ex.getMessage()
+    );
+    assertTrue(ex.getMessage().contains("'topic-a'"), () -> "message should name the route: " + ex.getMessage());
+  }
+
+  @Test
+  void multiBuilderAcceptsConsumerWideMetricsTracerAndCircuitBreaker() {
+    // Smoke: the consumer-wide MultiBuilder setters still work and don't trip the per-route guard.
+    final var breaker = new CircuitBreakerController(0.5, 100, Duration.ofSeconds(1));
+    assertDoesNotThrow(() ->
+      KPipe.multi(props())
+        .withMetrics(ConsumerMetrics.noop())
+        .withTracer(Tracer.noop())
+        .withCircuitBreaker(breaker)
         .json("topic-a", s -> s.toCustom(_ -> {}))
         .json("topic-b", s -> s.toCustom(_ -> {}))
     );

--- a/lib/kpipe-api/src/test/java/io/github/eschizoid/kpipe/KPipeFacadeBuildTest.java
+++ b/lib/kpipe-api/src/test/java/io/github/eschizoid/kpipe/KPipeFacadeBuildTest.java
@@ -122,7 +122,7 @@ class KPipeFacadeBuildTest {
     final var multi = KPipe.multi(props()).json("topic-a", s ->
       s.withProcessingMode(ProcessingMode.KEY_ORDERED).toCustom(_ -> {})
     );
-    final var ex = assertThrows(IllegalStateException.class, multi::start);
+    final var ex = assertThrows(IllegalArgumentException.class, multi::start);
     assertTrue(
       ex.getMessage().contains("KEY_ORDERED"),
       () -> "message should name the offending mode: " + ex.getMessage()
@@ -138,7 +138,7 @@ class KPipeFacadeBuildTest {
     // Same footgun as withProcessingMode — withKeyOrderedMaxKeys on a route would be silently
     // dropped because the LRU cap is a consumer-wide setting. Fail loud at start().
     final var multi = KPipe.multi(props()).json("topic-a", s -> s.withKeyOrderedMaxKeys(50_000).toCustom(_ -> {}));
-    final var ex = assertThrows(IllegalStateException.class, multi::start);
+    final var ex = assertThrows(IllegalArgumentException.class, multi::start);
     assertTrue(ex.getMessage().contains("50000"), () -> "message should name the offending value: " + ex.getMessage());
     assertTrue(
       ex.getMessage().contains("MultiBuilder.withKeyOrderedMaxKeys"),


### PR DESCRIPTION
## Summary

`MultiBuilder.start()` was a §12 silent-failure: per-route consumer-wide
settings like `withRetry`, `withDeadLetterTopic`, `withErrorHandler`,
`withPollTimeout`, `withMetrics`, `withTracer`, `withCircuitBreaker`,
and `withBackpressure` were quietly dropped when a route configurator
set them. The previous `rejectPerRouteConsumerWideSettings` guard only
caught `withProcessingMode` + `withKeyOrderedMaxKeys`; everything else
fell on the floor.

### The bug

`MultiBuilder.start()` only invokes `ds.buildPipeline()` /
`addBatchRoute(...)` for each route. `DefaultStream.applyCommonConsumerConfig`
(which propagates retry / backpressure / metrics / errorHandler /
dlqTopic / pollTimeout / tracer onto the underlying `KPipeConsumer.Builder`)
is **never called** from the multi path. Every per-route consumer-wide
setting other than the two already guarded was silently lost.

### Reproduction (before this PR)

```java
KPipe.multi(props)
  .json("t", s -> s.withRetry(3, Duration.ofSeconds(1)).withDeadLetterTopic("dlq"))
  .start();
```

…built a consumer with **neither retry NOR DLQ** wired, and emitted no
error. The misconfig surfaced only as missing behavior at runtime —
exactly the overloaded-null / silent-drop footgun §12 exists to prevent.

### Fix

Extend `MultiBuilder.rejectPerRouteConsumerWideSettings` to throw
`IllegalArgumentException` when a per-route configurator sets any
consumer-wide value. Two message shapes:

- **Has a symmetric `MultiBuilder.with*` mirror** (`withMetrics`,
  `withTracer`, `withCircuitBreaker`): error points users at the
  consumer-level setter.
- **No mirror yet** (`withRetry`, `withBackpressure`,
  `withDeadLetterTopic`, `withErrorHandler`, `withPollTimeout`):
  error points users at the explicit `KPipeConsumer.Builder`
  escape hatch and notes the deferred multi-builder mirror follow-up.

### Deferred follow-up

Adding consumer-wide mirrors on `MultiBuilder` for `withRetry` /
`withDeadLetterTopic` / `withErrorHandler` / `withPollTimeout` /
`withBackpressure` is a separate change — they need design decisions
(e.g. should DLQ be a consumer-wide single topic or per-route routing?).
This PR's rejection message documents the gap so users hit a loud error
with a workable next step, instead of a silently-broken consumer.

## Test plan

- [x] One test per rejected setting: `withRetry`, `withBackpressure`,
  `withDeadLetterTopic`, `withErrorHandler`, `withPollTimeout`,
  `withMetrics`, `withTracer`, `withCircuitBreaker`. Each asserts the
  thrown `IllegalArgumentException` names the offending setter and the
  offending route topic, and (for mirrored settings) the message points
  at the consumer-level `MultiBuilder.with*` setter.
- [x] Smoke test that the consumer-wide `MultiBuilder` setters
  (`withMetrics`, `withTracer`, `withCircuitBreaker`) still build
  cleanly together with the existing `withProcessingMode` /
  `withKeyOrderedMaxKeys` chain.
- [x] `./gradlew :lib:kpipe-api:test` — all 21 cases in
  `KPipeFacadeBuildTest` pass; full module suite green.