### PR TITLE
fix(format): enrich SerDe error messages with format name + byte context

### DIFF
--- a/lib/kpipe-format-avro/src/main/java/io/github/eschizoid/kpipe/format/avro/AvroFormat.java
+++ b/lib/kpipe-format-avro/src/main/java/io/github/eschizoid/kpipe/format/avro/AvroFormat.java
@@ -138,7 +138,10 @@ public final class AvroFormat implements MessageFormat<GenericRecord> {
       encoder.flush();
       return output.toByteArray();
     } catch (final IOException e) {
-      throw new RuntimeException("Failed to serialize Avro record", e);
+      throw new RuntimeException(
+        "AvroFormat.serialize failed for record with schema " + data.getSchema().getFullName(),
+        e
+      );
     }
   }
 
@@ -159,8 +162,12 @@ public final class AvroFormat implements MessageFormat<GenericRecord> {
     final var decoder = DecoderFactory.get().binaryDecoder(data, null);
     try {
       return reader.read(null, decoder);
-    } catch (final IOException e) {
-      throw new RuntimeException("Failed to deserialize Avro record", e);
+    } catch (final IOException | RuntimeException e) {
+      throw new RuntimeException(
+        "AvroFormat.deserialize failed in static mode on " + data.length + " bytes against schema " +
+          staticSchema.getFullName(),
+        e
+      );
     }
   }
 

--- a/lib/kpipe-format-avro/src/test/java/io/github/eschizoid/kpipe/format/avro/AvroFormatBehaviorTest.java
+++ b/lib/kpipe-format-avro/src/test/java/io/github/eschizoid/kpipe/format/avro/AvroFormatBehaviorTest.java
@@ -4,6 +4,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.apache.avro.Schema;
 import org.apache.avro.SchemaParseException;
@@ -93,5 +94,16 @@ class AvroFormatBehaviorTest {
   void deserializeThrowsForGarbageBytes() {
     final var format = AvroFormat.of(USER_SCHEMA_JSON);
     assertThrows(RuntimeException.class, () -> format.deserialize(new byte[] { 0x7f, 0x7f, 0x7f }));
+  }
+
+  @Test
+  void deserializeErrorMessageCarriesFormatNameAndByteLength() {
+    final var format = AvroFormat.of(USER_SCHEMA_JSON);
+    final var garbage = new byte[] { 0x7f, 0x7f, 0x7f };
+    final var thrown = assertThrows(RuntimeException.class, () -> format.deserialize(garbage));
+    final var message = thrown.getMessage();
+    assertTrue(message.contains("AvroFormat"), () -> "message should name the format: " + message);
+    assertTrue(message.contains(garbage.length + " bytes"), () -> "message should report the byte length: " + message);
+    assertTrue(message.contains("com.example.User"), () -> "message should name the schema: " + message);
   }
 }

--- a/lib/kpipe-format-json/src/main/java/io/github/eschizoid/kpipe/format/json/JsonFormat.java
+++ b/lib/kpipe-format-json/src/main/java/io/github/eschizoid/kpipe/format/json/JsonFormat.java
@@ -4,6 +4,7 @@ import com.alibaba.fastjson2.JSON;
 import com.alibaba.fastjson2.JSONException;
 import com.alibaba.fastjson2.JSONFactory;
 import io.github.eschizoid.kpipe.registry.MessageFormat;
+import java.util.HexFormat;
 import java.util.Map;
 
 /// JSON implementation of [MessageFormat] for KPipe.
@@ -52,7 +53,7 @@ public final class JsonFormat implements MessageFormat<Map<String, Object>> {
     try {
       return JSON.toJSONBytes(data);
     } catch (final JSONException e) {
-      throw new RuntimeException("Failed to serialize JSON", e);
+      throw new RuntimeException("JsonFormat.serialize failed for map with " + data.size() + " entries", e);
     }
   }
 
@@ -66,7 +67,24 @@ public final class JsonFormat implements MessageFormat<Map<String, Object>> {
     try {
       return JSON.parseObject(data);
     } catch (final JSONException e) {
-      throw new RuntimeException("Failed to deserialize JSON", e);
+      throw new RuntimeException(
+        "JsonFormat.deserialize failed on " + data.length + " bytes (first bytes " + hexPreview(data) + ")",
+        e
+      );
     }
   }
+
+  /// Renders a short hex preview of the leading bytes of `data` for diagnostics, capped at
+  /// [#HEX_PREVIEW_LIMIT] bytes. Handles empty/short arrays without throwing.
+  ///
+  /// @param data the byte array to preview (never null at the call site)
+  /// @return space-separated lowercase hex of the leading bytes, with a trailing ellipsis when truncated
+  private static String hexPreview(final byte[] data) {
+    final var count = Math.min(data.length, HEX_PREVIEW_LIMIT);
+    final var hex = HexFormat.ofDelimiter(" ").formatHex(data, 0, count);
+    return count < data.length ? hex + " ..." : hex;
+  }
+
+  /// Maximum number of leading bytes rendered by [#hexPreview].
+  private static final int HEX_PREVIEW_LIMIT = 8;
 }

--- a/lib/kpipe-format-json/src/test/java/io/github/eschizoid/kpipe/format/json/JsonFormatTest.java
+++ b/lib/kpipe-format-json/src/test/java/io/github/eschizoid/kpipe/format/json/JsonFormatTest.java
@@ -1,0 +1,36 @@
+package io.github.eschizoid.kpipe.format.json;
+
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.nio.charset.StandardCharsets;
+import org.junit.jupiter.api.Test;
+
+class JsonFormatTest {
+
+  @Test
+  void deserializeReturnsNullForNullOrEmptyBytes() {
+    assertNull(JsonFormat.INSTANCE.deserialize(null));
+    assertNull(JsonFormat.INSTANCE.deserialize(new byte[0]));
+  }
+
+  @Test
+  void deserializeErrorMessageCarriesFormatNameAndByteLength() {
+    final var malformed = "{\"a\":".getBytes(StandardCharsets.UTF_8);
+    final var thrown = assertThrows(RuntimeException.class, () -> JsonFormat.INSTANCE.deserialize(malformed));
+    final var message = thrown.getMessage();
+    assertTrue(message.contains("JsonFormat"), () -> "message should name the format: " + message);
+    assertTrue(
+      message.contains(malformed.length + " bytes"),
+      () -> "message should report the byte length: " + message
+    );
+  }
+
+  @Test
+  void deserializeErrorMessageHandlesShortPayloadWithoutThrowing() {
+    final var shortMalformed = new byte[] { (byte) 0xff, (byte) 0xfe };
+    final var thrown = assertThrows(RuntimeException.class, () -> JsonFormat.INSTANCE.deserialize(shortMalformed));
+    assertTrue(thrown.getMessage().contains("2 bytes"), () -> "message: " + thrown.getMessage());
+  }
+}

--- a/lib/kpipe-format-protobuf/src/main/java/io/github/eschizoid/kpipe/format/protobuf/ProtobufFormat.java
+++ b/lib/kpipe-format-protobuf/src/main/java/io/github/eschizoid/kpipe/format/protobuf/ProtobufFormat.java
@@ -5,6 +5,7 @@ import com.google.protobuf.DynamicMessage;
 import com.google.protobuf.InvalidProtocolBufferException;
 import com.google.protobuf.Message;
 import io.github.eschizoid.kpipe.registry.MessageFormat;
+import java.util.HexFormat;
 import java.util.Objects;
 
 /// Protobuf codec for KPipe — stateless `MessageFormat<Message>` bound to a single
@@ -58,7 +59,25 @@ public final class ProtobufFormat implements MessageFormat<Message> {
     try {
       return DynamicMessage.parseFrom(descriptor, data);
     } catch (final InvalidProtocolBufferException e) {
-      throw new RuntimeException("Failed to deserialize Protobuf message", e);
+      throw new RuntimeException(
+        "ProtobufFormat.deserialize failed on " + data.length + " bytes for descriptor " + descriptor.getFullName() +
+          " (first bytes " + hexPreview(data) + ") — if using Confluent wire format, check skipBytes(6)",
+        e
+      );
     }
   }
+
+  /// Renders a short hex preview of the leading bytes of `data` for diagnostics, capped at
+  /// [#HEX_PREVIEW_LIMIT] bytes. Handles empty/short arrays without throwing.
+  ///
+  /// @param data the byte array to preview (never null at the call site)
+  /// @return space-separated lowercase hex of the leading bytes, with a trailing ellipsis when truncated
+  private static String hexPreview(final byte[] data) {
+    final var count = Math.min(data.length, HEX_PREVIEW_LIMIT);
+    final var hex = HexFormat.ofDelimiter(" ").formatHex(data, 0, count);
+    return count < data.length ? hex + " ..." : hex;
+  }
+
+  /// Maximum number of leading bytes rendered by [#hexPreview].
+  private static final int HEX_PREVIEW_LIMIT = 8;
 }

--- a/lib/kpipe-format-protobuf/src/test/java/io/github/eschizoid/kpipe/format/protobuf/ProtobufFormatTest.java
+++ b/lib/kpipe-format-protobuf/src/test/java/io/github/eschizoid/kpipe/format/protobuf/ProtobufFormatTest.java
@@ -78,6 +78,16 @@ class ProtobufFormatTest {
     assertThrows(RuntimeException.class, () -> format.deserialize(new byte[] { (byte) 0xFF, (byte) 0xFF }));
   }
 
+  @Test
+  void deserializeErrorMessageCarriesFormatNameAndByteLength() {
+    final var garbage = new byte[] { (byte) 0xFF, (byte) 0xFF };
+    final var thrown = assertThrows(RuntimeException.class, () -> format.deserialize(garbage));
+    final var message = thrown.getMessage();
+    assertTrue(message.contains("ProtobufFormat"), () -> "message should name the format: " + message);
+    assertTrue(message.contains(garbage.length + " bytes"), () -> "message should report the byte length: " + message);
+    assertTrue(message.contains(descriptor.getFullName()), () -> "message should name the descriptor: " + message);
+  }
+
   private static Descriptors.Descriptor buildTestDescriptor() throws Descriptors.DescriptorValidationException {
     final var msg = DescriptorProtos.DescriptorProto.newBuilder()
       .setName("TestMessage")


### PR DESCRIPTION
## Why

The no-silent-failures doctrine exists because a wrong `skipBytes(5)` once made protobuf deserialization fail while a "processed" counter kept rising. The doctrine cares about the **signal** when deserialize genuinely throws — and that signal is the message + cause chain. The bare `"Failed to deserialize X"` messages buried the format name and byte context behind the nested cause, so an operator triaging a log line couldn't tell **which** format, **how many** bytes, or **what mode** without unwrapping the stack trace.

## What

- **JsonFormat.deserialize** — message now reports input byte length + a short leading-byte hex preview. `serialize` reports the map entry count.
- **ProtobufFormat.deserialize** — message reports byte length, `descriptor.getFullName()`, leading-byte hex preview, and a Confluent-envelope `skipBytes(6)` hint.
- **AvroFormat** — static-mode deserialize message reports byte length + `staticSchema.getFullName()`, matching the quality of the existing envelope path. `serialize` reports the record's schema name. Static deserialize now also catches Avro's own `RuntimeException` decode failures (e.g. "Malformed data. Length is negative") so the enriched message wins instead of the bare buried one — previously the most common malformed-bytes failure escaped uncaught.

## Constraints honored

- Exception **type** unchanged — still `RuntimeException` wrapping the original cause. Only the message changed; callers catching `RuntimeException` are unaffected.
- Hex-preview helper caps at 8 bytes and handles empty/short arrays without throwing (a deserialize error on a 0- or 2-byte payload still produces a clean message, no AIOOBE).
- Messages are single-line (no embedded newlines) for log friendliness.

## Tests

Each format gains a malformed-bytes test asserting the thrown message contains the format name AND the byte length, pinning the triage-signal contract. `JsonFormatTest` is new (JSON previously had only pipeline/registry tests); Avro and Protobuf tests are extended.

`./gradlew :lib:kpipe-format-json:test :lib:kpipe-format-avro:test :lib:kpipe-format-protobuf:test` — green.