### PR TITLE
fix(consumer): close resources on constructor-failure paths

### DIFF
--- a/lib/kpipe-consumer/src/main/java/io/github/eschizoid/kpipe/consumer/KPipeConsumer.java
+++ b/lib/kpipe-consumer/src/main/java/io/github/eschizoid/kpipe/consumer/KPipeConsumer.java
@@ -725,183 +725,254 @@ public class KPipeConsumer<K> implements AutoCloseable {
   ///
   /// @param builder the builder containing the consumer configuration
   public KPipeConsumer(final Builder<K> builder) {
-    this.kafkaConsumer =
-      builder.consumerProvider != null
-        ? builder.consumerProvider.get()
-        : new KafkaConsumer<>(Objects.requireNonNull(builder.kafkaProps));
-    this.topics = Set.copyOf(Objects.requireNonNull(builder.topics, "Topics must be set"));
-    // `build()` sets `topics` to the UNION of regular + batch routes for Kafka subscription, so
-    // the homogeneous branch must filter out batch-route topics to avoid replicating the regular
-    // pipeline onto a topic that's owned by a batch wrapper.
-    if (builder.pipelinesPerTopic != null) {
-      this.pipelines = builder.pipelinesPerTopic;
-    } else if (builder.pipeline != null) {
-      final var map = new LinkedHashMap<String, MessagePipeline<?>>(builder.topics.size());
-      for (final var t : builder.topics) if (!builder.batchSpecs.containsKey(t)) map.put(t, builder.pipeline);
-      this.pipelines = Map.copyOf(map);
-    } else {
-      this.pipelines = Map.of();
-    }
-    this.pollTimeout = Objects.requireNonNull(builder.pollTimeout);
-    this.errorHandler = builder.errorHandler;
-    this.maxRetries = builder.maxRetries;
-    this.retryBackoff = builder.retryBackoff;
-    this.processingMode = builder.processingMode;
-    this.waitForMessagesTimeout = builder.waitForMessagesTimeout;
-    this.threadTerminationTimeout = builder.threadTerminationTimeout;
-    this.executorTerminationTimeout = builder.executorTerminationTimeout;
-    this.dispatcher = switch (this.processingMode) {
-      case SEQUENTIAL -> new SequentialDispatcher<>();
-      case PARALLEL -> new ParallelDispatcher<>(this::handleParallelRejection, this.executorTerminationTimeout);
-      case KEY_ORDERED -> new KeyOrderedDispatcher<>(builder.keyOrderedMaxKeys);
-    };
-    this.offsetManager =
-      builder.offsetManager != null
-        ? builder.offsetManager
-        : builder.offsetManagerProvider != null
-          ? builder.offsetManagerProvider.apply(this.kafkaConsumer)
-          : null;
-    this.commandQueue = builder.commandQueue != null ? builder.commandQueue : new ConcurrentLinkedQueue<>();
-    this.rebalanceListener =
-      builder.rebalanceListener != null
-        ? builder.rebalanceListener
-        : (this.offsetManager != null ? this.offsetManager.createRebalanceListener() : null);
-
-    final var bp = (
-      builder.backpressureController != null
-        ? builder.backpressureController
-        : new BackpressureController(
-            BackpressureController.DEFAULT_HIGH_WATERMARK,
-            BackpressureController.DEFAULT_LOW_WATERMARK,
-            null
-          )
-    ).withStrategy(
-      this.processingMode == ProcessingMode.SEQUENTIAL
-        ? BackpressureController.lagStrategy()
-        : BackpressureController.inFlightStrategy(this::totalInFlight)
-    );
-
-    this.tracer = builder.tracer != null ? builder.tracer : Tracer.noop();
-
-    this.deadLetterTopic = builder.deadLetterTopic;
-    this.kpipeProducer =
-      builder.kpipeProducer != null
-        ? builder.kpipeProducer
-        : this.deadLetterTopic != null
-          ? KPipeProducer.<K, byte[]>builder().withProperties(builder.kafkaProps).withTracer(this.tracer).build()
-          : null;
-
-    final var needScheduler = !builder.batchSpecs.isEmpty() || builder.circuitBreakerController != null;
-    if (needScheduler) {
-      this.scheduler = Executors.newSingleThreadScheduledExecutor(r -> {
-        final var t = Thread.ofVirtual().unstarted(r);
-        t.setName("kpipe-scheduler");
-        return t;
-      });
-    } else {
-      this.scheduler = null;
-    }
-
-    if (!builder.batchSpecs.isEmpty()) {
-      final var wrappers = new LinkedHashMap<String, BatchPipelineWrapper<K, ?>>(builder.batchSpecs.size());
-      for (final var entry : builder.batchSpecs.entrySet()) {
-        wrappers.put(entry.getKey(), createBatchWrapper(entry.getValue()));
+    // The constructor opens resources in sequence: the Kafka consumer, the dispatcher (PARALLEL
+    // owns a virtual-thread executor), an optional built-in DLQ producer, an optional scheduler,
+    // the batch wrappers, and a JVM shutdown hook. If any step after the first open throws — e.g.
+    // addShutdownHook while the JVM is already shutting down, or a user-supplied
+    // metrics/tracer/circuit-breaker whose construction work throws — everything already opened
+    // would leak for the JVM lifetime. Wrap construction so any throwable triggers reverse-order
+    // cleanup of whatever was opened, then rethrow with cleanup failures suppressed onto it.
+    try {
+      this.kafkaConsumer =
+        builder.consumerProvider != null
+          ? builder.consumerProvider.get()
+          : new KafkaConsumer<>(Objects.requireNonNull(builder.kafkaProps));
+      this.topics = Set.copyOf(Objects.requireNonNull(builder.topics, "Topics must be set"));
+      // `build()` sets `topics` to the UNION of regular + batch routes for Kafka subscription, so
+      // the homogeneous branch must filter out batch-route topics to avoid replicating the regular
+      // pipeline onto a topic that's owned by a batch wrapper.
+      if (builder.pipelinesPerTopic != null) {
+        this.pipelines = builder.pipelinesPerTopic;
+      } else if (builder.pipeline != null) {
+        final var map = new LinkedHashMap<String, MessagePipeline<?>>(builder.topics.size());
+        for (final var t : builder.topics) if (!builder.batchSpecs.containsKey(t)) map.put(t, builder.pipeline);
+        this.pipelines = Map.copyOf(map);
+      } else {
+        this.pipelines = Map.of();
       }
-      this.batchWrappers = Map.copyOf(wrappers);
-    } else {
-      this.batchWrappers = Map.of();
-    }
+      this.pollTimeout = Objects.requireNonNull(builder.pollTimeout);
+      this.errorHandler = builder.errorHandler;
+      this.maxRetries = builder.maxRetries;
+      this.retryBackoff = builder.retryBackoff;
+      this.processingMode = builder.processingMode;
+      this.waitForMessagesTimeout = builder.waitForMessagesTimeout;
+      this.threadTerminationTimeout = builder.threadTerminationTimeout;
+      this.executorTerminationTimeout = builder.executorTerminationTimeout;
+      this.dispatcher = switch (this.processingMode) {
+        case SEQUENTIAL -> new SequentialDispatcher<>();
+        case PARALLEL -> new ParallelDispatcher<>(this::handleParallelRejection, this.executorTerminationTimeout);
+        case KEY_ORDERED -> new KeyOrderedDispatcher<>(builder.keyOrderedMaxKeys);
+      };
+      this.offsetManager =
+        builder.offsetManager != null
+          ? builder.offsetManager
+          : builder.offsetManagerProvider != null
+            ? builder.offsetManagerProvider.apply(this.kafkaConsumer)
+            : null;
+      this.commandQueue = builder.commandQueue != null ? builder.commandQueue : new ConcurrentLinkedQueue<>();
+      this.rebalanceListener =
+        builder.rebalanceListener != null
+          ? builder.rebalanceListener
+          : (this.offsetManager != null ? this.offsetManager.createRebalanceListener() : null);
 
-    this.metricsReporters = List.copyOf(builder.metricsReporters);
-    this.metricsReporterInterval = builder.metricsReporterInterval;
-    this.useShutdownHook = builder.useShutdownHook;
-    if (this.useShutdownHook) {
-      this.shutdownHookThread = new Thread(this::close, "kpipe-shutdown-hook");
-      Runtime.getRuntime().addShutdownHook(this.shutdownHookThread);
-    }
-
-    if (builder.backpressureController == null) {
-      LOGGER.log(
-        Level.INFO,
-        "No backpressure configured, using default {0} strategy (high={1}, low={2})",
-        bp.getMetricName(),
-        bp.highWatermark(),
-        bp.lowWatermark()
+      final var bp = (
+        builder.backpressureController != null
+          ? builder.backpressureController
+          : new BackpressureController(
+              BackpressureController.DEFAULT_HIGH_WATERMARK,
+              BackpressureController.DEFAULT_LOW_WATERMARK,
+              null
+            )
+      ).withStrategy(
+        this.processingMode == ProcessingMode.SEQUENTIAL
+          ? BackpressureController.lagStrategy()
+          : BackpressureController.inFlightStrategy(this::totalInFlight)
       );
+
+      this.tracer = builder.tracer != null ? builder.tracer : Tracer.noop();
+
+      this.deadLetterTopic = builder.deadLetterTopic;
+      this.kpipeProducer =
+        builder.kpipeProducer != null
+          ? builder.kpipeProducer
+          : this.deadLetterTopic != null
+            ? KPipeProducer.<K, byte[]>builder().withProperties(builder.kafkaProps).withTracer(this.tracer).build()
+            : null;
+
+      final var needScheduler = !builder.batchSpecs.isEmpty() || builder.circuitBreakerController != null;
+      if (needScheduler) {
+        this.scheduler = Executors.newSingleThreadScheduledExecutor(r -> {
+          final var t = Thread.ofVirtual().unstarted(r);
+          t.setName("kpipe-scheduler");
+          return t;
+        });
+      } else {
+        this.scheduler = null;
+      }
+
+      if (!builder.batchSpecs.isEmpty()) {
+        final var wrappers = new LinkedHashMap<String, BatchPipelineWrapper<K, ?>>(builder.batchSpecs.size());
+        for (final var entry : builder.batchSpecs.entrySet()) {
+          wrappers.put(entry.getKey(), createBatchWrapper(entry.getValue()));
+        }
+        this.batchWrappers = Map.copyOf(wrappers);
+      } else {
+        this.batchWrappers = Map.of();
+      }
+
+      this.metricsReporters = List.copyOf(builder.metricsReporters);
+      this.metricsReporterInterval = builder.metricsReporterInterval;
+      this.useShutdownHook = builder.useShutdownHook;
+      if (this.useShutdownHook) {
+        this.shutdownHookThread = new Thread(this::close, "kpipe-shutdown-hook");
+        Runtime.getRuntime().addShutdownHook(this.shutdownHookThread);
+      }
+
+      if (builder.backpressureController == null) {
+        LOGGER.log(
+          Level.INFO,
+          "No backpressure configured, using default {0} strategy (high={1}, low={2})",
+          bp.getMetricName(),
+          bp.highWatermark(),
+          bp.lowWatermark()
+        );
+      }
+
+      metrics.putAll(
+        Map.of(
+          METRIC_MESSAGES_RECEIVED,
+          new AtomicLong(0),
+          METRIC_MESSAGES_PROCESSED,
+          new AtomicLong(0),
+          METRIC_PROCESSING_ERRORS,
+          new AtomicLong(0),
+          METRIC_PROCESSING_DURATION_TOTAL_MS,
+          new AtomicLong(0),
+          METRIC_RETRIES,
+          new AtomicLong(0),
+          METRIC_BACKPRESSURE_PAUSE_COUNT,
+          new AtomicLong(0),
+          METRIC_BACKPRESSURE_TIME_MS,
+          new AtomicLong(0),
+          METRIC_CIRCUIT_BREAKER_TRIPS,
+          new AtomicLong(0),
+          METRIC_CIRCUIT_BREAKER_TIME_OPEN_MS,
+          new AtomicLong(0),
+          METRIC_DLQ_SENT,
+          new AtomicLong(0)
+        )
+      );
+
+      this.otelMetrics = builder.consumerMetrics != null ? builder.consumerMetrics : ConsumerMetrics.noop();
+
+      this.health = new ConsumerHealthController(
+        bp,
+        builder.circuitBreakerController,
+        this.scheduler,
+        new ConsumerHealthController.Hook() {
+          @Override
+          public void onPause() {
+            internalPause();
+          }
+
+          @Override
+          public void onResume() {
+            internalResume();
+          }
+
+          @Override
+          public void onBackpressurePause() {
+            metrics.get(METRIC_BACKPRESSURE_PAUSE_COUNT).incrementAndGet();
+            otelMetrics.recordBackpressurePause();
+          }
+
+          @Override
+          public void onBackpressureTimeMs(final long ms) {
+            metrics.get(METRIC_BACKPRESSURE_TIME_MS).addAndGet(ms);
+            otelMetrics.recordBackpressureTime(ms);
+          }
+
+          @Override
+          public void onCircuitBreakerTrip() {
+            metrics.get(METRIC_CIRCUIT_BREAKER_TRIPS).incrementAndGet();
+            otelMetrics.recordCircuitBreakerTrip();
+          }
+
+          @Override
+          public void onCircuitBreakerStateChange(final CircuitBreakerState state) {
+            otelMetrics.recordCircuitBreakerStateChange(state);
+          }
+
+          @Override
+          public void onCircuitBreakerTimeOpenMs(final long ms) {
+            metrics.get(METRIC_CIRCUIT_BREAKER_TIME_OPEN_MS).addAndGet(ms);
+            otelMetrics.recordCircuitBreakerTimeOpen(ms);
+          }
+        }
+      );
+    } catch (final Throwable t) {
+      closePartiallyConstructed(t);
+      throw t;
     }
+  }
 
-    metrics.putAll(
-      Map.of(
-        METRIC_MESSAGES_RECEIVED,
-        new AtomicLong(0),
-        METRIC_MESSAGES_PROCESSED,
-        new AtomicLong(0),
-        METRIC_PROCESSING_ERRORS,
-        new AtomicLong(0),
-        METRIC_PROCESSING_DURATION_TOTAL_MS,
-        new AtomicLong(0),
-        METRIC_RETRIES,
-        new AtomicLong(0),
-        METRIC_BACKPRESSURE_PAUSE_COUNT,
-        new AtomicLong(0),
-        METRIC_BACKPRESSURE_TIME_MS,
-        new AtomicLong(0),
-        METRIC_CIRCUIT_BREAKER_TRIPS,
-        new AtomicLong(0),
-        METRIC_CIRCUIT_BREAKER_TIME_OPEN_MS,
-        new AtomicLong(0),
-        METRIC_DLQ_SENT,
-        new AtomicLong(0)
-      )
-    );
-
-    this.otelMetrics = builder.consumerMetrics != null ? builder.consumerMetrics : ConsumerMetrics.noop();
-
-    this.health = new ConsumerHealthController(
-      bp,
-      builder.circuitBreakerController,
-      this.scheduler,
-      new ConsumerHealthController.Hook() {
-        @Override
-        public void onPause() {
-          internalPause();
-        }
-
-        @Override
-        public void onResume() {
-          internalResume();
-        }
-
-        @Override
-        public void onBackpressurePause() {
-          metrics.get(METRIC_BACKPRESSURE_PAUSE_COUNT).incrementAndGet();
-          otelMetrics.recordBackpressurePause();
-        }
-
-        @Override
-        public void onBackpressureTimeMs(final long ms) {
-          metrics.get(METRIC_BACKPRESSURE_TIME_MS).addAndGet(ms);
-          otelMetrics.recordBackpressureTime(ms);
-        }
-
-        @Override
-        public void onCircuitBreakerTrip() {
-          metrics.get(METRIC_CIRCUIT_BREAKER_TRIPS).incrementAndGet();
-          otelMetrics.recordCircuitBreakerTrip();
-        }
-
-        @Override
-        public void onCircuitBreakerStateChange(final CircuitBreakerState state) {
-          otelMetrics.recordCircuitBreakerStateChange(state);
-        }
-
-        @Override
-        public void onCircuitBreakerTimeOpenMs(final long ms) {
-          metrics.get(METRIC_CIRCUIT_BREAKER_TIME_OPEN_MS).addAndGet(ms);
-          otelMetrics.recordCircuitBreakerTimeOpen(ms);
+  /// Closes whatever the constructor managed to open before a later init step threw, in reverse
+  /// of the open order — shutdown hook, scheduler, producer, batch wrappers, dispatcher, Kafka
+  /// consumer. Each field is read off `this` (a partially-constructed instance leaves the
+  /// not-yet-assigned ones at their default `null`), so every step is null-guarded. Cleanup
+  /// failures are suppressed onto the original throwable rather than masking it. Mirrors the
+  /// ownership rules of `releaseConstructedResources` / the consumer-thread teardown: the Kafka
+  /// consumer and the DLQ producer are closed regardless of whether they were supplied or built
+  /// internally, because once handed to the consumer they are consumer-owned.
+  private void closePartiallyConstructed(final Throwable original) {
+    if (shutdownHookThread != null) {
+      try {
+        Runtime.getRuntime().removeShutdownHook(shutdownHookThread);
+      } catch (final IllegalStateException e) {
+        // JVM already shutting down — nothing to remove. Ignore.
+      } catch (final RuntimeException e) {
+        original.addSuppressed(e);
+      } finally {
+        shutdownHookThread = null;
+      }
+    }
+    if (scheduler != null) {
+      try {
+        scheduler.shutdownNow();
+      } catch (final RuntimeException e) {
+        original.addSuppressed(e);
+      }
+    }
+    if (kpipeProducer != null) {
+      try {
+        kpipeProducer.close();
+      } catch (final Exception e) {
+        original.addSuppressed(e);
+      }
+    }
+    if (batchWrappers != null) {
+      for (final var wrapper : batchWrappers.values()) {
+        try {
+          wrapper.close();
+        } catch (final Exception e) {
+          original.addSuppressed(e);
         }
       }
-    );
+    }
+    if (dispatcher != null) {
+      try {
+        dispatcher.close();
+      } catch (final Exception e) {
+        original.addSuppressed(e);
+      }
+    }
+    if (kafkaConsumer != null) {
+      try {
+        kafkaConsumer.close();
+      } catch (final Exception e) {
+        original.addSuppressed(e);
+      }
+    }
   }
 
   private <T> BatchPipelineWrapper<K, T> createBatchWrapper(final Builder.BatchSpec<T> spec) {

--- a/lib/kpipe-consumer/src/main/java/io/github/eschizoid/kpipe/health/HttpHealthServer.java
+++ b/lib/kpipe-consumer/src/main/java/io/github/eschizoid/kpipe/health/HttpHealthServer.java
@@ -53,7 +53,14 @@ public final class HttpHealthServer implements AutoCloseable {
     this.path = normalizePath(path);
     this.appName = appName != null ? appName : "kpipe-app";
     this.server = HttpServer.create(new InetSocketAddress(host, port), 0);
-    this.server.createContext(this.path, this::handleHealth);
+    // HttpServer.create already bound the socket. If createContext throws, the socket would leak,
+    // so close the server before propagating.
+    try {
+      this.server.createContext(this.path, this::handleHealth);
+    } catch (final RuntimeException e) {
+      this.server.stop(0);
+      throw e;
+    }
   }
 
   /// Create an {@link HttpHealthServer} using environment variables when enabled.
@@ -78,9 +85,17 @@ public final class HttpHealthServer implements AutoCloseable {
     final var port = HealthConfig.getPort();
 
     try {
-      return Optional.of(
-        new HttpHealthServer(host, port, path, healthSupplier, inFlightSupplier, pausedSupplier, appName)
+      final var server = new HttpHealthServer(
+        host,
+        port,
+        path,
+        healthSupplier,
+        inFlightSupplier,
+        pausedSupplier,
+        appName
       );
+      server.start();
+      return Optional.of(server);
     } catch (final IOException e) {
       LOGGER.log(Level.ERROR, "Failed to start health HTTP server", e);
       return Optional.empty();

--- a/lib/kpipe-consumer/src/test/java/io/github/eschizoid/kpipe/consumer/KPipeConsumerMockingTest.java
+++ b/lib/kpipe-consumer/src/test/java/io/github/eschizoid/kpipe/consumer/KPipeConsumerMockingTest.java
@@ -489,6 +489,30 @@ class KPipeConsumerMockingTest {
   }
 
   @Test
+  void constructorClosesKafkaConsumerWhenLaterInitStepThrows() {
+    // The constructor opens the Kafka consumer first, then the dispatcher, then runs the
+    // offset-manager provider. A provider that throws lands after both are already open — the
+    // constructor must close what it opened (here: the Kafka consumer) instead of leaking it.
+    final var mockConsumer = new MockConsumer<String, byte[]>("earliest");
+    final var boom = new IllegalStateException("offset-manager provider blew up");
+
+    final var thrown = assertThrows(IllegalStateException.class, () ->
+      KPipeConsumer.<String>builder()
+        .withProperties(properties)
+        .withTopic(TOPIC)
+        .withPipeline(TestPipelines.identity())
+        .withConsumer(() -> mockConsumer)
+        .withOffsetManagerProvider(c -> {
+          throw boom;
+        })
+        .build()
+    );
+
+    assertSame(boom, thrown);
+    assertTrue(mockConsumer.closed(), "Kafka consumer opened by the constructor must be closed when init fails");
+  }
+
+  @Test
   void builderShouldThrowNullPointerExceptionWhenMissingRequiredFields() {
     final var builder = KPipeConsumer.<String>builder();
 

--- a/lib/kpipe-consumer/src/test/java/io/github/eschizoid/kpipe/health/HttpHealthServerTest.java
+++ b/lib/kpipe-consumer/src/test/java/io/github/eschizoid/kpipe/health/HttpHealthServerTest.java
@@ -88,6 +88,31 @@ class HttpHealthServerTest {
     }
   }
 
+  @Test
+  void shouldReturnStartedServerFromEnv() throws Exception {
+    // fromEnv documents that the returned server is started; this proves the contract by hitting
+    // the endpoint without calling start() ourselves.
+    try (final var mocked = Mockito.mockStatic(AppConfig.class)) {
+      mocked.when(() -> AppConfig.getEnvOrDefault(HealthConfig.ENV_ENABLED, "true")).thenReturn("true");
+      mocked
+        .when(() -> AppConfig.getEnvOrDefault(HealthConfig.ENV_HOST, HealthConfig.DEFAULT_HOST))
+        .thenReturn("127.0.0.1");
+      mocked.when(() -> AppConfig.getEnvOrDefault(HealthConfig.ENV_PORT, "8080")).thenReturn("0");
+      mocked
+        .when(() -> AppConfig.getEnvOrDefault(HealthConfig.ENV_PATH, HealthConfig.DEFAULT_PATH))
+        .thenReturn("/health");
+
+      final var maybeServer = HttpHealthServer.fromEnv(() -> true, () -> 7L, () -> false, "test-app");
+      assertTrue(maybeServer.isPresent());
+
+      try (final var server = maybeServer.get()) {
+        final var response = sendRequest(server, "GET");
+        assertEquals(200, response.statusCode());
+        assertTrue(response.body().contains("\"inFlight\": 7"));
+      }
+    }
+  }
+
   private static HttpHealthServer newServer(final BooleanSupplier supplier) throws Exception {
     return new HttpHealthServer("127.0.0.1", 0, "/health", supplier, () -> 0L, () -> false, "test-app");
   }


### PR DESCRIPTION
## What

Fixes three resource-leak risks surfaced by the resource-leak audit, all on construction paths where a partial init would otherwise strand already-opened resources for the JVM lifetime.

### 1. (MEDIUM) `KPipeConsumer` constructor leaks resources if a later field init throws

The constructor opens, in order: the Kafka consumer, the dispatcher (PARALLEL owns a virtual-thread executor), an optional built-in DLQ `KPipeProducer`, an optional scheduler, the batch wrappers, and a JVM shutdown hook. If anything after the first open threw — e.g. `addShutdownHook` while the JVM is already shutting down (`IllegalStateException`), or a user-supplied `ConsumerMetrics`/`Tracer`/`CircuitBreakerController` whose construction work throws — every already-opened resource leaked.

The constructor body is now wrapped so any throwable triggers `closePartiallyConstructed(t)`, which closes whatever was opened in **reverse** of the open order (shutdown hook → scheduler → producer → batch wrappers → dispatcher → Kafka consumer), suppressing any cleanup failure onto the original throwable, then rethrows.

**Ownership** mirrors the existing teardown (`releaseConstructedResources` / the consumer-thread `finally`): the Kafka consumer and the DLQ producer are closed regardless of whether they were supplied via `withConsumer(...)` / `withKafkaProducer(...)` or built internally, because once handed to the consumer they are consumer-owned. The helper reads fields off `this` (a partially-constructed instance leaves not-yet-assigned fields at their default `null`), so every step is null-guarded. The whitespace-ignoring diff for this file is +71 lines (the `try`, the `catch`, and the helper); the rest of the large diff is pure re-indentation of the wrapped body.

This is the load-bearing fix.

### 2. (LOW) `HttpHealthServer` constructor leaks bound socket if `createContext` throws

`HttpServer.create(addr, 0)` binds the socket; if the subsequent `createContext(path, ...)` throws, the socket leaked. Now wrapped: `try { createContext(...) } catch (RuntimeException e) { server.stop(0); throw e; }`.

### 3. (LOW) `HttpHealthServer.fromEnv` Javadoc said "started" but never called `start()`

The Javadoc promised "a started `HttpHealthServer` instance", but `fromEnv` never started the server. The only caller is a test exercising the disabled path, so nothing started it on the caller side — the doc claim was a real bug. `fromEnv` now calls `server.start()` before returning, matching the documented contract (no double-start: `start()` is idempotent via a CAS guard).

## Deferred

**Scheduler `awaitTermination` finding (#4 in the audit) was considered and deliberately deferred.** It is purely defensive — all scheduled tasks are cancelled before `shutdownNow()` today, so there is nothing to await — and adding an `awaitTermination` would only add shutdown latency for no behavioral gain.

## Tests

- `KPipeConsumerMockingTest.constructorClosesKafkaConsumerWhenLaterInitStepThrows` — supplies a real `MockConsumer` via `withConsumer(...)` plus a `withOffsetManagerProvider(...)` that throws (the provider runs after both the Kafka consumer and the dispatcher are open), asserts the thrown exception propagates unchanged, and asserts `mockConsumer.closed()` — proving the load-bearing Kafka-consumer close.
- `HttpHealthServerTest.shouldReturnStartedServerFromEnv` — mocks the `HealthConfig` env reads to an ephemeral port and hits the endpoint over HTTP **without** calling `start()`, proving `fromEnv` started it.

No test was added for #2 (createContext failure): triggering it cleanly requires spying/subclassing `HttpServer` since `createContext` only throws on a duplicate/invalid path that `normalizePath` already prevents — a brittle test for a small, reviewable fix. Relying on review there.

## Verification

`./gradlew :lib:kpipe-consumer:test` — 265 passing; the only 2 failures are the known `DockerClientProviderStrategy` Testcontainers initialization errors (environmental, no Docker in this sandbox).