### PR TITLE
chore(jpms): remove unused requires, promote API-exposed deps to transitive

### DIFF
--- a/lib/kpipe-api/src/main/java/module-info.java
+++ b/lib/kpipe-api/src/main/java/module-info.java
@@ -13,9 +13,8 @@ module io.github.eschizoid.kpipe {
   requires transitive io.github.eschizoid.kpipe.format.json;
   requires transitive io.github.eschizoid.kpipe.format.avro;
   requires transitive io.github.eschizoid.kpipe.format.protobuf;
-  requires kafka.clients;
-  requires org.apache.avro;
-  requires com.google.protobuf;
+  requires transitive org.apache.avro;
+  requires transitive com.google.protobuf;
 
   exports io.github.eschizoid.kpipe;
 }

--- a/lib/kpipe-consumer/src/main/java/module-info.java
+++ b/lib/kpipe-consumer/src/main/java/module-info.java
@@ -5,9 +5,8 @@
 module io.github.eschizoid.kpipe.consumer {
   requires transitive io.github.eschizoid.kpipe.core;
   requires transitive io.github.eschizoid.kpipe.producer;
-  requires java.net.http;
   requires jdk.httpserver;
-  requires kafka.clients;
+  requires transitive kafka.clients;
 
   exports io.github.eschizoid.kpipe.consumer;
   exports io.github.eschizoid.kpipe.consumer.config;

--- a/lib/kpipe-format-avro/src/main/java/module-info.java
+++ b/lib/kpipe-format-avro/src/main/java/module-info.java
@@ -3,7 +3,7 @@
 /// Add this module to your build only if your pipeline consumes or produces Avro messages.
 module io.github.eschizoid.kpipe.format.avro {
   requires transitive io.github.eschizoid.kpipe.core;
-  requires org.apache.avro;
+  requires transitive org.apache.avro;
   // Jackson stays — Avro's EncoderFactory.jsonEncoder transitively exposes Jackson types in
   // AvroConsoleSink. The HTTP fetcher's direct use of JsonFactory / JsonToken has moved to
   // kpipe-schema-registry-confluent, but Avro itself still pulls Jackson at compile time.

--- a/lib/kpipe-format-protobuf/src/main/java/module-info.java
+++ b/lib/kpipe-format-protobuf/src/main/java/module-info.java
@@ -3,7 +3,7 @@
 /// Add this module to your build only if your pipeline consumes or produces Protobuf messages.
 module io.github.eschizoid.kpipe.format.protobuf {
   requires transitive io.github.eschizoid.kpipe.core;
-  requires com.google.protobuf;
+  requires transitive com.google.protobuf;
   requires com.google.protobuf.util;
 
   exports io.github.eschizoid.kpipe.format.protobuf;

--- a/lib/kpipe-metrics-otel/src/main/java/module-info.java
+++ b/lib/kpipe-metrics-otel/src/main/java/module-info.java
@@ -13,7 +13,7 @@
 /// Bring your own SDK (`io.opentelemetry:opentelemetry-sdk` + an exporter); this module only
 /// requires `opentelemetry-api`.
 module io.github.eschizoid.kpipe.metrics.otel {
-  requires io.github.eschizoid.kpipe.metrics;
+  requires transitive io.github.eschizoid.kpipe.metrics;
   requires transitive io.github.eschizoid.kpipe.core;
   requires io.opentelemetry.api;
 

--- a/lib/kpipe-producer/src/main/java/module-info.java
+++ b/lib/kpipe-producer/src/main/java/module-info.java
@@ -2,7 +2,7 @@
 module io.github.eschizoid.kpipe.producer {
   requires transitive io.github.eschizoid.kpipe.core;
   requires transitive io.github.eschizoid.kpipe.metrics;
-  requires kafka.clients;
+  requires transitive kafka.clients;
 
   exports io.github.eschizoid.kpipe.producer;
   exports io.github.eschizoid.kpipe.producer.config;

--- a/lib/kpipe-schema-registry-confluent/src/main/java/module-info.java
+++ b/lib/kpipe-schema-registry-confluent/src/main/java/module-info.java
@@ -15,7 +15,7 @@
 /// final var format = AvroFormat.of(schemaJson);
 /// ```
 module io.github.eschizoid.kpipe.schemaregistry.confluent {
-  requires io.github.eschizoid.kpipe.core;
+  requires transitive io.github.eschizoid.kpipe.core;
   requires java.net.http;
 
   exports io.github.eschizoid.kpipe.schemaregistry.confluent;

--- a/lib/kpipe-tracing-otel/src/main/java/module-info.java
+++ b/lib/kpipe-tracing-otel/src/main/java/module-info.java
@@ -14,7 +14,7 @@
 /// requires `opentelemetry-api`. Propagation is W3C-only in v1 (no B3, Datadog, or custom
 /// propagators).
 module io.github.eschizoid.kpipe.tracing.otel {
-  requires io.github.eschizoid.kpipe.producer;
+  requires transitive io.github.eschizoid.kpipe.producer;
   requires io.opentelemetry.api;
   requires kafka.clients;
   requires io.opentelemetry.context;


### PR DESCRIPTION
JPMS audit follow-up: tighten `module-info.java` across the module graph. **Build-metadata only — no behavior change.** Module-graph changes affect downstream consumers, so each one was verified by grep + a full clean compile (`compileJava` + `compileTestJava` across all modules, re-run with `--rerun-tasks` to defeat caching). All passed.

## Part A — remove unused `requires`

| Module | Removed | Verification grep |
|---|---|---|
| `kpipe-api` | `requires kafka.clients` | `grep -rn "org.apache.kafka" lib/kpipe-api/src/main/java/` → **no matches** (exit 1) |
| `kpipe-consumer` | `requires java.net.http` | `grep -rn "java.net.http" lib/kpipe-consumer/src/main/java/` → only match was the `module-info.java` declaration itself; the health server uses `jdk.httpserver` / `com.sun.net.httpserver`, which stays declared |

Both removals confirmed safe: no audit-missed usage, and the clean compile across all modules still succeeds.

## Part B — promote `requires` → `requires transitive`

Each promotion was confirmed by locating the required module's type on a public/exported signature before promoting:

| Module | Promoted | Public-API exposure (verified) |
|---|---|---|
| `kpipe-api` | `org.apache.avro` | `KPipe.avro(...)` returns `Stream<GenericRecord>` |
| `kpipe-api` | `com.google.protobuf` | `KPipe.protobuf(...)` returns `Stream<Message>` |
| `kpipe-consumer` | `kafka.clients` | `Builder.withConsumer(Supplier<Consumer<K,byte[]>>)`, `withKafkaProducer(Producer<K,byte[]>)`, `withOffsetManagerProvider(Function<Consumer<K,byte[]>, …>)` |
| `kpipe-producer` | `kafka.clients` | `KPipeProducer.Builder.withProducer(Producer<K,V>)`, `send(ProducerRecord)`, `sendAsync(ProducerRecord)` |
| `kpipe-metrics-otel` | `io.github.eschizoid.kpipe.metrics` | `OtelConsumerMetrics implements ConsumerMetrics` (and `OtelProducerMetrics implements ProducerMetrics`) |
| `kpipe-tracing-otel` | `io.github.eschizoid.kpipe.producer` | `OtelTracer implements Tracer` (`producer.tracing.Tracer`) |
| `kpipe-schema-registry-confluent` | `io.github.eschizoid.kpipe.core` | `CachedSchemaResolver` / `ConfluentSchemaResolver implements SchemaResolver` |
| `kpipe-format-avro` | `org.apache.avro` | `AvroFormat(Schema)` ctor, `implements MessageFormat<GenericRecord>` |
| `kpipe-format-protobuf` | `com.google.protobuf` | `ProtobufFormat(Descriptor)` ctor, `implements MessageFormat<Message>` |

**Deliberately NOT promoted** (internal-only, audit-confirmed correct as non-transitive):
- `com.fasterxml.jackson.core` in `kpipe-format-avro` — only leaks transitively through Avro's encoder internals; not on KPipe's own public surface.
- `com.google.protobuf.util` in `kpipe-format-protobuf` — internal-only (console-sink JSON formatting).

## Downstream module-graph impact

This changes the module graph for consumers of the facade. Because `kpipe-api` now `requires transitive org.apache.avro` / `com.google.protobuf`, and the format modules re-export their dependency types, **downstream consumers of `kpipe-api` no longer need to manually `requires org.apache.avro` / `requires com.google.protobuf`** in their own `module-info.java` to name `GenericRecord` / `Message` from the facade return types. Likewise, consumers of `kpipe-consumer` / `kpipe-producer` no longer need a manual `requires kafka.clients` to name the Kafka types those builders expose.

## Verification
- `./gradlew clean compileJava compileTestJava` across all modules — **BUILD SUCCESSFUL** (re-run with `--rerun-tasks`).
- A wrong `requires` removal would break compilation; nothing did, so no removal was reverted.

(Note: `./gradlew clean build` itself fails in this CI worktree only because the Spotless `ratchetFrom("origin/main")` jgit step can't resolve the worktree gitdir indirection — unrelated to these changes; `module-info.java` edits are not Spotless-formatted.)