### PR TITLE
perf(consumer): cache TopicPartition per partition in KafkaOffsetManager + add JMH benchmark

### DIFF
--- a/benchmarks/src/jmh/java/io/github/eschizoid/kpipe/benchmarks/OffsetManagerBoxingBenchmark.java
+++ b/benchmarks/src/jmh/java/io/github/eschizoid/kpipe/benchmarks/OffsetManagerBoxingBenchmark.java
@@ -1,0 +1,143 @@
+package io.github.eschizoid.kpipe.benchmarks;
+
+import io.github.eschizoid.kpipe.consumer.ConsumerCommand;
+import io.github.eschizoid.kpipe.consumer.KafkaOffsetManager;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Queue;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.TimeUnit;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.clients.consumer.MockConsumer;
+import org.apache.kafka.common.TopicPartition;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OperationsPerInvocation;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+import org.openjdk.jmh.annotations.Warmup;
+
+/// JMH benchmark for the `KafkaOffsetManager` hot path — `trackOffset` + `markOffsetProcessed`.
+///
+/// ### What it measures
+///
+/// Per-record cost of the two `OffsetManager` calls that fire on every Kafka record. Pre-cache
+/// each call allocated a fresh `TopicPartition(topic, partition)` to use as a `ConcurrentHashMap`
+/// key — at ~100k rec/s that's ~200k disposable `TopicPartition` instances/sec from this manager
+/// alone. The cache (a `ConcurrentHashMap<String, ConcurrentHashMap<Integer, TopicPartition>>`
+/// keyed by topic then partition) collapses those allocations to one instance per partition for
+/// the lifetime of the assignment.
+///
+/// The bench drives the public `KafkaOffsetManager` API directly with synthetic `ConsumerRecord`
+/// instances (no Kafka, no MockConsumer poll loop, no SerDe). The cache is pre-warmed in
+/// `@Setup` so the steady-state fast path is the only thing measured — first-call allocations
+/// are excluded from the measurement window.
+///
+/// ### Parameters
+///
+/// - `partitions ∈ {8}` — a small assignment that pre-warms the cache. Matches the audit's
+///   "partition set is warm in steady state" assumption. Wider sweeps (1, 8, 64) aren't
+///   informative here because the cache lookup is O(1) per record regardless of partition count.
+///
+/// ### Companion profilers
+///
+/// Run with `-prof gc` to see the allocation-rate drop directly:
+///
+/// ```bash
+/// ./gradlew :benchmarks:jmh \
+///   -Pjmh.includes='OffsetManagerBoxingBenchmark' \
+///   -Pjmh.profilers='gc'
+/// ```
+///
+/// The `gc.alloc.rate.norm` column (bytes allocated per op) is the primary signal — the cache
+/// should remove one `TopicPartition` instance worth of bytes per record (16 bytes object header
+/// + topic ref + partition int + alignment ~= 24 bytes on a 64-bit JVM with compressed oops).
+/// Throughput improvement is secondary; the JIT may already optimize the constructor away in
+/// the baseline, in which case the alloc-rate delta is the only signal.
+@State(Scope.Benchmark)
+@BenchmarkMode(Mode.Throughput)
+@OutputTimeUnit(TimeUnit.SECONDS)
+@Warmup(iterations = 3, time = 2, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 5, time = 3, timeUnit = TimeUnit.SECONDS)
+@Fork(1)
+public class OffsetManagerBoxingBenchmark {
+
+  private static final String TOPIC = "kpipe-offsetmgr-bench";
+  private static final int PARTITION_COUNT = 8;
+
+  /// Records driven through the manager per `@Benchmark` invocation. Sized to amortize the
+  /// JMH per-invocation overhead while keeping the bench cell short enough that JIT/GC noise
+  /// stays bounded. Each record exercises both `trackOffset` and `markOffsetProcessed`.
+  private static final int RECORDS_PER_INVOCATION = 10_000;
+
+  private static final byte[] PAYLOAD = "v".getBytes();
+
+  @Param({ "8" })
+  public int partitions;
+
+  private KafkaOffsetManager<String> offsetManager;
+  private Queue<ConsumerCommand> commandQueue;
+  private MockConsumer<String, byte[]> mockConsumer;
+  private ConsumerRecord<String, byte[]>[] records;
+
+  @Setup(Level.Trial)
+  @SuppressWarnings("unchecked")
+  public void setup() {
+    commandQueue = new ConcurrentLinkedQueue<>();
+    mockConsumer = new MockConsumer<>("earliest");
+    final var assignment = new ArrayList<TopicPartition>(partitions);
+    for (var p = 0; p < partitions; p++) assignment.add(new TopicPartition(TOPIC, p));
+    mockConsumer.assign(assignment);
+    final var beginningOffsets = new HashMap<TopicPartition, Long>();
+    for (final var tp : assignment) beginningOffsets.put(tp, 0L);
+    mockConsumer.updateBeginningOffsets(beginningOffsets);
+
+    offsetManager = KafkaOffsetManager.<String>builder(mockConsumer).withCommandQueue(commandQueue).build();
+    offsetManager.start();
+
+    // Pre-build the synthetic record set so the bench loop does no allocation outside the
+    // manager — only the cache-hit path is on the timed path.
+    records = (ConsumerRecord<String, byte[]>[]) new ConsumerRecord<?, ?>[RECORDS_PER_INVOCATION];
+    for (var i = 0; i < RECORDS_PER_INVOCATION; i++) {
+      records[i] = new ConsumerRecord<>(TOPIC, i % partitions, i, "k-" + i, PAYLOAD);
+    }
+
+    // Warm the cache: one track per partition populates `topicPartitionCache` so the
+    // measurement loop only exercises the fast path.
+    for (var p = 0; p < partitions; p++) {
+      offsetManager.trackOffset(new ConsumerRecord<>(TOPIC, p, -1L, "warmup", PAYLOAD));
+      offsetManager.markOffsetProcessed(new ConsumerRecord<>(TOPIC, p, -1L, "warmup", PAYLOAD));
+    }
+  }
+
+  @TearDown(Level.Trial)
+  public void tearDown() {
+    if (offsetManager != null) offsetManager.close();
+    if (mockConsumer != null) mockConsumer.close();
+    if (commandQueue != null) commandQueue.clear();
+  }
+
+  /// Drives `trackOffset` then `markOffsetProcessed` for each pre-built `ConsumerRecord`. The
+  /// `@OperationsPerInvocation` count is `RECORDS_PER_INVOCATION` so the reported throughput
+  /// is in records/sec rather than invocations/sec.
+  @Benchmark
+  @OperationsPerInvocation(RECORDS_PER_INVOCATION)
+  public void trackAndMark() {
+    final var rs = records;
+    final var mgr = offsetManager;
+    for (var i = 0; i < rs.length; i++) {
+      final var r = rs[i];
+      mgr.trackOffset(r);
+      mgr.markOffsetProcessed(r);
+    }
+  }
+
+}

--- a/lib/kpipe-consumer/src/main/java/io/github/eschizoid/kpipe/consumer/KafkaOffsetManager.java
+++ b/lib/kpipe-consumer/src/main/java/io/github/eschizoid/kpipe/consumer/KafkaOffsetManager.java
@@ -82,6 +82,19 @@ public class KafkaOffsetManager<K> implements OffsetManager<K> {
   private final Map<String, CompletableFuture<Boolean>> commitFutures = new ConcurrentHashMap<>();
   private final Map<TopicPartition, ConcurrentSkipListSet<Long>> pendingOffsets = new ConcurrentHashMap<>();
   private final Map<TopicPartition, Long> highestProcessedOffsets = new ConcurrentHashMap<>();
+
+  /// Per-partition `TopicPartition` cache used by `trackOffset` and `markOffsetProcessed`. Each
+  /// `ConsumerRecord` carries `topic()` (a `String`) + `partition()` (an `int`) — constructing a
+  /// fresh `TopicPartition` per call on every record allocates twice per record on the hot path
+  /// (track from the consumer thread, mark from the worker), which at 100k rec/s is ~200k
+  /// disposable instances/sec from this manager alone.
+  ///
+  /// The cache is keyed by topic name (outer map) then partition number (inner map) so the
+  /// outer-map miss path (one-time per topic) is small and the per-record fast path is two
+  /// `ConcurrentHashMap` lookups returning a stable, interned instance. Entries are evicted in
+  /// `onPartitionsRevoked` so a rebalance that hands a partition off doesn't leak the cached
+  /// instance — `onPartitionsAssigned` will repopulate on first record.
+  private final Map<String, Map<Integer, TopicPartition>> topicPartitionCache = new ConcurrentHashMap<>();
   private final Duration commitInterval;
   private volatile ScheduledExecutorService scheduler;
   private volatile ScheduledFuture<?> scheduledCommitTask;
@@ -203,7 +216,7 @@ public class KafkaOffsetManager<K> implements OffsetManager<K> {
   @Override
   public void trackOffset(final ConsumerRecord<K, byte[]> record) {
     if (state.get() == OffsetState.STOPPED) return;
-    final var partition = new TopicPartition(record.topic(), record.partition());
+    final var partition = cachedTopicPartition(record.topic(), record.partition());
     final var offset = record.offset();
     pendingOffsets.computeIfAbsent(partition, _ -> new ConcurrentSkipListSet<>()).add(offset);
   }
@@ -220,7 +233,7 @@ public class KafkaOffsetManager<K> implements OffsetManager<K> {
   @Override
   public void markOffsetProcessed(final ConsumerRecord<K, byte[]> record) {
     if (state.get() == OffsetState.STOPPED) return;
-    final var partition = new TopicPartition(record.topic(), record.partition());
+    final var partition = cachedTopicPartition(record.topic(), record.partition());
     final var offset = record.offset();
 
     highestProcessedOffsets.compute(partition, (_, v) -> v == null ? offset : Math.max(v, offset));
@@ -228,6 +241,35 @@ public class KafkaOffsetManager<K> implements OffsetManager<K> {
     pendingOffsets.computeIfPresent(partition, (_, set) -> {
       set.remove(offset);
       return set.isEmpty() ? null : set;
+    });
+  }
+
+  /// Returns a cached `TopicPartition` for the given `(topic, partition)` pair, allocating one
+  /// on first observation and reusing the same instance for every subsequent call. The fast
+  /// path is two `ConcurrentHashMap` lookups returning a stable instance, replacing two `new
+  /// TopicPartition(...)` allocations per record on the hot path.
+  ///
+  /// `computeIfAbsent` on the outer map atomicizes the inner-map creation; the inner-map
+  /// lambda closes over `topic` from the local rather than the `BiFunction`'s `t` argument, so
+  /// the `TopicPartition(topic, partition)` constructor sees the exact `String` reference the
+  /// caller passed (`String#intern` is not assumed — `TopicPartition.equals/hashCode` use
+  /// value equality and pooled inner-map entries don't depend on string identity).
+  private TopicPartition cachedTopicPartition(final String topic, final int partition) {
+    return topicPartitionCache
+      .computeIfAbsent(topic, _ -> new ConcurrentHashMap<>())
+      .computeIfAbsent(partition, p -> new TopicPartition(topic, p));
+  }
+
+  /// Evicts the cached `TopicPartition` for a revoked partition. Uses `computeIfPresent` on the
+  /// inner map so the inner-map removal and the outer-map cleanup are bucket-locked together —
+  /// a concurrent `cachedTopicPartition` call for a different partition under the same topic
+  /// cannot see a transient empty inner map and double-allocate. If the inner map becomes empty
+  /// after removal (last partition for a topic), the outer entry is dropped so the cache doesn't
+  /// retain stale topic keys across rebalances.
+  private void evictCachedTopicPartition(final TopicPartition partition) {
+    topicPartitionCache.computeIfPresent(partition.topic(), (_, inner) -> {
+      inner.remove(partition.partition());
+      return inner.isEmpty() ? null : inner;
     });
   }
 
@@ -478,6 +520,7 @@ public class KafkaOffsetManager<K> implements OffsetManager<K> {
           }
           pendingOffsets.remove(partition);
           highestProcessedOffsets.remove(partition);
+          evictCachedTopicPartition(partition);
         });
 
         if (!offsetsToCommit.isEmpty()) {
@@ -571,5 +614,6 @@ public class KafkaOffsetManager<K> implements OffsetManager<K> {
   private void cleanup() {
     pendingOffsets.clear();
     highestProcessedOffsets.clear();
+    topicPartitionCache.clear();
   }
 }

--- a/lib/kpipe-consumer/src/test/java/io/github/eschizoid/kpipe/consumer/KafkaOffsetManagerTest.java
+++ b/lib/kpipe-consumer/src/test/java/io/github/eschizoid/kpipe/consumer/KafkaOffsetManagerTest.java
@@ -1247,4 +1247,99 @@ class KafkaOffsetManagerTest {
       );
     }
   }
+
+  /// Verifies the per-partition `TopicPartition` cache behavior in `trackOffset` /
+  /// `markOffsetProcessed`: same instance reused across calls, evicted on revoke, re-allocated
+  /// after re-assignment. The behavioral tests above (offset commit semantics, rebalance
+  /// handling, etc.) cover correctness; these tests verify the allocation contract that exists
+  /// to keep the hot path off the per-record `new TopicPartition(...)` path.
+  @Nested
+  class TopicPartitionCacheTests {
+
+    /// Reflection accessor for the cache so the test can inspect cached instances without
+    /// widening the production surface. Keeps the cache field private — only the tests reach
+    /// inside.
+    @SuppressWarnings("unchecked")
+    private Map<Integer, TopicPartition> innerCache(final KafkaOffsetManager<?> manager, final String topic)
+      throws Exception {
+      final var field = KafkaOffsetManager.class.getDeclaredField("topicPartitionCache");
+      field.setAccessible(true);
+      final var outer = (Map<String, Map<Integer, TopicPartition>>) field.get(manager);
+      return outer.get(topic);
+    }
+
+    @Test
+    void cachedTopicPartitionIsTheSameInstanceAcrossCalls() throws Exception {
+      final var record1 = new ConsumerRecord<>(TOPIC, 0, 100L, "k", "v".getBytes());
+      final var record2 = new ConsumerRecord<>(TOPIC, 0, 101L, "k", "v".getBytes());
+
+      offsetManager.trackOffset(record1);
+      final var tp1 = innerCache(offsetManager, TOPIC).get(0);
+      assertNotNull(tp1, "trackOffset must populate the cache");
+
+      offsetManager.markOffsetProcessed(record1);
+      final var tp2 = innerCache(offsetManager, TOPIC).get(0);
+      assertSame(tp1, tp2, "markOffsetProcessed must reuse the cached TopicPartition");
+
+      offsetManager.trackOffset(record2);
+      offsetManager.markOffsetProcessed(record2);
+      final var tp3 = innerCache(offsetManager, TOPIC).get(0);
+      assertSame(tp1, tp3, "subsequent track/mark on the same partition must reuse the cached instance");
+    }
+
+    @Test
+    void revokedPartitionsAreEvictedFromTheCache() throws Exception {
+      final var record = new ConsumerRecord<>(TOPIC, 0, 100L, "k", "v".getBytes());
+      offsetManager.trackOffset(record);
+      offsetManager.markOffsetProcessed(record);
+      assertNotNull(innerCache(offsetManager, TOPIC).get(0), "precondition: cache populated");
+
+      offsetManager.createRebalanceListener().onPartitionsRevoked(List.of(PARTITION));
+
+      final var inner = innerCache(offsetManager, TOPIC);
+      assertNull(inner, "revoking the only partition for a topic must drop the inner map entry");
+    }
+
+    @Test
+    void reAssignedPartitionAllocatesNewCachedInstance() throws Exception {
+      final var record = new ConsumerRecord<>(TOPIC, 0, 100L, "k", "v".getBytes());
+      offsetManager.trackOffset(record);
+      final var original = innerCache(offsetManager, TOPIC).get(0);
+      assertNotNull(original, "precondition: cache populated");
+
+      final var listener = offsetManager.createRebalanceListener();
+      listener.onPartitionsRevoked(List.of(PARTITION));
+      listener.onPartitionsAssigned(List.of(PARTITION));
+
+      // Cache is empty after revoke — first track after re-assignment must repopulate it with a
+      // new instance (NOT the original — that one was evicted).
+      offsetManager.trackOffset(record);
+      final var reAllocated = innerCache(offsetManager, TOPIC).get(0);
+      assertNotNull(reAllocated, "track after re-assignment must repopulate the cache");
+      assertNotSame(original, reAllocated, "re-assignment must allocate a fresh TopicPartition, not reuse the evicted one");
+      assertEquals(original, reAllocated, "value-equality must still hold (same topic + partition number)");
+    }
+
+    @Test
+    void evictionOfOnePartitionPreservesSiblingPartitionsForSameTopic() throws Exception {
+      final var p0 = new TopicPartition(TOPIC, 0);
+      final var p1 = new TopicPartition(TOPIC, 1);
+
+      final var r0 = new ConsumerRecord<>(TOPIC, 0, 100L, "k", "v".getBytes());
+      final var r1 = new ConsumerRecord<>(TOPIC, 1, 200L, "k", "v".getBytes());
+      offsetManager.trackOffset(r0);
+      offsetManager.trackOffset(r1);
+      final var tp1Before = innerCache(offsetManager, TOPIC).get(1);
+      assertNotNull(tp1Before, "precondition: partition 1 cached");
+
+      // Revoke only partition 0; partition 1 should remain cached.
+      offsetManager.createRebalanceListener().onPartitionsRevoked(List.of(p0));
+
+      final var inner = innerCache(offsetManager, TOPIC);
+      assertNotNull(inner, "topic entry should still exist while partition 1 remains");
+      assertNull(inner.get(0), "partition 0 must be evicted");
+      assertSame(tp1Before, inner.get(1), "partition 1 must remain cached as the same instance");
+      assertEquals(p1, inner.get(1), "value equality check");
+    }
+  }
 }


### PR DESCRIPTION
## Summary

`KafkaOffsetManager.{trackOffset, markOffsetProcessed}` previously allocated a fresh `TopicPartition(topic, partition)` per call to use as a `ConcurrentHashMap` key. At 100k rec/s that's ~200k disposable `TopicPartition` instances/sec from this manager alone — twice per record (consumer thread + worker thread).

This PR introduces a per-partition cache so the per-record allocation is gone, plus a JMH benchmark to measure it.

## The cache

- **Shape:** `ConcurrentHashMap<String, ConcurrentHashMap<Integer, TopicPartition>>` (outer keyed by topic name, inner by partition number).
- **Lookup:** `outerMap.computeIfAbsent(topic, _ -> new ConcurrentHashMap<>()).computeIfAbsent(partition, p -> new TopicPartition(topic, p))`. Fast path = two CHM lookups returning a stable instance.
- **Eviction:** the existing rebalance listener already iterates `onPartitionsRevoked` partitions to clear `pendingOffsets` and `highestProcessedOffsets`. The cache eviction is added in the same loop. `onPartitionsLost` delegates to `onPartitionsRevoked` so it gets the same treatment.
- **Bucket-locked removal:** `evictCachedTopicPartition` uses `computeIfPresent` on the outer map so removing a partition and dropping the (now-empty) inner map happens under one bucket lock — a concurrent `cachedTopicPartition` call for a sibling partition under the same topic cannot see a transient empty inner map and double-allocate.

## Out of scope (deferred)

- **`Long` boxing** in `ConcurrentSkipListSet<Long>.add/remove` and the `compute*` lambdas — that's a data-structure change (would need a primitive-long sorted set). Separate PR.
- **The `Math.max` lambda** in `compute(... Math.max ...)` — JIT typically inlines the single call site; not worth a behavioral change for a sub-measurable win.

## Tests

- All existing `KafkaOffsetManagerTest` cases pass unchanged — behavior is identical.
- New `TopicPartitionCacheTests` nested class verifies:
  - The cached `TopicPartition` is `assertSame` across multiple track/mark calls for the same partition.
  - Revoked partitions are evicted from the cache after `onPartitionsRevoked`.
  - A fresh `TopicPartition` (`assertNotSame` to the original) is allocated after re-assignment of a previously-revoked partition.
  - Evicting one partition under a topic preserves cached siblings.

## Benchmark

`OffsetManagerBoxingBenchmark` drives `trackOffset` + `markOffsetProcessed` through the public API with pre-built synthetic `ConsumerRecord`s. Cache is pre-warmed in `@Setup` so the timed loop only exercises the fast path.

### Smoke run (single-shot, post-fix only — not a baseline)

```
# JMH 1.36, JDK 25.0.3 OpenJDK 64-Bit Server VM
# Warmup: 1 iteration, 2s; Measurement: 1 iteration, 3s; Fork: 1; Threads: 1

Benchmark                                  (partitions)   Mode  Cnt        Score   Error  Units
OffsetManagerBoxingBenchmark.trackAndMark             8  thrpt       3955634.128          ops/s
```

This is the cached path only — single-shot run intended just to verify the bench compiles and produces sensible numbers. **No baseline comparison is asserted here.** Run with full iteration counts plus `-prof gc` to capture the real before/after; the `gc.alloc.rate.norm` column is the primary signal (one `TopicPartition` instance ~= 24 bytes on a 64-bit JVM with compressed oops should disappear per record).

Reproduce:

```bash
./gradlew :benchmarks:jmh \
  -Pjmh.includes='OffsetManagerBoxingBenchmark' \
  -Pjmh.profilers='gc'
```

## Test plan

- [x] `./gradlew :lib:kpipe-consumer:test --tests "*KafkaOffsetManagerTest*"` — green
- [x] `./gradlew :benchmarks:compileJmhJava` — green
- [x] Smoke-run `OffsetManagerBoxingBenchmark` with `-i 1 -wi 1 -f 1` — produces sensible numbers
- [ ] Reviewer runs full JMH with `-prof gc` against `main` baseline + this branch to confirm allocation-rate drop