### PR TITLE
docs: harden audit-review comments on non-obvious correctness

### DIFF
--- a/benchmarks/src/jmh/java/io/github/eschizoid/kpipe/benchmarks/OffsetManagerBoxingBenchmark.java
+++ b/benchmarks/src/jmh/java/io/github/eschizoid/kpipe/benchmarks/OffsetManagerBoxingBenchmark.java
@@ -58,10 +58,11 @@ import org.openjdk.jmh.annotations.Warmup;
 /// ```
 ///
 /// The `gc.alloc.rate.norm` column (bytes allocated per op) is the primary signal — the cache
-/// should remove one `TopicPartition` instance worth of bytes per record (16 bytes object header
-/// + topic ref + partition int + alignment ~= 24 bytes on a 64-bit JVM with compressed oops).
-/// Throughput improvement is secondary; the JIT may already optimize the constructor away in
-/// the baseline, in which case the alloc-rate delta is the only signal.
+/// should remove one `TopicPartition` instance worth of allocation per record. Read the actual
+/// per-op byte delta from the profiler rather than estimating the header size, which varies by
+/// JVM version and compressed-oops mode. Throughput improvement is secondary; the JIT may already
+/// optimize the constructor away in the baseline, in which case the alloc-rate delta is the only
+/// signal.
 @State(Scope.Benchmark)
 @BenchmarkMode(Mode.Throughput)
 @OutputTimeUnit(TimeUnit.SECONDS)

--- a/lib/kpipe-consumer/src/main/java/io/github/eschizoid/kpipe/consumer/KPipeConsumer.java
+++ b/lib/kpipe-consumer/src/main/java/io/github/eschizoid/kpipe/consumer/KPipeConsumer.java
@@ -928,6 +928,11 @@ public class KPipeConsumer<K> implements AutoCloseable {
   /// ownership rules of `releaseConstructedResources` / the consumer-thread teardown: the Kafka
   /// consumer and the DLQ producer are closed regardless of whether they were supplied or built
   /// internally, because once handed to the consumer they are consumer-owned.
+  ///
+  /// Reading the `final` fields here is legal precisely because this runs in a *separate method*,
+  /// not inline in the constructor — definite-assignment analysis only guards in-constructor reads,
+  /// so a blank-final that the constructor never reached simply reads its default `null`. Don't
+  /// "fix" the apparent unassigned-final read by dropping `final`; the null-guard is the contract.
   private void closePartiallyConstructed(final Throwable original) {
     if (shutdownHookThread != null) {
       try {

--- a/lib/kpipe-core/src/main/java/io/github/eschizoid/kpipe/registry/MessageProcessorRegistry.java
+++ b/lib/kpipe-core/src/main/java/io/github/eschizoid/kpipe/registry/MessageProcessorRegistry.java
@@ -101,6 +101,11 @@ public class MessageProcessorRegistry {
   /// [RegistryKey], whose cardinality is the (finite) set of keys a pipeline ever looks up. Kept
   /// separate per namespace so an unrouted key warned on the operator side still warns once on the
   /// sink side (the two lookups are independent).
+  ///
+  /// The one unbounded case is a caller that generates fresh `RegistryKey` instances dynamically
+  /// (e.g. a key derived from per-record data) and routes none of them — each distinct miss adds
+  /// a set entry. That's a pathological misuse (the registry is meant for a fixed, declared key
+  /// set), but if it ever becomes a real concern, cap the set or switch to a bounded LRU.
   private final Set<RegistryKey<?>> warnedMissingOperatorKeys = ConcurrentHashMap.newKeySet();
 
   private final Set<RegistryKey<?>> warnedMissingSinkKeys = ConcurrentHashMap.newKeySet();

--- a/lib/kpipe-format-avro/src/main/java/io/github/eschizoid/kpipe/format/avro/AvroFormat.java
+++ b/lib/kpipe-format-avro/src/main/java/io/github/eschizoid/kpipe/format/avro/AvroFormat.java
@@ -156,6 +156,11 @@ public final class AvroFormat implements MessageFormat<GenericRecord> {
     try {
       return reader.read(null, decoder);
     } catch (final IOException | RuntimeException e) {
+      // RuntimeException is caught alongside IOException because malformed bytes surface as Avro's
+      // own AvroRuntimeException (e.g. "Malformed data. Length is negative"), not IOException — so
+      // the common bad-payload case would otherwise escape with a bare, context-free message. The
+      // original cause is always attached, so a genuine programming error (NPE, IllegalState) is
+      // still visible in the cause chain rather than swallowed.
       throw new RuntimeException(
         "AvroFormat.deserialize failed in static mode on " + data.length + " bytes against schema " +
           staticSchema.getFullName(),


### PR DESCRIPTION
## Summary

Four documentation hardenings surfaced as **Worth Considering** during the R1 convergence review of the audit-fix PRs (#205–#210). All comment/javadoc only — zero behavior change, no new tests needed.

Each documents *why* a piece of non-obvious code is correct, so a future maintainer doesn't "fix" it into a bug:

| Source PR | Hardening |
|---|---|
| #207 | `AvroFormat.deserializeStatic` — why the catch is broadened to `RuntimeException` (Avro throws `AvroRuntimeException` for malformed bytes, not `IOException`) + the cause is always attached so real bugs stay visible |
| #209 | `KPipeConsumer.closePartiallyConstructed` — why reading the `final` fields compiles (separate method ⇒ definite-assignment doesn't guard the read ⇒ unreached blank-final reads `null`); explicit "don't drop `final` to fix the apparent unassigned read" |
| #210 | `MessageProcessorRegistry` — the one unbounded case for the unrouted-key dedup set (dynamically-generated keys) + remedy if it ever becomes real |
| #205 | `OffsetManagerBoxingBenchmark` — drop the JVM-specific object-header byte estimate; point at the measured `gc.alloc.rate.norm` delta (prove, don't assert) |

## Test plan

- [x] `./gradlew :lib:kpipe-format-avro:test :lib:kpipe-core:compileJava :lib:kpipe-consumer:compileJava :benchmarks:compileJmhJava` → BUILD SUCCESSFUL
- [ ] Merge to main