### PR TITLE
test: replace bare Thread.sleep with poll-until-deadline in flake-prone sites

### DIFF
--- a/lib/kpipe-consumer/src/test/java/io/github/eschizoid/kpipe/consumer/ConsumerHealthControllerTest.java
+++ b/lib/kpipe-consumer/src/test/java/io/github/eschizoid/kpipe/consumer/ConsumerHealthControllerTest.java
@@ -143,8 +143,9 @@ class ConsumerHealthControllerTest {
     health.recordOutcome(false);
     assertEquals(CircuitBreakerState.OPEN, health.circuitBreakerState());
 
-    // Probe scheduled 150ms out; wait generously.
-    Thread.sleep(400);
+    // Probe is scheduled 150ms out; wait for it to fire by latching on the resume hook signal.
+    // A bare sleep budget can be exceeded under loaded CI by GC pauses or scheduling jitter.
+    assertTrue(hook.awaitResumeCall(Duration.ofSeconds(5)), "probe should have fired and called onResume");
     assertEquals(CircuitBreakerState.HALF_OPEN, health.circuitBreakerState(), "probe should have fired");
     assertEquals(1, hook.resumeCalls, "probe fires onResume exactly once");
   }
@@ -156,7 +157,7 @@ class ConsumerHealthControllerTest {
 
     health.recordOutcome(false);
     health.recordOutcome(false);
-    Thread.sleep(300);
+    assertTrue(hook.awaitResumeCall(Duration.ofSeconds(5)), "probe should have fired and called onResume");
     assertEquals(CircuitBreakerState.HALF_OPEN, health.circuitBreakerState());
 
     health.recordOutcome(true);
@@ -170,7 +171,7 @@ class ConsumerHealthControllerTest {
 
     health.recordOutcome(false);
     health.recordOutcome(false);
-    Thread.sleep(300);
+    assertTrue(hook.awaitResumeCall(Duration.ofSeconds(5)), "probe should have fired and called onResume");
     assertEquals(CircuitBreakerState.HALF_OPEN, health.circuitBreakerState());
 
     health.recordOutcome(false);
@@ -274,6 +275,18 @@ class ConsumerHealthControllerTest {
     int resumeCalls;
     int backpressurePauses;
     int trips;
+    private final CountDownLatch resumeLatch = new CountDownLatch(1);
+
+    /// Blocks until `onResume` has been invoked at least once, or `timeout` elapses. Used by
+    /// circuit-breaker probe tests to fence on the probe actually firing rather than guessing a
+    /// sleep budget — the latter flakes on a loaded CI runner when GC or VT-scheduling jitter
+    /// pushes the probe past a fixed sleep.
+    ///
+    /// @param timeout maximum time to block
+    /// @return true if `onResume` was observed within the timeout
+    boolean awaitResumeCall(final Duration timeout) throws InterruptedException {
+      return resumeLatch.await(timeout.toMillis(), TimeUnit.MILLISECONDS);
+    }
 
     @Override
     public void onPause() {
@@ -283,6 +296,7 @@ class ConsumerHealthControllerTest {
     @Override
     public void onResume() {
       resumeCalls++;
+      resumeLatch.countDown();
     }
 
     @Override

--- a/lib/kpipe-consumer/src/test/java/io/github/eschizoid/kpipe/consumer/KPipeConsumerMockingTest.java
+++ b/lib/kpipe-consumer/src/test/java/io/github/eschizoid/kpipe/consumer/KPipeConsumerMockingTest.java
@@ -407,8 +407,12 @@ class KPipeConsumerMockingTest {
 
     assertTrue(latch.await(1, TimeUnit.SECONDS), "Processing did not complete in time");
 
-    // Give virtual threads time to complete processing
-    Thread.sleep(500);
+    // Wait for the worker virtual thread to mark messagesProcessed.
+    TestAwaits.pollUntil(
+      () -> functionalConsumer.getMetrics().get("messagesProcessed") == 1L,
+      Duration.ofSeconds(2),
+      "messagesProcessed reaches 1"
+    );
 
     // Verify metrics
     final var metrics = functionalConsumer.getMetrics();
@@ -556,12 +560,9 @@ class KPipeConsumerMockingTest {
 
     functionalConsumer.executeProcessRecords(records);
 
-    // Wait briefly for async processing to settle.
-    Thread.sleep(200);
-
     // The processor was never called; the error handler caught the contract violation.
     verifyNoInteractions(processor);
-    verify(errorHandler).accept(any(KPipeConsumer.ProcessingError.class));
+    verify(errorHandler, timeout(2000)).accept(any(KPipeConsumer.ProcessingError.class));
   }
 
   @Test
@@ -840,8 +841,12 @@ class KPipeConsumerMockingTest {
     // Allow processing to complete
     completeLatch.countDown();
 
-    // Wait for processing to complete
-    Thread.sleep(300);
+    // Wait for the dispatcher to drain.
+    TestAwaits.pollUntil(
+      () -> functionalConsumer.getProcessingCount() == 0,
+      Duration.ofSeconds(2),
+      "in-flight processing count drains to 0"
+    );
 
     // Verify count returns to 0
     assertEquals(0, functionalConsumer.getProcessingCount(), "Should have no in-flight messages after completion");
@@ -906,7 +911,7 @@ class KPipeConsumerMockingTest {
     executor.submit(functionalConsumer::start);
 
     // Wait for consumer to start
-    Thread.sleep(100);
+    TestAwaits.pollUntil(functionalConsumer::isRunning, Duration.ofSeconds(2), "consumer reaches RUNNING after start");
 
     // Check the running state
     assertTrue(functionalConsumer.isRunning(), "Should be running after start");
@@ -914,7 +919,7 @@ class KPipeConsumerMockingTest {
 
     // Pause consumer
     functionalConsumer.pause();
-    Thread.sleep(50);
+    TestAwaits.pollUntil(functionalConsumer::isPaused, Duration.ofSeconds(2), "consumer reaches PAUSED after pause()");
 
     // Check paused state
     assertTrue(functionalConsumer.isRunning(), "Should still be running when paused");
@@ -922,7 +927,11 @@ class KPipeConsumerMockingTest {
 
     // Resume consumer
     functionalConsumer.resume();
-    Thread.sleep(50);
+    TestAwaits.pollUntil(
+      () -> !functionalConsumer.isPaused(),
+      Duration.ofSeconds(2),
+      "consumer leaves PAUSED after resume()"
+    );
 
     // Check resumed state
     assertTrue(functionalConsumer.isRunning(), "Should be running after resume");
@@ -930,7 +939,11 @@ class KPipeConsumerMockingTest {
 
     // Close consumer
     functionalConsumer.close();
-    Thread.sleep(50);
+    TestAwaits.pollUntil(
+      () -> !functionalConsumer.isRunning(),
+      Duration.ofSeconds(2),
+      "consumer leaves RUNNING after close()"
+    );
 
     // Check closed state
     assertFalse(functionalConsumer.isRunning(), "Should not be running after close");
@@ -976,7 +989,9 @@ class KPipeConsumerMockingTest {
     // Wait for processing to complete
     assertTrue(latch.await(1, TimeUnit.SECONDS), "Processing did not complete in time");
 
-    Thread.sleep(200);
+    // Wait for the worker to invoke the offset manager — markOffsetProcessed is called from the
+    // record-processing finally, AFTER the latch counts down inside the throwing answer.
+    verify(offsetManager, timeout(2000).times(1)).markOffsetProcessed(record);
 
     // Process the commands in the queue
     functionalConsumer.processCommands();

--- a/lib/kpipe-consumer/src/test/java/io/github/eschizoid/kpipe/consumer/KPipeConsumerTest.java
+++ b/lib/kpipe-consumer/src/test/java/io/github/eschizoid/kpipe/consumer/KPipeConsumerTest.java
@@ -542,7 +542,11 @@ class KPipeConsumerTest {
 
     // Act
     consumer.processRecord(record);
-    Thread.sleep(200);
+    TestAwaits.pollUntil(
+      () -> consumer.getMetrics().get("messagesProcessed") == 1L,
+      Duration.ofSeconds(2),
+      "messagesProcessed reaches 1 after retry"
+    );
 
     // Assert
     final var metrics = consumer.getMetrics();
@@ -572,7 +576,11 @@ class KPipeConsumerTest {
 
     // Act
     consumer.processRecord(record);
-    Thread.sleep(100);
+    TestAwaits.pollUntil(
+      () -> consumer.getMetrics().get("processingErrors") == 1L,
+      Duration.ofSeconds(2),
+      "processingErrors reaches 1 after exhausting retries"
+    );
 
     // Assert
     final var errorCaptor = ArgumentCaptor.forClass(KPipeConsumer.ProcessingError.class);
@@ -609,7 +617,11 @@ class KPipeConsumerTest {
       final var record = createRecord(i, "key" + i, "value" + i);
       consumer.processRecord(record);
     }
-    Thread.sleep(200);
+    TestAwaits.pollUntil(
+      () -> consumer.getMetrics().get("messagesProcessed") == 3L,
+      Duration.ofSeconds(2),
+      "messagesProcessed reaches 3 after intermittent retries"
+    );
 
     // Assert
     final var metrics = consumer.getMetrics();
@@ -729,13 +741,16 @@ class KPipeConsumerTest {
   void withBackpressureShouldPauseConsumerWhenInFlightExceedsHighWatermark() throws InterruptedException {
     // Arrange: slow sink to keep messages in-flight; high watermark of 2
     final var commandQueue = new ConcurrentLinkedQueue<ConsumerCommand>();
+    final var sinkStarted = new CountDownLatch(3);
+    final var sinkRelease = new CountDownLatch(1);
     final var consumer = KPipeConsumer.<String>builder()
       .withProperties(properties)
       .withTopic(TOPIC)
       .withPipeline(
         TestPipelines.sideEffect(value -> {
+          sinkStarted.countDown();
           try {
-            Thread.sleep(500);
+            sinkRelease.await(5, TimeUnit.SECONDS);
           } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
           }
@@ -751,26 +766,31 @@ class KPipeConsumerTest {
     consumer.processRecord(createRecord(1, "k1", "v1"));
     consumer.processRecord(createRecord(2, "k2", "v2"));
 
-    // Wait briefly for virtual threads to start (messages are received but not yet processed)
-    Thread.sleep(50);
+    // Wait for all 3 sink invocations to begin — proves the dispatcher started the work, so
+    // messagesReceived has been counted and in-flight is at 3.
+    assertTrue(sinkStarted.await(3, TimeUnit.SECONDS), "All 3 records should be in-flight at the sink");
 
     // In-flight = 3 received - 0 processed = 3 >= highWatermark(2)
     final var metrics = consumer.getMetrics();
     assertTrue(metrics.get("messagesReceived") >= 3);
 
+    sinkRelease.countDown();
     consumer.close();
   }
 
   @Test
   void withBackpressureShouldIncrementPauseCountWhenHighWatermarkExceeded() throws InterruptedException {
     // Arrange: high watermark of 2, low watermark of 1
+    final var sinkStarted = new CountDownLatch(3);
+    final var sinkRelease = new CountDownLatch(1);
     final var consumer = KPipeConsumer.<String>builder()
       .withProperties(properties)
       .withTopic(TOPIC)
       .withPipeline(
         TestPipelines.sideEffect(value -> {
+          sinkStarted.countDown();
           try {
-            Thread.sleep(500);
+            sinkRelease.await(5, TimeUnit.SECONDS);
           } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
           }
@@ -784,13 +804,14 @@ class KPipeConsumerTest {
     consumer.processRecord(createRecord(0, "k0", "v0"));
     consumer.processRecord(createRecord(1, "k1", "v1"));
     consumer.processRecord(createRecord(2, "k2", "v2"));
-    Thread.sleep(50);
+    assertTrue(sinkStarted.await(3, TimeUnit.SECONDS), "All 3 records should be in-flight at the sink");
 
     consumer.pause();
     final var metrics = consumer.getMetrics();
     assertTrue(metrics.containsKey(KPipeConsumer.METRIC_BACKPRESSURE_PAUSE_COUNT));
     assertTrue(metrics.containsKey(KPipeConsumer.METRIC_BACKPRESSURE_TIME_MS));
 
+    sinkRelease.countDown();
     consumer.close();
   }
 

--- a/lib/kpipe-consumer/src/test/java/io/github/eschizoid/kpipe/consumer/TestAwaits.java
+++ b/lib/kpipe-consumer/src/test/java/io/github/eschizoid/kpipe/consumer/TestAwaits.java
@@ -1,0 +1,47 @@
+package io.github.eschizoid.kpipe.consumer;
+
+import java.time.Duration;
+import java.util.function.BooleanSupplier;
+
+/// Poll-until-deadline helpers for flake-prone consumer tests.
+///
+/// Use these in place of bare `Thread.sleep(N)` followed by an immediate assertion. On a loaded
+/// CI runner a fixed sleep budget can be exceeded by GC pauses or virtual-thread scheduling
+/// jitter, and the follow-up assertion will then race against the wall clock instead of the
+/// actual condition.
+///
+/// Typical shape:
+/// ```java
+/// pollUntil(() -> metrics.get("messagesProcessed") == 1L, Duration.ofSeconds(2),
+///   "messagesProcessed reaches 1");
+/// assertEquals(1L, metrics.get("messagesProcessed"));
+/// ```
+///
+/// The trailing `assertEquals` is the fence: the poll proves the condition has been observed at
+/// least once before the deadline; the assertion ratifies the final state.
+final class TestAwaits {
+
+  private static final Duration POLL_INTERVAL = Duration.ofMillis(20);
+
+  private TestAwaits() {}
+
+  /// Polls `cond` until it returns true or `timeout` elapses, sleeping briefly between checks.
+  ///
+  /// Throws [AssertionError] on timeout. Silently passing would let downstream assertions run
+  /// against a partial state.
+  ///
+  /// @param cond predicate observed each poll iteration
+  /// @param timeout deadline measured from the call site
+  /// @param desc human-readable description of the awaited condition for the timeout message
+  /// @throws InterruptedException if the polling thread is interrupted
+  static void pollUntil(final BooleanSupplier cond, final Duration timeout, final String desc)
+    throws InterruptedException {
+    final var deadlineNanos = System.nanoTime() + timeout.toNanos();
+    while (!cond.getAsBoolean()) {
+      if (System.nanoTime() >= deadlineNanos) {
+        throw new AssertionError("Timed out after " + timeout.toMillis() + "ms waiting for: " + desc);
+      }
+      Thread.sleep(POLL_INTERVAL.toMillis());
+    }
+  }
+}


### PR DESCRIPTION
## Summary

The test-brittleness audit flagged bare `Thread.sleep(N)` followed by an immediate assertion as the highest-severity pattern. Under loaded CI a fixed sleep budget can be exceeded by GC pauses or VT scheduling jitter, and the follow-up assertion races the wall clock instead of the actual condition.

- Add `TestAwaits.pollUntil(BooleanSupplier, Duration, String)` — shared helper that throws `AssertionError` on timeout (silent passes would let downstream assertions run against partial state).
- Replace 13 bare-sleep + assertion pairs across three test classes with poll-until-deadline, sink-start `CountDownLatch`es, or Mockito `verify(..., timeout(N))` where the mock interaction is itself the observable signal.

## Sites fixed

### `KPipeConsumerTest.java`
- `processorWithRetryEnabledShouldRetryFailedMessages` (line ~545): `Thread.sleep(200)` → `pollUntil(messagesProcessed == 1L, 2s)`.
- `processorWithMaxRetriesExceededShouldCallErrorHandler` (line ~575): `Thread.sleep(100)` → `pollUntil(processingErrors == 1L, 2s)`.
- `metricsTrackingWithFailuresAndRetriesShouldIncrementCorrectly` (line ~612): `Thread.sleep(200)` → `pollUntil(messagesProcessed == 3L, 2s)`.
- `withBackpressureShouldPauseConsumerWhenInFlightExceedsHighWatermark` (line ~755) and `withBackpressureShouldIncrementPauseCountWhenHighWatermarkExceeded` (line ~787): `Thread.sleep(50)` "give virtual threads time to start" → `sinkStarted.await()` latch fence, mirroring the pattern already used in `KPipeBackpressureIntegrationTest`.

### `KPipeConsumerMockingTest.java`
- `shouldUpdateMetricsOnSuccessfulProcessing` (line ~411): `Thread.sleep(500)` → `pollUntil(messagesProcessed == 1L, 2s)`.
- `shouldHandleNullValueInRecord` (line ~560): `Thread.sleep(200)` → `verify(errorHandler, timeout(2000)).accept(...)`.
- `processingCountShouldReflectInFlightMessages` (line ~844): `Thread.sleep(300)` → `pollUntil(getProcessingCount() == 0, 2s)`.
- `stateShouldTransitionCorrectlyDuringLifecycle` (lines 909-933): four bare sleeps (100/50/50/50) replaced by `pollUntil` on the state predicate at each transition.
- `shouldMarkOffsetAsProcessedEvenWhenProcessingFails` (line ~979): `Thread.sleep(200)` → `verify(offsetManager, timeout(2000).times(1)).markOffsetProcessed(record)`.

### `ConsumerHealthControllerTest.java`
- `probeFiresAfterOpenDurationAndHalfOpens` (line 147), `halfOpenSuccessClosesBreaker` (line 159), `halfOpenFailureTripsBreakerAgain` (line 173): probe sleep budgets (3x the configured probe delay) replaced by `hook.awaitResumeCall(Duration)` — a `CountDownLatch` fired from `RecordingHook.onResume`, so the fence is the probe actually firing.

## Out of scope (per audit — ratified patterns)

- `pendingCount()` post-dispatch deadline polls in `ParallelDispatcherTest`, `KeyOrderedDispatcherTest`, `DispatcherIntegrationTest`.
- `Thread.sleep` inside test pipeline lambdas (slow-sink simulation).
- Negative-assertion sleeps with documented justification (e.g. `KPipeReporterThreadTest.POST_CLOSE_SAFETY_MS`).
- `AppConfigTest.java:159` clock-based unique key — flagged as medium severity.

## Test plan

- [x] `./gradlew :lib:kpipe-consumer:compileTestJava` — compiles.
- [x] `./gradlew :lib:kpipe-consumer:test --tests KPipeConsumerTest --tests KPipeConsumerMockingTest --tests ConsumerHealthControllerTest --rerun-tasks` — green 3 consecutive runs (75 tests).
- [x] Two Testcontainer integration tests (`ExternalOffsetIntegrationTest`, `KPipeProducerIntegrationTest`) fail at suite level due to local Docker unavailability — pre-existing, unrelated to this change.
- [ ] CI green on remote.