### PR TITLE
perf: hot-path quick wins — hoist getSimpleName, batch scratch buffer + BitSet, drop KeyOrdered wrapper

### DIFF
--- a/lib/kpipe-consumer/src/main/java/io/github/eschizoid/kpipe/consumer/BatchPipelineWrapper.java
+++ b/lib/kpipe-consumer/src/main/java/io/github/eschizoid/kpipe/consumer/BatchPipelineWrapper.java
@@ -7,7 +7,7 @@ import io.github.eschizoid.kpipe.sink.BatchSink;
 import java.lang.System.Logger;
 import java.lang.System.Logger.Level;
 import java.util.ArrayList;
-import java.util.HashSet;
+import java.util.BitSet;
 import java.util.List;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
@@ -136,21 +136,26 @@ final class BatchPipelineWrapper<K, T> implements AutoCloseable {
     }
   }
 
-  /// Caller must hold `lock`. Snapshots the buffer, clears it, invokes the user sink, then
-  /// dispatches per-record outcomes. `bufferedCount` is decremented in `finally` by the snapshot
-  /// size so it tracks records still owned by the wrapper even if dispatch throws.
+  /// Caller must hold `lock`. Snapshots the buffer's values into a single pre-sized list, clears
+  /// the buffer, then drives the sink + dispatches per-record outcomes off the same snapshot.
+  /// `bufferedCount` is decremented in `finally` by the snapshot size so it tracks records still
+  /// owned by the wrapper even if dispatch throws.
+  ///
+  /// The buffer itself is reused — `ArrayList.clear()` keeps the backing array, so steady-state
+  /// flushes don't reallocate the buffer. Only the per-flush snapshot list (used to walk records
+  /// after `flush` has finished iterating values) is allocated fresh per cycle.
   private void flushLocked() {
-    if (buffer.isEmpty()) return;
-    final var snapshot = List.copyOf(buffer);
-    buffer.clear();
-
-    final var values = new ArrayList<T>(snapshot.size());
+    final var size = buffer.size();
+    if (size == 0) return;
+    final var snapshot = new ArrayList<>(buffer);
+    final var values = new ArrayList<T>(size);
     for (final var entry : snapshot) values.add(entry.value());
+    buffer.clear();
 
     try {
       flush(snapshot, values);
     } finally {
-      bufferedCount.addAndGet(-snapshot.size());
+      bufferedCount.addAndGet(-size);
     }
   }
 
@@ -178,9 +183,12 @@ final class BatchPipelineWrapper<K, T> implements AutoCloseable {
       return;
     }
 
-    final var succeeded = new HashSet<Integer>(size * 2);
+    // BitSet is constant-time `set` / `get` on primitive int indexes — no boxing on the hot path,
+    // unlike `HashSet<Integer>`. Sized exactly to the batch so all sets land in word 0 for small
+    // batches.
+    final var succeeded = new BitSet(size);
     for (final var i : result.succeededIndexes()) {
-      if (i != null && i >= 0 && i < size) succeeded.add(i);
+      if (i != null && i >= 0 && i < size) succeeded.set(i);
       else logOutOfRange("succeeded", i, size);
     }
     for (final var i : result.failedByIndex().keySet()) {
@@ -188,11 +196,17 @@ final class BatchPipelineWrapper<K, T> implements AutoCloseable {
     }
 
     IllegalStateException coverageViolation = null;
-    final var missing = new ArrayList<Integer>();
+    // First pass: count missing indexes without allocating a list. Build the list only on the
+    // contract-violation path (rare); the common success path stays allocation-free.
+    var missingCount = 0;
     for (int i = 0; i < size; i++) {
-      if (!succeeded.contains(i) && !result.failedByIndex().containsKey(i)) missing.add(i);
+      if (!succeeded.get(i) && !result.failedByIndex().containsKey(i)) missingCount++;
     }
-    if (!missing.isEmpty()) {
+    if (missingCount > 0) {
+      final var missing = new ArrayList<Integer>(missingCount);
+      for (int i = 0; i < size; i++) {
+        if (!succeeded.get(i) && !result.failedByIndex().containsKey(i)) missing.add(i);
+      }
       coverageViolation = new IllegalStateException(
         "BatchSink for topic " +
           topic +
@@ -207,7 +221,7 @@ final class BatchPipelineWrapper<K, T> implements AutoCloseable {
 
     for (int i = 0; i < size; i++) {
       final var record = snapshot.get(i).record();
-      if (succeeded.contains(i)) {
+      if (succeeded.get(i)) {
         callbacks.markProcessed(record);
         continue;
       }

--- a/lib/kpipe-consumer/src/main/java/io/github/eschizoid/kpipe/consumer/KeyOrderedDispatcher.java
+++ b/lib/kpipe-consumer/src/main/java/io/github/eschizoid/kpipe/consumer/KeyOrderedDispatcher.java
@@ -114,18 +114,10 @@ final class KeyOrderedDispatcher<K> implements Dispatcher<K> {
     final var key = normalizeKey(record.key());
     pending.incrementAndGet();
 
-    final Runnable wrappedTask = () -> {
-      try {
-        processTask.run();
-      } finally {
-        pending.decrementAndGet();
-        try {
-          onComplete.run();
-        } catch (final RuntimeException e) {
-          LOGGER.log(Level.WARNING, "onComplete callback threw", e);
-        }
-      }
-    };
+    // Hold `(processTask, onComplete)` together as a single small record rather than wrapping
+    // them in a closure that also captures `pending` and `key`. `drain()` runs each half
+    // directly with its own try/finally, eliminating the per-record wrapper Runnable allocation.
+    final var queued = new QueuedTask(processTask, onComplete);
 
     lock.lock();
     try {
@@ -139,7 +131,7 @@ final class KeyOrderedDispatcher<K> implements Dispatcher<K> {
           return;
         }
       }
-      queue.tasks.addLast(wrappedTask);
+      queue.tasks.addLast(queued);
       if (!queue.workerActive) {
         queue.workerActive = true;
         try {
@@ -245,9 +237,11 @@ final class KeyOrderedDispatcher<K> implements Dispatcher<K> {
   }
 
   /// Inner drain loop for [#startWorker]. Pulls tasks under the lock; runs them outside.
+  /// `pending.decrement` and `onComplete` were previously folded into a wrapper [Runnable]
+  /// allocated per-dispatch; they now happen here, removing that allocation from the hot path.
   private void drain(final KeyQueue queue) {
     while (true) {
-      Runnable task;
+      QueuedTask task;
       lock.lock();
       try {
         task = queue.tasks.pollFirst();
@@ -258,11 +252,20 @@ final class KeyOrderedDispatcher<K> implements Dispatcher<K> {
       } finally {
         lock.unlock();
       }
-      // Run OUTSIDE the lock. `wrappedTask` (set in dispatch) handles pending.decrement
-      // and onComplete in its own try/finally; we add an outer guard so a Throwable from
-      // the wrapper doesn't break the drain loop.
+      // Run OUTSIDE the lock. Outer try/finally guarantees pending is decremented and
+      // onComplete is invoked even if processTask throws; the outer catch keeps the drain
+      // loop alive on any Throwable, mirroring the previous wrapper's safety net.
       try {
-        task.run();
+        try {
+          task.processTask.run();
+        } finally {
+          pending.decrementAndGet();
+          try {
+            task.onComplete.run();
+          } catch (final RuntimeException e) {
+            LOGGER.log(Level.WARNING, "onComplete callback threw", e);
+          }
+        }
       } catch (final Throwable t) {
         LOGGER.log(Level.ERROR, "Per-key worker task threw; continuing drain", t);
       }
@@ -382,7 +385,11 @@ final class KeyOrderedDispatcher<K> implements Dispatcher<K> {
   /// [KeyOrderedDispatcher#lock].
   private static final class KeyQueue {
 
-    final ArrayDeque<Runnable> tasks = new ArrayDeque<>();
+    final ArrayDeque<QueuedTask> tasks = new ArrayDeque<>();
     boolean workerActive = false;
   }
+
+  /// Pairs the per-record `processTask` with its `onComplete` callback. Replaces the
+  /// per-dispatch wrapper [Runnable] that previously captured both plus `pending` and `key`.
+  private record QueuedTask(Runnable processTask, Runnable onComplete) {}
 }

--- a/lib/kpipe-core/src/main/java/io/github/eschizoid/kpipe/registry/TypedPipelineBuilder.java
+++ b/lib/kpipe-core/src/main/java/io/github/eschizoid/kpipe/registry/TypedPipelineBuilder.java
@@ -109,6 +109,10 @@ public final class TypedPipelineBuilder<T> {
     final var pipelineOperators = List.copyOf(operators);
     final var pipelineSink = this.sink;
     final var bytesToSkip = this.skipBytes;
+    /// Hoisted once at build-time — `getClass().getSimpleName()` walks the class hierarchy and
+    /// is only used inside the `catch` arm of `deserialize`. Computing it per-record put the cost
+    /// on every successful deserialize as well.
+    final var formatName = format.getClass().getSimpleName();
 
     return new MessagePipeline<>() {
       @Override
@@ -119,7 +123,6 @@ public final class TypedPipelineBuilder<T> {
       @Override
       public T deserialize(byte[] data) {
         if (data == null) return null;
-        final var formatName = format.getClass().getSimpleName();
         if (bytesToSkip > 0) {
           if (data.length <= bytesToSkip) return null;
           final var actualData = new byte[data.length - bytesToSkip];


### PR DESCRIPTION
## Summary

Three small, surgical allocation cuts on the per-record hot path. No behavior change; existing tests pass unmodified.

### 1. `TypedPipelineBuilder.deserialize` — hoist `getSimpleName()`

`format.getClass().getSimpleName()` was recomputed on every `deserialize()` call, but the value is only used inside the catch arm (diagnostic message wrap). Moved it to a `final` capture in `build()` so it's computed exactly once per built pipeline.

**Allocation eliminated:** one `String` plus a class-hierarchy walk per record on the success path.

### 2. `BatchPipelineWrapper.flushLocked` — scratch buffer reuse + `BitSet`

- Replaced `List.copyOf(buffer)` + separate `ArrayList<T>` for values with one pre-sized `ArrayList<>(buffer)` snapshot and one pre-sized values list. The `buffer` field is now reused (`ArrayList.clear()` keeps the backing array), so steady-state flushes don't reallocate the buffer.
- Replaced `HashSet<Integer>(size * 2)` for `succeeded` with `BitSet(size)` — constant-time `set` / `get` on primitive `int` indexes, zero `Integer` boxing on the walks.
- Replaced `ArrayList<Integer> missing` with a count-first pass; only allocate the list on the (rare) coverage-violation path. Common case is allocation-free for the missing-index tracking.

**Allocations eliminated per flush:** the immutable `List.copyOf` array, the `HashSet` plus its boxed `Integer` entries, the always-allocated `missing` list, and the buffer's backing array on every steady-state flush.

### 3. `KeyOrderedDispatcher.dispatch` — drop the wrapper `Runnable`

The dispatcher used to wrap `(processTask, onComplete)` in a per-dispatch lambda that also captured `pending` and `key`. Replaced with a small `QueuedTask` record holding only `(processTask, onComplete)`. `drain()` now handles `pending.decrement` + `onComplete` directly in its own try/finally, preserving the same throw-safety + drain-loop-survives-any-`Throwable` semantics as the old wrapper.

The dispatcher's public `dispatch(record, processTask, onComplete)` signature is unchanged — all existing dispatcher tests pass without modification.

**Allocation eliminated:** the wrapper `Runnable` (captures 4 things) becomes a 2-field record. Lower object header + capture overhead per dispatch.

## Deferred for JMH-baselined PRs

Bigger wins surfaced by the same audit are deliberately not in this PR — they need before/after benchmark numbers, not just "looks faster":

- `OffsetManager`: cache `TopicPartition` instances per `(topic, partition)` instead of allocating one per record's `markOffsetProcessed` / `trackOffset`.
- `MessageFormat` SPI: add `deserialize(byte[], int, int)` so the `skipBytes(n)` path can skip the `System.arraycopy` on every record.

## Test plan

- [x] `./gradlew :lib:kpipe-core:test` — green (change 1 covered)
- [x] `./gradlew :lib:kpipe-consumer:test` — green twice, 263 unit tests pass on both runs. Two `@Testcontainers` integration tests (`ExternalOffsetIntegrationTest`, `KPipeProducerIntegrationTest`) fail with `DockerClientProviderStrategy` errors — pre-existing failure on `main` in any environment without a running Docker daemon, unrelated to these changes.
- [x] All `KeyOrderedDispatcherTest` cases pass without modification (signature preserved).
- [x] All `BatchPipelineWrapper*Test` cases pass — coverage contract, concurrency, and out-of-range index handling all green.