### PR TITLE
fix(logging): dedup unrouted-key WARN, drop per-record INFO spam, attach throwables

### DIFF
--- a/lib/kpipe-api/src/main/java/io/github/eschizoid/kpipe/DefaultSink.java
+++ b/lib/kpipe-api/src/main/java/io/github/eschizoid/kpipe/DefaultSink.java
@@ -102,7 +102,7 @@ record DefaultSink<T>(DefaultStream<T> stream, MessageSink<T> terminalSink) impl
     try {
       observer.accept(arg);
     } catch (final RuntimeException e) {
-      LOGGER.log(Level.WARNING, name + " observer threw; swallowing to keep the pipeline running", e);
+      LOGGER.log(Level.WARNING, () -> name + " observer threw; swallowing to keep the pipeline running", e);
     }
   }
 

--- a/lib/kpipe-consumer/src/main/java/io/github/eschizoid/kpipe/consumer/BatchPipelineWrapper.java
+++ b/lib/kpipe-consumer/src/main/java/io/github/eschizoid/kpipe/consumer/BatchPipelineWrapper.java
@@ -216,7 +216,7 @@ final class BatchPipelineWrapper<K, T> implements AutoCloseable {
           size +
           " — treating as failures to avoid silent data loss"
       );
-      LOGGER.log(Level.WARNING, coverageViolation.getMessage());
+      LOGGER.log(Level.WARNING, coverageViolation.getMessage(), coverageViolation);
     }
 
     for (int i = 0; i < size; i++) {

--- a/lib/kpipe-consumer/src/main/java/io/github/eschizoid/kpipe/consumer/KPipeConsumer.java
+++ b/lib/kpipe-consumer/src/main/java/io/github/eschizoid/kpipe/consumer/KPipeConsumer.java
@@ -921,7 +921,7 @@ public class KPipeConsumer<K> implements AutoCloseable {
       public void onBatchFailure(final ConsumerRecord<K, byte[]> record, final Exception cause) {
         metrics.get(METRIC_PROCESSING_ERRORS).incrementAndGet();
         otelMetrics.recordProcessingError(record.topic());
-        LOGGER.log(Level.WARNING, "Batch failure for record at offset {0}: {1}", record.offset(), cause.getMessage());
+        LOGGER.log(Level.WARNING, () -> "Batch failure for record at offset " + record.offset(), cause);
         if (deadLetterTopic != null && kpipeProducer != null) {
           final var sent = kpipeProducer.sendToDlq(deadLetterTopic, record, record.topic(), cause);
           if (sent) metrics.get(METRIC_DLQ_SENT).incrementAndGet();
@@ -1545,7 +1545,7 @@ public class KPipeConsumer<K> implements AutoCloseable {
     } catch (final Exception ex) {
       LOGGER.log(
         Level.ERROR,
-        "Error handler threw while handling rejected task at offset %d: %s".formatted(record.offset(), ex.getMessage()),
+        () -> "Error handler threw while handling rejected task at offset " + record.offset(),
         ex
       );
     }
@@ -1585,7 +1585,7 @@ public class KPipeConsumer<K> implements AutoCloseable {
     try {
       span = tracer.startConsumerSpan(record);
     } catch (final Exception traceEx) {
-      LOGGER.log(Level.WARNING, "Tracer.startConsumerSpan threw: {0}", traceEx.getMessage());
+      LOGGER.log(Level.WARNING, "Tracer.startConsumerSpan threw", traceEx);
       span = Tracer.SpanScope.noop();
     }
 
@@ -1603,7 +1603,7 @@ public class KPipeConsumer<K> implements AutoCloseable {
       try {
         span.close();
       } catch (final Exception traceEx) {
-        LOGGER.log(Level.WARNING, "Tracer.SpanScope.close threw: {0}", traceEx.getMessage());
+        LOGGER.log(Level.WARNING, "Tracer.SpanScope.close threw", traceEx);
       }
       // In-flight count + backpressure-unpark handled by the dispatcher's `onComplete`
       // callback (`afterRecordComplete`). See `processRecords`.
@@ -1628,7 +1628,7 @@ public class KPipeConsumer<K> implements AutoCloseable {
       if (attempt > 0) {
         metrics.get(METRIC_RETRIES).incrementAndGet();
         LOGGER.log(
-          Level.INFO,
+          Level.DEBUG,
           "Retrying message at offset {0} (attempt {1} of {2})",
           record.offset(),
           attempt,
@@ -1749,14 +1749,12 @@ public class KPipeConsumer<K> implements AutoCloseable {
     try {
       span.recordException(e);
     } catch (final Exception traceEx) {
-      LOGGER.log(Level.WARNING, "Tracer.SpanScope.recordException threw: {0}", traceEx.getMessage());
+      LOGGER.log(Level.WARNING, "Tracer.SpanScope.recordException threw", traceEx);
     }
     LOGGER.log(
       Level.WARNING,
-      "Failed to process message at offset {0} after {1} attempt(s): {2}",
-      record.offset(),
-      retryCount + 1,
-      e.getMessage()
+      () -> "Failed to process message at offset " + record.offset() + " after " + (retryCount + 1) + " attempt(s)",
+      e
     );
     if (deadLetterTopic != null && kpipeProducer != null) {
       final var sent = kpipeProducer.sendToDlq(deadLetterTopic, record, record.topic(), e);

--- a/lib/kpipe-consumer/src/main/java/io/github/eschizoid/kpipe/consumer/ParallelDispatcher.java
+++ b/lib/kpipe-consumer/src/main/java/io/github/eschizoid/kpipe/consumer/ParallelDispatcher.java
@@ -96,6 +96,7 @@ final class ParallelDispatcher<K> implements Dispatcher<K> {
       }
     } catch (final InterruptedException e) {
       Thread.currentThread().interrupt();
+      LOGGER.log(Level.WARNING, "Interrupted while awaiting executor termination", e);
       executor.shutdownNow();
     }
   }

--- a/lib/kpipe-consumer/src/test/java/io/github/eschizoid/kpipe/consumer/BatchPipelineWrapperCoverageContractTest.java
+++ b/lib/kpipe-consumer/src/test/java/io/github/eschizoid/kpipe/consumer/BatchPipelineWrapperCoverageContractTest.java
@@ -139,6 +139,72 @@ class BatchPipelineWrapperCoverageContractTest {
     }
   }
 
+  /// **Coverage-violation WARN carries the throwable.** The coverage-violation WARNING must
+  /// attach the synthetic [IllegalStateException] as the [LogRecord]'s `thrown`, so an operator
+  /// gets the stack trace — not just the bare message. Pins the throwable-attach fix: a regression
+  /// that drops the cause (e.g. passing only `getMessage()`) leaves `getThrown()` null.
+  @Test
+  void coverageViolationWarnCarriesThrowable() {
+    final var topic = "coverage-thrown";
+    final var policy = new BatchPolicy(5, Duration.ofMinutes(1));
+    final var callbacks = new RecordingCallbacks();
+
+    final BatchSink<byte[]> sink = batch -> {
+      final var succeeded = new ArrayList<Integer>();
+      for (int i = 0; i < batch.size() - 1; i++) succeeded.add(i);
+      return new BatchResult(succeeded, Map.of());
+    };
+
+    final var julLogger = Logger.getLogger(BatchPipelineWrapper.class.getName());
+    final var captured = new CopyOnWriteArrayList<LogRecord>();
+    final var handler = new Handler() {
+      @Override
+      public void publish(final LogRecord record) {
+        if (record.getLevel().intValue() >= Level.WARNING.intValue()) captured.add(record);
+      }
+
+      @Override
+      public void flush() {}
+
+      @Override
+      public void close() {}
+    };
+    final var originalLevel = julLogger.getLevel();
+    final var originalUseParent = julLogger.getUseParentHandlers();
+    julLogger.addHandler(handler);
+    julLogger.setLevel(Level.ALL);
+    julLogger.setUseParentHandlers(false);
+
+    final var wrapper = new BatchPipelineWrapper<>(topic, TestPipelines.identity(), sink, policy, scheduler, callbacks);
+    wrapper.start();
+    try {
+      for (int i = 0; i < 5; i++) {
+        final var rec = record(topic, i);
+        wrapper.enqueue(rec, rec.value());
+      }
+
+      final var coverageWarn = captured
+        .stream()
+        .filter(r -> r.getMessage() != null && r.getMessage().contains("did not account for"))
+        .findFirst()
+        .orElseThrow(() -> new AssertionError("expected a coverage-violation WARNING; captured=" + captured.size()));
+      assertNotNull(
+        coverageWarn.getThrown(),
+        "coverage-violation WARN must attach the synthetic cause so the stack trace is logged"
+      );
+      assertInstanceOf(
+        IllegalStateException.class,
+        coverageWarn.getThrown(),
+        "attached throwable must be the synthetic IllegalStateException"
+      );
+    } finally {
+      julLogger.removeHandler(handler);
+      julLogger.setLevel(originalLevel);
+      julLogger.setUseParentHandlers(originalUseParent);
+      wrapper.close();
+    }
+  }
+
   /// **Out-of-range index guard.** Feeds N=3 records to a wrapper whose sink returns a
   /// [BatchResult] naming index 99 (way out of range). The wrapper must (a) log a WARNING about
   /// the out-of-range succeeded index, (b) treat the real indexes 0..2 as unaccounted-for and

--- a/lib/kpipe-core/src/main/java/io/github/eschizoid/kpipe/registry/MessageProcessorRegistry.java
+++ b/lib/kpipe-core/src/main/java/io/github/eschizoid/kpipe/registry/MessageProcessorRegistry.java
@@ -94,6 +94,17 @@ public class MessageProcessorRegistry {
   private final Namespace operators = new Namespace();
   private final Namespace sinks = new Namespace();
 
+  /// Tracks which unrouted keys have already been warned about, so the per-record WARNING for a
+  /// missing operator/sink fires once per distinct key instead of once per record. The WARNING
+  /// signal is load-bearing — operators need to know a key is unrouted — but repeating it per
+  /// record floods logs during a sustained misconfiguration. Bounded in practice: keyed by
+  /// [RegistryKey], whose cardinality is the (finite) set of keys a pipeline ever looks up. Kept
+  /// separate per namespace so an unrouted key warned on the operator side still warns once on the
+  /// sink side (the two lookups are independent).
+  private final Set<RegistryKey<?>> warnedMissingOperatorKeys = ConcurrentHashMap.newKeySet();
+
+  private final Set<RegistryKey<?>> warnedMissingSinkKeys = ConcurrentHashMap.newKeySet();
+
   /// Creates a new registry. The registry is format-agnostic — supply the format per pipeline via
   /// [#pipeline(MessageFormat)].
   public MessageProcessorRegistry() {}
@@ -146,10 +157,15 @@ public class MessageProcessorRegistry {
     return input -> {
       final RegistryEntry<UnaryOperator<T>> entry = operators.getAs(key);
       if (entry == null) {
-        LOGGER.log(
-          Level.WARNING,
-          "No operator registered under key %s — passing input through unchanged".formatted(key)
-        );
+        // Warn once per distinct key — repeats are suppressed so a sustained misconfig
+        // doesn't flood logs while still surfacing the unrouted key the first time.
+        if (warnedMissingOperatorKeys.add(key)) {
+          LOGGER.log(
+            Level.WARNING,
+            "No operator registered under key {0} — passing input through unchanged",
+            key
+          );
+        }
         return input;
       }
       return entry.apply(input);
@@ -218,7 +234,11 @@ public class MessageProcessorRegistry {
     return value -> {
       final RegistryEntry<MessageSink<T>> entry = sinks.getAs(key);
       if (entry == null) {
-        LOGGER.log(Level.WARNING, "No sink found in registry for key: {0}", key);
+        // Warn once per distinct key — repeats are suppressed so a sustained misconfig
+        // doesn't flood logs while still surfacing the unrouted key the first time.
+        if (warnedMissingSinkKeys.add(key)) {
+          LOGGER.log(Level.WARNING, "No sink found in registry for key: {0}", key);
+        }
         return;
       }
       entry.accept(value);

--- a/lib/kpipe-core/src/main/java/io/github/eschizoid/kpipe/sink/CompositeMessageSink.java
+++ b/lib/kpipe-core/src/main/java/io/github/eschizoid/kpipe/sink/CompositeMessageSink.java
@@ -24,7 +24,9 @@ public record CompositeMessageSink<T>(List<MessageSink<T>> sinks) implements Mes
       try {
         sink.accept(processedValue);
       } catch (final Exception e) {
-        LOGGER.log(Level.ERROR, "Sink %s failed to process value".formatted(sink.getClass().getSimpleName()), e);
+        // Best-effort fanout: one sink failing must not stop the others, so log and continue.
+        // WARNING (not ERROR) — a sustained downstream outage would otherwise flood at ERROR.
+        LOGGER.log(Level.WARNING, () -> "Sink " + sink.getClass().getSimpleName() + " failed to process value", e);
       }
     }
   }

--- a/lib/kpipe-core/src/test/java/io/github/eschizoid/kpipe/registry/MessageProcessorRegistryUnroutedKeyWarnTest.java
+++ b/lib/kpipe-core/src/test/java/io/github/eschizoid/kpipe/registry/MessageProcessorRegistryUnroutedKeyWarnTest.java
@@ -1,0 +1,152 @@
+package io.github.eschizoid.kpipe.registry;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.logging.Handler;
+import java.util.logging.Level;
+import java.util.logging.LogRecord;
+import java.util.logging.Logger;
+import org.junit.jupiter.api.Test;
+
+/// Verifies the unrouted-key WARNING is deduped: the load-bearing WARN that an operator/sink key
+/// is unrouted must fire once per distinct key, not once per record, so a sustained misconfig
+/// can't flood logs at the consumer's poll rate.
+///
+/// We capture System.Logger output via the JUL handler the System.Logger bridges to (same
+/// approach as the KEY_ORDERED saturation test). Note: JUL's `LogRecord.getMessage()` carries the
+/// raw `{0}` format string (substitution happens in the formatter), so assertions match the raw
+/// message and read the key off `getParameters()`.
+class MessageProcessorRegistryUnroutedKeyWarnTest {
+
+  @Test
+  void unroutedOperatorKeyWarnsOncePerDistinctKey() {
+    final var julLogger = Logger.getLogger(MessageProcessorRegistry.class.getName());
+    final var captured = new CopyOnWriteArrayList<LogRecord>();
+    final var handler = capturingHandler(captured);
+    final var originalLevel = julLogger.getLevel();
+    final var originalUseParent = julLogger.getUseParentHandlers();
+    julLogger.addHandler(handler);
+    julLogger.setLevel(Level.ALL);
+    julLogger.setUseParentHandlers(false);
+
+    try {
+      final var registry = new MessageProcessorRegistry();
+      final var keyA = RegistryKey.of("missingOpA", Object.class);
+      final var keyB = RegistryKey.of("missingOpB", Object.class);
+
+      // Same key looked up many times (per-record simulation) → exactly one WARN.
+      final var opA = registry.getOperator(keyA);
+      for (int i = 0; i < 50; i++) opA.apply("v" + i);
+      // A second distinct key → one more WARN.
+      final var opB = registry.getOperator(keyB);
+      for (int i = 0; i < 50; i++) opB.apply("v" + i);
+
+      final var opWarns = captured
+        .stream()
+        .filter(r -> r.getMessage() != null && r.getMessage().contains("No operator registered under key"))
+        .toList();
+      assertEquals(
+        2,
+        opWarns.size(),
+        () -> "exactly one operator WARN per distinct key; got " + opWarns.size()
+      );
+    } finally {
+      julLogger.removeHandler(handler);
+      julLogger.setLevel(originalLevel);
+      julLogger.setUseParentHandlers(originalUseParent);
+    }
+  }
+
+  @Test
+  void unroutedSinkKeyWarnsOncePerDistinctKey() {
+    final var julLogger = Logger.getLogger(MessageProcessorRegistry.class.getName());
+    final var captured = new CopyOnWriteArrayList<LogRecord>();
+    final var handler = capturingHandler(captured);
+    final var originalLevel = julLogger.getLevel();
+    final var originalUseParent = julLogger.getUseParentHandlers();
+    julLogger.addHandler(handler);
+    julLogger.setLevel(Level.ALL);
+    julLogger.setUseParentHandlers(false);
+
+    try {
+      final var registry = new MessageProcessorRegistry();
+      final var keyA = RegistryKey.of("missingSinkA", Object.class);
+      final var keyB = RegistryKey.of("missingSinkB", Object.class);
+
+      final var sinkA = registry.getSink(keyA);
+      for (int i = 0; i < 50; i++) sinkA.accept("v" + i);
+      final var sinkB = registry.getSink(keyB);
+      for (int i = 0; i < 50; i++) sinkB.accept("v" + i);
+
+      final var sinkWarns = captured
+        .stream()
+        .filter(r -> r.getMessage() != null && r.getMessage().contains("No sink found in registry for key"))
+        .toList();
+      assertEquals(
+        2,
+        sinkWarns.size(),
+        () -> "exactly one sink WARN per distinct key; got " + sinkWarns.size()
+      );
+    } finally {
+      julLogger.removeHandler(handler);
+      julLogger.setLevel(originalLevel);
+      julLogger.setUseParentHandlers(originalUseParent);
+    }
+  }
+
+  @Test
+  void operatorAndSinkNamespacesDedupIndependently() {
+    // The same key unrouted on both the operator and sink side must warn once on each side —
+    // the two lookups are independent, so a shared dedup set would wrongly swallow the second.
+    final var julLogger = Logger.getLogger(MessageProcessorRegistry.class.getName());
+    final var captured = new CopyOnWriteArrayList<LogRecord>();
+    final var handler = capturingHandler(captured);
+    final var originalLevel = julLogger.getLevel();
+    final var originalUseParent = julLogger.getUseParentHandlers();
+    julLogger.addHandler(handler);
+    julLogger.setLevel(Level.ALL);
+    julLogger.setUseParentHandlers(false);
+
+    try {
+      final var registry = new MessageProcessorRegistry();
+      final var key = RegistryKey.of("sharedName", Object.class);
+
+      registry.getOperator(key).apply("v");
+      registry.getOperator(key).apply("v");
+      registry.getSink(key).accept("v");
+      registry.getSink(key).accept("v");
+
+      final var opWarns = captured
+        .stream()
+        .filter(r -> r.getMessage() != null && r.getMessage().contains("No operator registered under key"))
+        .count();
+      final var sinkWarns = captured
+        .stream()
+        .filter(r -> r.getMessage() != null && r.getMessage().contains("No sink found in registry for key"))
+        .count();
+      assertEquals(1, opWarns, "operator side warns once");
+      assertEquals(1, sinkWarns, "sink side warns once");
+    } finally {
+      julLogger.removeHandler(handler);
+      julLogger.setLevel(originalLevel);
+      julLogger.setUseParentHandlers(originalUseParent);
+    }
+  }
+
+  private static Handler capturingHandler(final List<LogRecord> sink) {
+    return new Handler() {
+      @Override
+      public void publish(final LogRecord record) {
+        if (record.getLevel().intValue() >= Level.WARNING.intValue()) sink.add(record);
+      }
+
+      @Override
+      public void flush() {}
+
+      @Override
+      public void close() {}
+    };
+  }
+}

--- a/lib/kpipe-producer/src/main/java/io/github/eschizoid/kpipe/producer/KPipeProducer.java
+++ b/lib/kpipe-producer/src/main/java/io/github/eschizoid/kpipe/producer/KPipeProducer.java
@@ -182,16 +182,16 @@ public class KPipeProducer<K, V> implements AutoCloseable {
     try {
       tracer.injectContextInto(producerRecord.headers());
     } catch (final Exception traceEx) {
-      LOGGER.log(Level.WARNING, "Tracer.injectContextInto threw during DLQ send: {0}", traceEx.getMessage());
+      LOGGER.log(Level.WARNING, "Tracer.injectContextInto threw during DLQ send", traceEx);
     }
 
     try {
       send(producerRecord);
       otelMetrics.recordDlqSent();
-      LOGGER.log(Level.INFO, "Sent record to DLQ topic {0}", dlqTopic);
+      LOGGER.log(Level.DEBUG, "Sent record to DLQ topic {0}", dlqTopic);
       return true;
     } catch (final Exception ex) {
-      LOGGER.log(Level.ERROR, "Failed to send record to DLQ topic " + dlqTopic, ex);
+      LOGGER.log(Level.ERROR, () -> "Failed to send record to DLQ topic " + dlqTopic, ex);
       return false;
     }
   }

--- a/lib/kpipe-producer/src/main/java/io/github/eschizoid/kpipe/producer/sink/KafkaMessageSink.java
+++ b/lib/kpipe-producer/src/main/java/io/github/eschizoid/kpipe/producer/sink/KafkaMessageSink.java
@@ -61,10 +61,12 @@ public class KafkaMessageSink<T> implements MessageSink<T> {
     try {
       tracer.injectContextInto(record.headers());
     } catch (final Exception traceEx) {
-      LOGGER.log(Level.WARNING, "Tracer.injectContextInto threw: {0}", traceEx.getMessage());
+      LOGGER.log(Level.WARNING, "Tracer.injectContextInto threw", traceEx);
     }
     producer.send(record, (_, exception) -> {
-      if (exception != null) LOGGER.log(Level.WARNING, "Failed to send record to topic %s".formatted(topic), exception);
+      if (exception != null) {
+        LOGGER.log(Level.WARNING, () -> "Failed to send record to topic " + topic, exception);
+      }
     });
   }
 

--- a/lib/kpipe-tracing-otel/src/main/java/io/github/eschizoid/kpipe/tracing/otel/OtelTracer.java
+++ b/lib/kpipe-tracing-otel/src/main/java/io/github/eschizoid/kpipe/tracing/otel/OtelTracer.java
@@ -81,7 +81,7 @@ public final class OtelTracer implements Tracer {
     try {
       parent = propagator.extract(Context.current(), record.headers(), HeadersGetter.INSTANCE);
     } catch (final Exception e) {
-      LOGGER.log(Level.WARNING, "Failed to extract trace context from headers: {0}", e.getMessage());
+      LOGGER.log(Level.WARNING, "Failed to extract trace context from headers", e);
       return SpanScope.noop();
     }
 
@@ -98,7 +98,7 @@ public final class OtelTracer implements Tracer {
         .setAttribute(KAFKA_OFFSET_KEY, record.offset())
         .startSpan();
     } catch (final Exception e) {
-      LOGGER.log(Level.WARNING, "Failed to start span: {0}", e.getMessage());
+      LOGGER.log(Level.WARNING, "Failed to start span", e);
       return SpanScope.noop();
     }
 
@@ -106,7 +106,7 @@ public final class OtelTracer implements Tracer {
     try {
       scope = span.makeCurrent();
     } catch (final Exception e) {
-      LOGGER.log(Level.WARNING, "Failed to make span current: {0}", e.getMessage());
+      LOGGER.log(Level.WARNING, "Failed to make span current", e);
       span.end();
       return SpanScope.noop();
     }
@@ -120,7 +120,7 @@ public final class OtelTracer implements Tracer {
     try {
       propagator.inject(Context.current(), headers, HeadersSetter.INSTANCE);
     } catch (final Exception e) {
-      LOGGER.log(Level.WARNING, "Failed to inject trace context into headers: {0}", e.getMessage());
+      LOGGER.log(Level.WARNING, "Failed to inject trace context into headers", e);
     }
   }
 
@@ -144,7 +144,7 @@ public final class OtelTracer implements Tracer {
         span.recordException(t);
         span.setStatus(StatusCode.ERROR, t.getClass().getSimpleName());
       } catch (final Exception e) {
-        LOGGER.log(Level.WARNING, "Failed to record exception on span: {0}", e.getMessage());
+        LOGGER.log(Level.WARNING, "Failed to record exception on span", e);
       }
     }
 
@@ -157,12 +157,12 @@ public final class OtelTracer implements Tracer {
       try {
         scope.close();
       } catch (final Exception e) {
-        LOGGER.log(Level.WARNING, "Failed to close scope: {0}", e.getMessage());
+        LOGGER.log(Level.WARNING, "Failed to close scope", e);
       }
       try {
         span.end();
       } catch (final Exception e) {
-        LOGGER.log(Level.WARNING, "Failed to end span: {0}", e.getMessage());
+        LOGGER.log(Level.WARNING, "Failed to end span", e);
       }
     }
   }


### PR DESCRIPTION
Logging-hygiene roundup from the logging audit.

## A. Per-record spam (HIGH)
- **Registry unrouted-key WARN deduped.** The per-record WARN for an unrouted operator/sink key now fires **once per distinct key** (`ConcurrentHashMap.newKeySet()` guard, `Set.add()` as the one-shot gate — mirrors the one-shot-WARN pattern elsewhere in the codebase). The WARNING is load-bearing (operators need to know a key is unrouted) so it **stays at WARNING** — only the repeat is suppressed. Separate sets per namespace so the same key still warns once on the operator side and once on the sink side (the two lookups are independent). Bounded by `RegistryKey` cardinality.
- **`KPipeConsumer` retry log INFO -> DEBUG** (retry count already lives in `METRIC_RETRIES`).
- **`KPipeProducer` "Sent record to DLQ topic" INFO -> DEBUG** (`METRIC_DLQ_SENT` already counts).

## B. Missing throwable / dropped stack trace (MEDIUM)
Defensive tracer/span/sink shields and the per-record + batch failure logs that passed only `e.getMessage()` now actually attach the throwable.

> **Audit finding that changed the approach.** The task brief assumed `System.Logger` strips a trailing `Throwable` from positional substitution. That is **not true for the JDK `System.Logger` -> `java.util.logging` bridge** (`sun.util.logging.internal.LoggingProviderImpl$JULWrapper`). I verified empirically: the bridge only routes a trailing arg to `LogRecord.setThrown` when the message has **no `{N}` placeholders**. With any `{N}` present, the trailing throwable is consumed as a format param and — with no matching placeholder — silently dropped (no stack trace). So `"{0}: {1}", offset, e.getMessage(), e` would have logged the message but lost the stack trace.
>
> These sites therefore use either the placeholder-free `"message", throwable` form, or the lazy `Supplier<String> + Throwable` overload (lazy **and** attaches the throwable), instead of positional `{0}`/`{1}` + trailing throwable.

Sites: `OtelTracer` (7 catch blocks), `KPipeConsumer` (`startConsumerSpan` / `SpanScope.close` / `recordException` shields + per-record failure + batch-failure callback), `KPipeProducer` (tracer inject), `KafkaMessageSink` (tracer inject + send callback), `BatchPipelineWrapper` (coverage-violation WARN).

## C. Eager string building at log sites (MEDIUM/LOW)
`.formatted()` / `+` concat at log sites converted to lazy `Supplier<String>` where the throwable must stay attached (KafkaMessageSink, KPipeProducer DLQ-failure, DefaultSink observer, KPipeConsumer rejected-task), or positional `{0}` where no throwable is involved.

## D. Per-record ERROR -> WARNING (HIGH)
`CompositeMessageSink` is explicitly best-effort (continues past a failing sink); a sustained downstream outage at ERROR floods. Dropped to WARNING.

## E. Interrupt visibility (LOW)
`ParallelDispatcher.close()` now logs a WARNING (with the exception) when interrupted while awaiting executor termination, before `shutdownNow()`.

## Tests
- `MessageProcessorRegistryUnroutedKeyWarnTest` — pins the dedup: WARN fires exactly once per distinct key across 50 repeated lookups, and operator/sink namespaces dedup independently. Captured via the JUL bridge (same pattern as the KEY_ORDERED saturation test).
- `BatchPipelineWrapperCoverageContractTest.coverageViolationWarnCarriesThrowable` — asserts the coverage-violation WARN's `LogRecord.getThrown()` is the synthetic `IllegalStateException` (would be null if a regression dropped the cause).

## Test run
`./gradlew :lib:kpipe-consumer:test :lib:kpipe-producer:test :lib:kpipe-core:test :lib:kpipe-tracing-otel:test`

All unit tests pass. The only 2 failures are `ExternalOffsetIntegrationTest` / `KPipeProducerIntegrationTest`, which are `@Testcontainers` integration tests failing at `DockerClientProviderStrategy` because no Docker daemon is available in the build environment — unrelated to these changes; they pass where Docker is present.

## Conventions
No `@Deprecated` (delete + migrate same PR), `java.lang.System.Logger`, `final var`, no FQCN, no spec/section refs in comments — rules stated directly.