### PR TITLE
docs: fix package-info example, add Tracing capability row, drop stale processToSink refs

### DIFF
--- a/lib/kpipe-api/src/main/java/io/github/eschizoid/kpipe/package-info.java
+++ b/lib/kpipe-api/src/main/java/io/github/eschizoid/kpipe/package-info.java
@@ -7,9 +7,9 @@
 ///
 /// Typical usage:
 /// ```java
-/// KPipe.stream("topic", JsonFormat.of())
-///      .process(...)
-///      .to(Sink.console())
+/// KPipe.json("orders", kafkaProps)
+///      .pipe(enrich)
+///      .toConsole()
 ///      .start();
 /// ```
 package io.github.eschizoid.kpipe;

--- a/lib/kpipe-api/src/test/java/io/github/eschizoid/kpipe/StreamResultObserversTest.java
+++ b/lib/kpipe-api/src/test/java/io/github/eschizoid/kpipe/StreamResultObserversTest.java
@@ -28,8 +28,7 @@ class StreamResultObserversTest {
 
   /// Drive a pipeline from raw bytes the way `KPipeConsumer` would: deserialize,
   /// `switch (process(...))`, invoke the sink on `Passed`, no-op on `Filtered`,
-  /// re-throw the cause on `Failed`. Mirrors what the old `MessagePipeline.processToSink`
-  /// did before the byte-level entry points were removed.
+  /// re-throw the cause on `Failed`.
   private static <T> void drive(final MessagePipeline<T> pipeline, final byte[] data) {
     final var value = pipeline.deserializeOrFail(data);
     switch (pipeline.process(value)) {

--- a/lib/kpipe-consumer/src/main/java/io/github/eschizoid/kpipe/consumer/KPipeConsumer.java
+++ b/lib/kpipe-consumer/src/main/java/io/github/eschizoid/kpipe/consumer/KPipeConsumer.java
@@ -1252,7 +1252,8 @@ public class KPipeConsumer<K> implements AutoCloseable {
   /// * `messagesReceived` — records received from Kafka
   /// * `messagesProcessed` — records successfully processed
   /// * `processingErrors` — records that failed processing after all retries
-  /// * `processingDurationTotalMs` — total wall-clock time spent inside `processToSink`
+  /// * `processingDurationTotalMs` — total wall-clock time spent inside the pipeline
+  ///   (deserialize → operators → sink)
   /// * `retries` — retry attempts made for failed records
   /// * `backpressurePauseCount` / `backpressureTimeMs` — backpressure pause count and total ms held
   /// * `circuitBreakerTrips` / `circuitBreakerTimeOpenMs` — CB trip count and total ms in OPEN

--- a/lib/kpipe-consumer/src/test/java/io/github/eschizoid/kpipe/consumer/DispatcherIntegrationTest.java
+++ b/lib/kpipe-consumer/src/test/java/io/github/eschizoid/kpipe/consumer/DispatcherIntegrationTest.java
@@ -51,8 +51,8 @@ import org.junit.jupiter.params.provider.MethodSource;
 ///
 /// The dispatch path mocks the broker via [MockConsumer] but drives the genuine
 /// `KPipeConsumer.processRecords` → `Dispatcher.dispatch` → `processRecord` →
-/// `pipeline.processToSink` chain. The mode-specific assertions are what distinguish whether
-/// the corresponding dispatcher is correctly preserving the property the mode promises.
+/// `pipeline.process` → sink-invocation chain. The mode-specific assertions are what distinguish
+/// whether the corresponding dispatcher is correctly preserving the property the mode promises.
 class DispatcherIntegrationTest {
 
   private static final String TOPIC = "test-topic";


### PR DESCRIPTION
## Summary

Three documentation-drift fixes surfaced by an audit pass.

- **`kpipe-api/package-info.java`** — the worked example used `KPipe.stream("topic", JsonFormat.of())`, `.process(...)`, `.to(Sink.console())`. None of those exist. `JsonFormat` exposes `INSTANCE` (not `of()` — that is `AvroFormat`). Rewritten to the current `KPipe.json("orders", kafkaProps).pipe(enrich).toConsole().start();` shape, matching the rest of the docs.

- **Tracing capability row** in the local `.claude/CLAUDE.md` §17 table — `Stream.withTracer(Tracer)`, `MultiBuilder.withTracer(Tracer)`, and `KPipeConsumer.Builder.withTracer(Tracer)` are all user-facing but the table had no row. Added between "OTel/custom metrics" and "Custom error handler". Source modules: `kpipe-tracing-otel` for the OTel-backed `OtelTracer`, `kpipe-producer` for the `Tracer` SPI under `producer.tracing`. Notes column documents the W3C propagation behavior and the `Tracer.noop()` default. (`.claude/CLAUDE.md` is gitignored so this edit is not in the diff; it lives in the maintainer's local checkout.)

- **Stale `processToSink` references** — the legacy byte-level shim was removed long ago, but three references survived:
  - `KPipeConsumer.getMetrics()` Javadoc described `processingDurationTotalMs` as time spent inside `processToSink` → now reads "time spent inside the pipeline (deserialize → operators → sink)".
  - `DispatcherIntegrationTest` class Javadoc described the dispatch chain ending in `pipeline.processToSink` → now ends in `pipeline.process` + sink invocation.
  - `StreamResultObserversTest.drive` Javadoc compared its helper to "the old `MessagePipeline.processToSink`" → the comparison was historical context only; dropped.

  Post-edit: `grep -rn "processToSink" lib/ examples/ benchmarks/` returns zero hits.

## Test plan

- [x] `./gradlew :lib:kpipe-api:test` — green.
- [x] `./gradlew :lib:kpipe-consumer:test --tests "*DispatcherIntegrationTest*"` — green. (The full `:lib:kpipe-consumer:test` run has 2 unrelated Testcontainers init failures because Docker is unavailable on this machine — `ExternalOffsetIntegrationTest` and `KPipeProducerIntegrationTest`, both fail at `DockerClientProviderStrategy.java:274`; nothing here touches their code paths.)
- [x] `grep -rn "processToSink" lib/ examples/ benchmarks/ --include="*.java"` → 0 hits.