### PR TITLE
refactor(api): normalize KPipe.avro/protobuf arg order to (topic, props, format)

### DIFF
--- a/README.md
+++ b/README.md
@@ -787,7 +787,7 @@ try (final var resolver = new CachedSchemaResolver(
 }
 ```
 
-The factory above is equivalent to `KPipe.avro(AvroFormat.withRegistry(resolver), "orders", props)`. The format reads
+The factory above is equivalent to `KPipe.avro("orders", props, AvroFormat.withRegistry(resolver))`. The format reads
 the envelope per record. Do **not** combine `withSchemaRegistry(...)` with `skipBytes(5)` — the format already consumes
 the envelope. The static-mode path is still supported for shops with strict append-only evolution who fetch the schema
 once at startup:

--- a/examples/avro/src/main/java/io/github/eschizoid/kpipe/App.java
+++ b/examples/avro/src/main/java/io/github/eschizoid/kpipe/App.java
@@ -29,7 +29,7 @@ public final class App {
 
     final var props = KafkaConsumerConfig.createConsumerConfig(config.bootstrapServers(), config.consumerGroup());
 
-    try (final var handle = KPipe.avro(format, config.topic(), props).skipBytes(5).toConsole().start()) {
+    try (final var handle = KPipe.avro(config.topic(), props, format).skipBytes(5).toConsole().start()) {
       LOGGER.log(Level.INFO, "Avro consumer started for topic {0}", config.topic());
       handle.awaitShutdown();
     } catch (final Exception e) {

--- a/examples/avro/src/test/java/io/github/eschizoid/kpipe/AppIntegrationTest.java
+++ b/examples/avro/src/test/java/io/github/eschizoid/kpipe/AppIntegrationTest.java
@@ -62,7 +62,7 @@ class AppIntegrationTest {
     final var captured = new CopyOnWriteArrayList<GenericRecord>();
     final MessageSink<GenericRecord> capturingSink = captured::add;
 
-    try (final var handle = KPipe.avro(format, topic, consumerProps()).skipBytes(5).toCustom(capturingSink).start()) {
+    try (final var handle = KPipe.avro(topic, consumerProps(), format).skipBytes(5).toCustom(capturingSink).start()) {
       assertTrue(handle.isHealthy(), "Handle should be healthy after start()");
 
       produceUntilConsumed(topic, createConfluentWirePayload(), captured, Duration.ofSeconds(15));

--- a/examples/demo/src/main/java/io/github/eschizoid/kpipe/demo/DemoApp.java
+++ b/examples/demo/src/main/java/io/github/eschizoid/kpipe/demo/DemoApp.java
@@ -78,8 +78,8 @@ public class DemoApp implements AutoCloseable {
           .pipe(Operators.removeFields("password", "ssn"))
           .toCustom(new JsonConsoleSink<>())
       )
-      .avro(avroFormat, config.avroTopic(), s -> s.skipBytes(5).toConsole())
-      .protobuf(protoFormat, config.protoTopic(), s -> s.skipBytes(6).toConsole())
+      .avro(config.avroTopic(), avroFormat, s -> s.skipBytes(5).toConsole())
+      .protobuf(config.protoTopic(), protoFormat, s -> s.skipBytes(6).toConsole())
       .start();
   }
 

--- a/examples/protobuf/src/main/java/io/github/eschizoid/kpipe/App.java
+++ b/examples/protobuf/src/main/java/io/github/eschizoid/kpipe/App.java
@@ -24,7 +24,7 @@ public final class App {
 
     final var props = KafkaConsumerConfig.createConsumerConfig(config.bootstrapServers(), config.consumerGroup());
 
-    try (final var handle = KPipe.protobuf(format, config.topic(), props).toConsole().start()) {
+    try (final var handle = KPipe.protobuf(config.topic(), props, format).toConsole().start()) {
       LOGGER.log(Level.INFO, "Protobuf consumer started for topic {0}", config.topic());
       handle.awaitShutdown();
     } catch (final Exception e) {

--- a/examples/protobuf/src/test/java/io/github/eschizoid/kpipe/AppIntegrationTest.java
+++ b/examples/protobuf/src/test/java/io/github/eschizoid/kpipe/AppIntegrationTest.java
@@ -53,7 +53,7 @@ class AppIntegrationTest {
     final var descriptor = format.descriptor();
 
     try (
-      final var handle = KPipe.protobuf(format, topic, consumerProps())
+      final var handle = KPipe.protobuf(topic, consumerProps(), format)
         .pipe(msg ->
           msg.toBuilder().setField(msg.getDescriptorForType().findFieldByName("name"), "processed-by-kpipe").build()
         )

--- a/examples/schema-registry/src/test/java/io/github/eschizoid/kpipe/AppIntegrationTest.java
+++ b/examples/schema-registry/src/test/java/io/github/eschizoid/kpipe/AppIntegrationTest.java
@@ -94,7 +94,7 @@ class AppIntegrationTest {
     final MessageSink<GenericRecord> capturingSink = captured::add;
 
     try (
-      final var handle = KPipe.avro(format, topic, consumerProps())
+      final var handle = KPipe.avro(topic, consumerProps(), format)
         .withProcessingMode(ProcessingMode.SEQUENTIAL) // preserve send-order in captured list
         .skipBytes(5)
         .toCustom(capturingSink)

--- a/lib/kpipe-api/src/main/java/io/github/eschizoid/kpipe/KPipe.java
+++ b/lib/kpipe-api/src/main/java/io/github/eschizoid/kpipe/KPipe.java
@@ -60,25 +60,25 @@ public final class KPipe {
   /// `format` is used for both deserialization and the default `toConsole()` sink. Construct
   /// the format explicitly: `new AvroFormat(schema)` or `AvroFormat.of(schemaJson)`.
   ///
-  /// @param format the Avro codec (must be non-null)
   /// @param topic the Kafka topic to consume
   /// @param kafkaProps the Kafka consumer properties
+  /// @param format the Avro codec (must be non-null)
   /// @return a fluent [Stream] configured for Avro
-  public static Stream<GenericRecord> avro(final AvroFormat format, final String topic, final Properties kafkaProps) {
+  public static Stream<GenericRecord> avro(final String topic, final Properties kafkaProps, final AvroFormat format) {
     return new DefaultStream<>(topic, kafkaProps, format, format::consoleSink);
   }
 
   /// Avro-typed stream consuming from multiple homogeneous topics. See
-  /// [#avro(AvroFormat, String, Properties)].
+  /// [#avro(String, Properties, AvroFormat)].
   ///
-  /// @param format the Avro codec (must be non-null)
   /// @param topics the Kafka topics to consume (must be non-empty)
   /// @param kafkaProps the Kafka consumer properties
+  /// @param format the Avro codec (must be non-null)
   /// @return a fluent [Stream] configured for Avro
   public static Stream<GenericRecord> avro(
-    final AvroFormat format,
     final Collection<String> topics,
-    final Properties kafkaProps
+    final Properties kafkaProps,
+    final AvroFormat format
   ) {
     return new DefaultStream<>(topics, kafkaProps, format, format::consoleSink);
   }
@@ -86,7 +86,7 @@ public final class KPipe {
   /// Avro-typed stream wired for per-record Confluent Schema Registry lookup. The wire envelope
   /// is consumed by the format itself; do NOT pair this overload with `.skipBytes(5)`.
   ///
-  /// Equivalent to `avro(AvroFormat.withRegistry(resolver), topic, kafkaProps)`. Provided so the
+  /// Equivalent to `avro(topic, kafkaProps, AvroFormat.withRegistry(resolver))`. Provided so the
   /// "Confluent Avro topic in one line" pitch is genuinely one line. Wrap the underlying SR
   /// resolver with `CachedSchemaResolver` for the cache; that bookkeeping is your responsibility
   /// since the resolver typically outlives a single stream.
@@ -108,31 +108,31 @@ public final class KPipe {
     throw new IllegalStateException(
       "toConsole() requires a fixed schema; an AvroFormat in Schema-Registry mode has none. " +
         "Use .toCustom(...) with your own sink, or construct the stream via " +
-        "KPipe.avro(new AvroFormat(schema), topic, props) to keep the console-sink path."
+        "KPipe.avro(topic, props, new AvroFormat(schema)) to keep the console-sink path."
     );
   }
 
   /// Protobuf-typed stream consuming from `topic` using `format` for SerDe. Construct the format
   /// explicitly: `new ProtobufFormat(descriptor)`.
   ///
-  /// @param format the Protobuf codec (must be non-null)
   /// @param topic the Kafka topic to consume
   /// @param kafkaProps the Kafka consumer properties
+  /// @param format the Protobuf codec (must be non-null)
   /// @return a fluent [Stream] configured for Protobuf
-  public static Stream<Message> protobuf(final ProtobufFormat format, final String topic, final Properties kafkaProps) {
+  public static Stream<Message> protobuf(final String topic, final Properties kafkaProps, final ProtobufFormat format) {
     return new DefaultStream<>(topic, kafkaProps, format, format::consoleSink);
   }
 
   /// Protobuf-typed stream consuming from multiple homogeneous topics.
   ///
-  /// @param format the Protobuf codec (must be non-null)
   /// @param topics the Kafka topics to consume (must be non-empty)
   /// @param kafkaProps the Kafka consumer properties
+  /// @param format the Protobuf codec (must be non-null)
   /// @return a fluent [Stream] configured for Protobuf
   public static Stream<Message> protobuf(
-    final ProtobufFormat format,
     final Collection<String> topics,
-    final Properties kafkaProps
+    final Properties kafkaProps,
+    final ProtobufFormat format
   ) {
     return new DefaultStream<>(topics, kafkaProps, format, format::consoleSink);
   }

--- a/lib/kpipe-api/src/main/java/io/github/eschizoid/kpipe/MultiBuilder.java
+++ b/lib/kpipe-api/src/main/java/io/github/eschizoid/kpipe/MultiBuilder.java
@@ -32,8 +32,8 @@ import org.apache.avro.generic.GenericRecord;
 /// ```java
 /// KPipe.multi(props)
 ///     .json("events-json", s -> s.pipe(addTimestamp).toCustom(jsonSink))
-///     .avro(avroFormat, "events-avro", s -> s.filter(active).toCustom(avroSink))
-///     .protobuf(protoFormat, "events-proto", s -> s.toConsole())
+///     .avro("events-avro", avroFormat, s -> s.filter(active).toCustom(avroSink))
+///     .protobuf("events-proto", protoFormat, s -> s.toConsole())
 ///     .start();
 /// ```
 ///
@@ -130,13 +130,13 @@ public final class MultiBuilder {
   /// is used for both deserialization and the default `toConsole()` sink. Construct the format
   /// explicitly: `new AvroFormat(schema)` or `AvroFormat.of(schemaJson)`.
   ///
-  /// @param format the Avro codec (must be non-null)
   /// @param topic the Kafka topic
+  /// @param format the Avro codec (must be non-null)
   /// @param configurator builds the operator chain and chooses a terminal sink
   /// @return this builder
   public MultiBuilder avro(
-    final AvroFormat format,
     final String topic,
+    final AvroFormat format,
     final Function<Stream<GenericRecord>, Sink<GenericRecord>> configurator
   ) {
     return route(topic, format, format::consoleSink, configurator);
@@ -145,13 +145,13 @@ public final class MultiBuilder {
   /// Registers a Protobuf route for `topic` using `format` for SerDe. Construct the format
   /// explicitly: `new ProtobufFormat(descriptor)`.
   ///
-  /// @param format the Protobuf codec (must be non-null)
   /// @param topic the Kafka topic
+  /// @param format the Protobuf codec (must be non-null)
   /// @param configurator builds the operator chain and chooses a terminal sink
   /// @return this builder
   public MultiBuilder protobuf(
-    final ProtobufFormat format,
     final String topic,
+    final ProtobufFormat format,
     final Function<Stream<Message>, Sink<Message>> configurator
   ) {
     return route(topic, format, format::consoleSink, configurator);

--- a/lib/kpipe-api/src/test/java/io/github/eschizoid/kpipe/ToConsoleDispatchTest.java
+++ b/lib/kpipe-api/src/test/java/io/github/eschizoid/kpipe/ToConsoleDispatchTest.java
@@ -41,7 +41,7 @@ class ToConsoleDispatchTest {
       SchemaBuilder.record("Test").namespace("io.github.eschizoid.kpipe.test").fields().requiredString("id").endRecord()
     );
 
-    final var sink = (DefaultSink<?>) KPipe.avro(format, "t", props()).toConsole();
+    final var sink = (DefaultSink<?>) KPipe.avro("t", props(), format).toConsole();
     assertInstanceOf(AvroConsoleSink.class, sink.terminalSink());
   }
 
@@ -49,7 +49,7 @@ class ToConsoleDispatchTest {
   void protobufToConsoleDispatchesToProtobufConsoleSink() {
     final var format = new ProtobufFormat(buildTestDescriptor());
 
-    final var sink = (DefaultSink<?>) KPipe.protobuf(format, "t", props()).toConsole();
+    final var sink = (DefaultSink<?>) KPipe.protobuf("t", props(), format).toConsole();
     assertInstanceOf(ProtobufConsoleSink.class, sink.terminalSink());
   }
 

--- a/lib/kpipe-format-avro/src/main/java/io/github/eschizoid/kpipe/format/avro/AvroFormat.java
+++ b/lib/kpipe-format-avro/src/main/java/io/github/eschizoid/kpipe/format/avro/AvroFormat.java
@@ -43,7 +43,7 @@ import org.apache.avro.io.EncoderFactory;
 /// }
 /// ```
 ///
-/// Schema-Registry mode replaces the manual `KPipe.avro(...).skipBytes(5).pipe(...)` pattern.
+/// Schema-Registry mode replaces the manual `KPipe.avro(topic, props, format).skipBytes(5).pipe(...)` pattern.
 /// Do **not** combine `withRegistry(...)` with `skipBytes(5)` — the format already consumes
 /// the envelope.
 public final class AvroFormat implements MessageFormat<GenericRecord> {


### PR DESCRIPTION
## Summary

Normalize the static-mode `KPipe.avro` / `KPipe.protobuf` overloads (and the corresponding `MultiBuilder` per-format methods) so the format argument comes **last**, matching the established shape of `KPipe.custom(topic, props, format)` and `KPipe.avro(topic, props, resolver)`. The §17 capability table already documents `(topic, props, format)` as the canonical shape — the static-mode Avro/Protobuf overloads were the outliers.

### The asymmetry (before)

- `KPipe.avro(AvroFormat format, String topic, Properties kafkaProps)` — format **first**
- `KPipe.protobuf(ProtobufFormat format, String topic, Properties kafkaProps)` — format **first**
- `KPipe.custom(String topic, Properties kafkaProps, MessageFormat<T> format)` — format **last** (canonical)
- `KPipe.avro(String topic, Properties kafkaProps, SchemaResolver resolver)` — resolver **last** (consistent with `custom`)
- `KPipe.json/bytes(String topic, Properties kafkaProps)` — no format arg

### The fix

Hard-rename all six entry points (no `@Deprecated` overloads kept) and migrate every caller in the same PR, per the no-deprecation policy.

- `KPipe.avro(String topic, Properties kafkaProps, AvroFormat format)`
- `KPipe.avro(Collection<String> topics, Properties kafkaProps, AvroFormat format)`
- `KPipe.protobuf(String topic, Properties kafkaProps, ProtobufFormat format)`
- `KPipe.protobuf(Collection<String> topics, Properties kafkaProps, ProtobufFormat format)`
- `MultiBuilder.avro(String topic, AvroFormat format, Function<…> configurator)`
- `MultiBuilder.protobuf(String topic, ProtobufFormat format, Function<…> configurator)`

The SR-mode `KPipe.avro(topic, props, SchemaResolver)`, `KPipe.json/bytes`, and `KPipe.custom` are unchanged — they already match the canonical shape.

## Pre-verification (caller enumeration before migration)

```
$ grep -rn "KPipe.avro\b\|KPipe.protobuf\b" lib/ examples/ benchmarks/ --include="*.java"
lib/kpipe-api/src/test/java/io/github/eschizoid/kpipe/ToConsoleDispatchTest.java:44:    final var sink = (DefaultSink<?>) KPipe.avro(format, "t", props()).toConsole();
lib/kpipe-api/src/test/java/io/github/eschizoid/kpipe/ToConsoleDispatchTest.java:52:    final var sink = (DefaultSink<?>) KPipe.protobuf(format, "t", props()).toConsole();
lib/kpipe-api/src/main/java/io/github/eschizoid/kpipe/KPipe.java:111:        "KPipe.avro(new AvroFormat(schema), topic, props) to keep the console-sink path."
lib/kpipe-format-avro/src/main/java/io/github/eschizoid/kpipe/format/avro/AvroFormat.java:46:/// Schema-Registry mode replaces the manual `KPipe.avro(...).skipBytes(5).pipe(...)` pattern.
examples/schema-registry/src/test/java/io/github/eschizoid/kpipe/AppIntegrationTest.java:97:      final var handle = KPipe.avro(format, topic, consumerProps())
examples/schema-registry/src/main/java/io/github/eschizoid/kpipe/App.java:38:      final var handle = KPipe.avro(config.topic(), props, resolver)
examples/avro/src/test/java/io/github/eschizoid/kpipe/AppIntegrationTest.java:65:    try (final var handle = KPipe.avro(format, topic, consumerProps()).skipBytes(5).toCustom(capturingSink).start()) {
examples/avro/src/main/java/io/github/eschizoid/kpipe/App.java:32:    try (final var handle = KPipe.avro(format, config.topic(), props).skipBytes(5).toConsole().start()) {
examples/protobuf/src/test/java/io/github/eschizoid/kpipe/AppIntegrationTest.java:56:      final var handle = KPipe.protobuf(format, topic, consumerProps())
examples/protobuf/src/main/java/io/github/eschizoid/kpipe/App.java:27:    try (final var handle = KPipe.protobuf(format, config.topic(), props).toConsole().start()) {

$ grep -rn "\.avro(.*format.*topic\|\.protobuf(.*format.*topic" lib/ examples/ benchmarks/ --include="*.java"
examples/schema-registry/src/test/java/io/github/eschizoid/kpipe/AppIntegrationTest.java:97:      final var handle = KPipe.avro(format, topic, consumerProps())
examples/avro/src/test/java/io/github/eschizoid/kpipe/AppIntegrationTest.java:65:    try (final var handle = KPipe.avro(format, topic, consumerProps()).skipBytes(5).toCustom(capturingSink).start()) {
examples/avro/src/main/java/io/github/eschizoid/kpipe/App.java:32:    try (final var handle = KPipe.avro(format, config.topic(), props).skipBytes(5).toConsole().start()) {
examples/protobuf/src/test/java/io/github/eschizoid/kpipe/AppIntegrationTest.java:56:      final var handle = KPipe.protobuf(format, topic, consumerProps())
examples/protobuf/src/main/java/io/github/eschizoid/kpipe/App.java:27:    try (final var handle = KPipe.protobuf(format, config.topic(), props).toConsole().start()) {
```

The `examples/schema-registry/.../App.java:38` hit is the SR-mode `(topic, props, resolver)` overload — already canonical, not migrated.

The Javadoc and code-comment mentions inside `lib/kpipe-api/src/main/java/io/github/eschizoid/kpipe/KPipe.java` and `lib/kpipe-format-avro/src/main/java/io/github/eschizoid/kpipe/format/avro/AvroFormat.java` referenced the old shape verbatim — those were updated in-place.

There are no `KPipe.avro` / `KPipe.protobuf` callers in `benchmarks/`.

## Migrated callers

### Library

- `lib/kpipe-api/src/main/java/io/github/eschizoid/kpipe/KPipe.java` — overload signatures + Javadoc + the `registryModeConsoleSinkUnsupported` error message
- `lib/kpipe-api/src/main/java/io/github/eschizoid/kpipe/MultiBuilder.java` — `avro` / `protobuf` route method signatures + class-level Javadoc example
- `lib/kpipe-format-avro/src/main/java/io/github/eschizoid/kpipe/format/avro/AvroFormat.java` — Javadoc reference to the old `KPipe.avro(...).skipBytes(5)` pattern

### Tests

- `lib/kpipe-api/src/test/java/io/github/eschizoid/kpipe/ToConsoleDispatchTest.java` — `avroToConsoleDispatchesToAvroConsoleSink` + `protobufToConsoleDispatchesToProtobufConsoleSink`

### Examples

- `examples/avro/src/main/java/io/github/eschizoid/kpipe/App.java`
- `examples/avro/src/test/java/io/github/eschizoid/kpipe/AppIntegrationTest.java`
- `examples/protobuf/src/main/java/io/github/eschizoid/kpipe/App.java`
- `examples/protobuf/src/test/java/io/github/eschizoid/kpipe/AppIntegrationTest.java`
- `examples/schema-registry/src/test/java/io/github/eschizoid/kpipe/AppIntegrationTest.java` (the static-mode call site)
- `examples/demo/src/main/java/io/github/eschizoid/kpipe/demo/DemoApp.java` (`MultiBuilder.avro` / `.protobuf`)

### Docs

- `README.md` — equivalence note for the SR-shorthand

## No-deprecation policy

Per the project's no-deprecation policy: no `@Deprecated` overloads, no `@deprecated` Javadoc, no shim layer. The rename and all caller migrations land in this one PR so users always have a working reference and the surface stays clean. Same playbook as the prior `withSequentialProcessing(boolean)` removal.

## Test plan

- [x] `./gradlew :lib:kpipe-api:test :examples:avro:compileJava :examples:protobuf:compileJava :benchmarks:compileJmhJava` → green (BUILD SUCCESSFUL in 2m 17s)
- [x] `./gradlew :examples:demo:compileJava` → green (DemoApp uses MultiBuilder.avro / .protobuf)
- [x] `./gradlew :examples:schema-registry:compileJava :examples:schema-registry:compileTestJava :examples:avro:compileTestJava :examples:protobuf:compileTestJava` → green
- [x] Final caller grep shows zero `(format, topic, …)` call sites remaining.