### PR TITLE
fix: include offending value + remediation in validation error messages

### DIFF
--- a/lib/kpipe-api/src/main/java/io/github/eschizoid/kpipe/DefaultStream.java
+++ b/lib/kpipe-api/src/main/java/io/github/eschizoid/kpipe/DefaultStream.java
@@ -157,7 +157,7 @@ record DefaultStream<T>(
   @Override
   public Stream<T> withBackpressure(final long high, final long low) {
     if (low < 0 || low >= high) throw new IllegalArgumentException(
-      "Invalid watermarks: high must be positive and > low (got high=%d, low=%d)".formatted(high, low)
+      "withBackpressure requires high > low > 0 (got high=%d, low=%d)".formatted(high, low)
     );
     return mutate(m -> {
       m.backpressureHigh = high;

--- a/lib/kpipe-api/src/main/java/io/github/eschizoid/kpipe/MultiBuilder.java
+++ b/lib/kpipe-api/src/main/java/io/github/eschizoid/kpipe/MultiBuilder.java
@@ -217,7 +217,9 @@ public final class MultiBuilder {
   /// @return a [Handle] for lifecycle management
   /// @throws IllegalStateException if no routes have been registered
   public Handle start() {
-    if (routes.isEmpty()) throw new IllegalStateException("at least one route is required");
+    if (routes.isEmpty()) throw new IllegalStateException(
+      "MultiBuilder.start() requires at least one route — call .json(...) / .avro(...) / .protobuf(...) / .bytes(...) / .custom(...) before start()."
+    );
 
     final var nonBatchPipelines = new LinkedHashMap<String, MessagePipeline<?>>();
     final var consumerBuilder = KPipeConsumer.<byte[]>builder().withProperties(kafkaProps);

--- a/lib/kpipe-api/src/test/java/io/github/eschizoid/kpipe/StreamCompositionTest.java
+++ b/lib/kpipe-api/src/test/java/io/github/eschizoid/kpipe/StreamCompositionTest.java
@@ -3,6 +3,7 @@ package io.github.eschizoid.kpipe;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.HashMap;
@@ -36,6 +37,17 @@ class StreamCompositionTest {
       if (v == null) return null;
     }
     return v;
+  }
+
+  @Test
+  void withBackpressureRejectsInvalidWatermarksWithOffendingValues() {
+    final var stream = KPipe.json("topic", props());
+    final var thrown = assertThrows(
+      IllegalArgumentException.class, () -> stream.withBackpressure(5, 10));
+    assertTrue(
+      thrown.getMessage().contains("got high=5, low=10"), () -> "msg was: " + thrown.getMessage());
+    assertTrue(
+      thrown.getMessage().contains("withBackpressure"), () -> "msg was: " + thrown.getMessage());
   }
 
   @Test

--- a/lib/kpipe-consumer/src/main/java/io/github/eschizoid/kpipe/consumer/BackpressureController.java
+++ b/lib/kpipe-consumer/src/main/java/io/github/eschizoid/kpipe/consumer/BackpressureController.java
@@ -109,8 +109,8 @@ public record BackpressureController(long highWatermark, long lowWatermark, Stra
   /// @param lowWatermark the metric value at or below which the consumer should resume
   /// @param strategy the strategy to use for calculating the metric
   public BackpressureController {
-    if (highWatermark <= 0) throw new IllegalArgumentException("highWatermark must be positive");
-    if (lowWatermark < 0) throw new IllegalArgumentException("lowWatermark cannot be negative");
+    if (highWatermark <= 0) throw new IllegalArgumentException("highWatermark must be positive, got " + highWatermark);
+    if (lowWatermark < 0) throw new IllegalArgumentException("lowWatermark cannot be negative, got " + lowWatermark);
     if (lowWatermark >= highWatermark) throw new IllegalArgumentException(
       "lowWatermark (%d) must be less than highWatermark (%d)".formatted(lowWatermark, highWatermark)
     );

--- a/lib/kpipe-consumer/src/main/java/io/github/eschizoid/kpipe/consumer/KPipeConsumer.java
+++ b/lib/kpipe-consumer/src/main/java/io/github/eschizoid/kpipe/consumer/KPipeConsumer.java
@@ -697,9 +697,9 @@ public class KPipeConsumer<K> implements AutoCloseable {
       union.addAll(regularTopics);
       union.addAll(batchSpecs.keySet());
       this.topics = union;
-      if (maxRetries < 0) throw new IllegalArgumentException("Max retries cannot be negative");
+      if (maxRetries < 0) throw new IllegalArgumentException("Max retries cannot be negative, got " + maxRetries);
       if (pollTimeout.isNegative() || pollTimeout.isZero()) throw new IllegalArgumentException(
-        "Poll timeout must be positive"
+        "Poll timeout must be positive, got " + pollTimeout
       );
       if (offsetManager != null || offsetManagerProvider != null) kafkaProps.setProperty("enable.auto.commit", "false");
       if (backpressureController != null && processingMode == ProcessingMode.SEQUENTIAL) {

--- a/lib/kpipe-consumer/src/main/java/io/github/eschizoid/kpipe/consumer/KafkaOffsetManager.java
+++ b/lib/kpipe-consumer/src/main/java/io/github/eschizoid/kpipe/consumer/KafkaOffsetManager.java
@@ -130,7 +130,7 @@ public class KafkaOffsetManager<K> implements OffsetManager<K> {
     public Builder<K> withCommitInterval(final Duration interval) {
       this.commitInterval = Objects.requireNonNull(interval, "Commit interval cannot be null");
       if (interval.isNegative() || interval.isZero()) throw new IllegalArgumentException(
-        "Commit interval must be positive"
+        "Commit interval must be positive, got " + interval
       );
       return this;
     }
@@ -139,7 +139,7 @@ public class KafkaOffsetManager<K> implements OffsetManager<K> {
     ///
     /// @return A new KafkaOffsetManager instance
     public KafkaOffsetManager<K> build() {
-      if (commandQueue == null) throw new IllegalStateException("Command queue must be provided");
+      if (commandQueue == null) throw new IllegalStateException("withCommandQueue(...) must be called before build()");
       return new KafkaOffsetManager<>(this);
     }
   }

--- a/lib/kpipe-consumer/src/test/java/io/github/eschizoid/kpipe/consumer/BackpressureControllerTest.java
+++ b/lib/kpipe-consumer/src/test/java/io/github/eschizoid/kpipe/consumer/BackpressureControllerTest.java
@@ -45,6 +45,18 @@ class BackpressureControllerTest {
     assertThrows(IllegalArgumentException.class, () -> new BackpressureController(500, 1000, DUMMY_STRATEGY));
   }
 
+  @Test
+  void shouldIncludeOffendingValueInWatermarkMessages() {
+    final var highThrown = assertThrows(
+      IllegalArgumentException.class, () -> new BackpressureController(-7, 0, DUMMY_STRATEGY));
+    assertTrue(
+      highThrown.getMessage().contains("got -7"), () -> "msg was: " + highThrown.getMessage());
+
+    final var lowThrown = assertThrows(
+      IllegalArgumentException.class, () -> new BackpressureController(1000, -3, DUMMY_STRATEGY));
+    assertTrue(lowThrown.getMessage().contains("got -3"), () -> "msg was: " + lowThrown.getMessage());
+  }
+
   @ParameterizedTest(name = "value={0}, paused={1} → {2}")
   @CsvSource(
     {


### PR DESCRIPTION
## What

Validation throws that stated the rule but omitted the offending value (or omitted how to fix). Several sibling validations in the same files already do it right (include `got ` + value); this PR makes them consistent. These are message-only changes on existing throw sites — **exception types are unchanged**.

## Fixes

1. **`BackpressureController` ctor** — `highWatermark must be positive` / `lowWatermark cannot be negative` now append `, got <value>`, matching the existing `lowWatermark (%d) must be less than highWatermark (%d)` sibling.
2. **`KafkaOffsetManager.Builder.withCommitInterval`** — `Commit interval must be positive` → appends `, got <interval>`.
3. **`KPipeConsumer.Builder.build`** — `Poll timeout must be positive` / `Max retries cannot be negative` now append the got-value, matching the sibling `maxKeys`/`interval` checks.
4. **`DefaultStream.withBackpressure(long,long)`** — `Invalid watermarks: high must be positive and > low (got high=%d, low=%d)` → `withBackpressure requires high > low > 0 (got high=%d, low=%d)`. Names the entry point, drops the meta-word "Invalid".
5. **`MultiBuilder.start`** — `at least one route is required` → names the API and the route methods to call before `start()`.
6. **(LOW)** **`KafkaOffsetManager.Builder.build`** — `Command queue must be provided` → `withCommandQueue(...) must be called before build()`. Escape-hatch API, low urgency, cheap.

Out of scope: the `ConsumerHealthController` "hook cannot be null" finding (internal-ish constructor param, not user-facing).

## Tests

- Added focused got-value tests for the two most user-facing cases: `BackpressureControllerTest.shouldIncludeOffendingValueInWatermarkMessages` and `StreamCompositionTest.withBackpressureRejectsInvalidWatermarksWithOffendingValues`.
- No existing test asserted any of the changed strings, so nothing needed updating. The trivial string-only changes are not over-tested.

`./gradlew :lib:kpipe-consumer:test :lib:kpipe-api:test` is green except two Testcontainers integration tests that fail to initialize because no Docker daemon is available in this environment (`DockerClientProviderStrategy` init error) — unrelated to this change.