### PR TITLE
ci: add Benchmarks workflow (dispatch + weekly bench-rot smoke)

### DIFF
--- a/.github/workflows/benchmarks.yaml
+++ b/.github/workflows/benchmarks.yaml
@@ -1,0 +1,139 @@
+name: Benchmarks
+
+# JMH benchmarks are NOT run on every PR — they are slow, and GitHub-hosted runners are shared,
+# noisy CPU environments where absolute throughput numbers are unreliable. This workflow exists
+# for two things:
+#   1. workflow_dispatch — run a chosen benchmark set on demand with tunable rigor (iterations,
+#      warmup, fork). Use this when you want numbers to compare a branch against main; pin the
+#      runner conditions and read the delta, not the absolute value.
+#   2. schedule (weekly) — a low-iteration smoke of the Docker-free benches. Its real job is
+#      catching bench-rot: `failOnError = true` in benchmarks/build.gradle.kts means a benchmark
+#      that no longer compiles or throws at runtime fails this job. (The JsonPipelineBenchmark
+#      silently rotted through an architecture change once and had to be restored; this catches
+#      that class of regression automatically.)
+
+on:
+  workflow_dispatch:
+    inputs:
+      includes:
+        description: "JMH include regex (benchmark class names). Empty = all benchmarks."
+        required: false
+        default: "JsonPipeline|AvroPipeline|OffsetManagerBoxing|KeyOrderedDispatch|BatchSinkLatency"
+      iterations:
+        description: "Measurement iterations per benchmark"
+        required: false
+        default: "5"
+      warmup:
+        description: "Warmup iterations per benchmark"
+        required: false
+        default: "3"
+      fork:
+        description: "JVM forks per benchmark"
+        required: false
+        default: "1"
+      profilers:
+        description: "JMH profilers (comma-separated, e.g. 'gc'). Empty = none."
+        required: false
+        default: ""
+  schedule:
+    # Mondays 06:00 UTC — weekly bench-rot smoke of the Docker-free benches.
+    - cron: "0 6 * * 1"
+
+# A long benchmark run shouldn't pile up; cancel an in-progress run when a newer one starts.
+concurrency:
+  group: benchmarks-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  jmh:
+    runs-on: ubuntu-latest
+    # Generous ceiling: a full workflow_dispatch run with the Testcontainers benches + high
+    # iteration counts can take a while. The smoke schedule finishes well under this.
+    timeout-minutes: 120
+
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Set up JDK
+        uses: actions/setup-java@v5
+        with:
+          distribution: "graalvm"
+          java-version: "25"
+          cache: "gradle"
+
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@v6
+
+      # Scheduled runs use the Docker-free smoke set at low iterations (fast, reliable rot
+      # detection). Manual runs use whatever the dispatcher asked for.
+      - name: Resolve benchmark parameters
+        id: params
+        run: |
+          if [ "${{ github.event_name }}" = "schedule" ]; then
+            echo "includes=JsonPipeline|AvroPipeline|OffsetManagerBoxing|KeyOrderedDispatch|BatchSinkLatency" >> "$GITHUB_OUTPUT"
+            echo "iterations=2" >> "$GITHUB_OUTPUT"
+            echo "warmup=1" >> "$GITHUB_OUTPUT"
+            echo "fork=1" >> "$GITHUB_OUTPUT"
+            echo "profilers=" >> "$GITHUB_OUTPUT"
+          else
+            echo "includes=${{ inputs.includes }}" >> "$GITHUB_OUTPUT"
+            echo "iterations=${{ inputs.iterations }}" >> "$GITHUB_OUTPUT"
+            echo "warmup=${{ inputs.warmup }}" >> "$GITHUB_OUTPUT"
+            echo "fork=${{ inputs.fork }}" >> "$GITHUB_OUTPUT"
+            echo "profilers=${{ inputs.profilers }}" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Run JMH benchmarks
+        run: |
+          ARGS="-Pjmh.resultFormat=JSON"
+          ARGS="$ARGS -Pjmh.iterations=${{ steps.params.outputs.iterations }}"
+          ARGS="$ARGS -Pjmh.warmupIterations=${{ steps.params.outputs.warmup }}"
+          ARGS="$ARGS -Pjmh.fork=${{ steps.params.outputs.fork }}"
+          if [ -n "${{ steps.params.outputs.includes }}" ]; then
+            ARGS="$ARGS -Pjmh.includes=${{ steps.params.outputs.includes }}"
+          fi
+          if [ -n "${{ steps.params.outputs.profilers }}" ]; then
+            ARGS="$ARGS -Pjmh.profilers=${{ steps.params.outputs.profilers }}"
+          fi
+          echo "Gradle args: $ARGS"
+          ./gradlew :benchmarks:jmh $ARGS --no-daemon --stacktrace
+
+      - name: Write run summary
+        if: ${{ !cancelled() }}
+        run: |
+          RESULTS=benchmarks/build/results/jmh/results.json
+          {
+            echo "## JMH benchmark run"
+            echo ""
+            echo "| Parameter | Value |"
+            echo "| --- | --- |"
+            echo "| Trigger | ${{ github.event_name }} |"
+            echo "| Includes | \`${{ steps.params.outputs.includes }}\` |"
+            echo "| Iterations | ${{ steps.params.outputs.iterations }} |"
+            echo "| Warmup | ${{ steps.params.outputs.warmup }} |"
+            echo "| Fork | ${{ steps.params.outputs.fork }} |"
+            echo ""
+          } >> "$GITHUB_STEP_SUMMARY"
+          if [ -f "$RESULTS" ]; then
+            echo "### Results (score = throughput, ops/s)" >> "$GITHUB_STEP_SUMMARY"
+            echo "" >> "$GITHUB_STEP_SUMMARY"
+            echo "| Benchmark | Score | Error | Unit |" >> "$GITHUB_STEP_SUMMARY"
+            echo "| --- | ---: | ---: | --- |" >> "$GITHUB_STEP_SUMMARY"
+            # Parse the JMH JSON without extra tooling — jq is preinstalled on ubuntu-latest.
+            # scoreError is the string "NaN" when there are too few iterations to compute a
+            # stddev, so type-guard it before doing arithmetic.
+            jq -r '.[] | "| \(.benchmark | split(".") | last) | \(.primaryMetric.score | (. * 100 | round / 100)) | \(.primaryMetric.scoreError | if type == "number" then "±" + ((. * 100 | round / 100) | tostring) else "n/a" end) | \(.primaryMetric.scoreUnit) |"' "$RESULTS" >> "$GITHUB_STEP_SUMMARY" || echo "(could not parse $RESULTS)" >> "$GITHUB_STEP_SUMMARY"
+            echo "" >> "$GITHUB_STEP_SUMMARY"
+            echo "> GitHub-hosted runners are shared CPU — treat these as smoke / coarse-regression signal, not absolute numbers. For real measurements run on a dedicated, quiesced host." >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "No results file produced at \`$RESULTS\`." >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+      - name: Upload JMH results
+        if: ${{ !cancelled() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: jmh-results-${{ github.run_id }}
+          path: benchmarks/build/results/jmh/results.json
+          if-no-files-found: warn
+          retention-days: 90


### PR DESCRIPTION
## Summary

Adds `.github/workflows/benchmarks.yaml` to run the JMH suite — deliberately **not** on PRs (slow + noisy-runner numbers are unreliable), but in two useful modes:

### `workflow_dispatch` — run on demand
Inputs: `includes` (JMH class regex), `iterations`, `warmup`, `fork`, `profilers`. Defaults to the five Docker-free benches. Use it for branch-vs-main deltas under pinned conditions.

### `schedule` — weekly bench-rot smoke (Mondays 06:00 UTC)
Low-iteration run of the Docker-free benches. Its real value is **catching bench-rot automatically**: `failOnError = true` in `benchmarks/build.gradle.kts` means a benchmark that no longer compiles or throws at runtime fails this job. That's exactly the regression class that silently broke `JsonPipelineBenchmark` through an architecture change and forced its restoration in #154 — now it surfaces within a week instead of whenever someone next runs the suite.

## Output
- `results.json` uploaded as an artifact (90-day retention)
- A throughput digest table written to the job summary, with an explicit caveat that shared GitHub runners make these smoke / coarse-regression signal only — **not** absolute numbers

## Benchmark classification (why the smoke set is what it is)
| Bench | Harness | In weekly smoke? |
| --- | --- | --- |
| JsonPipelineBenchmark | in-process `MessagePipeline.process` | ✅ |
| AvroPipelineBenchmark | in-process `MessagePipeline.process` | ✅ |
| OffsetManagerBoxingBenchmark | synthetic records | ✅ |
| KeyOrderedDispatchBenchmark | MockConsumer | ✅ |
| BatchSinkLatencyBenchmark | MockConsumer | ✅ |
| ParallelProcessingBenchmark | Testcontainers Kafka | dispatch-only (heavier) |
| ParallelProcessingLatencyBenchmark | Testcontainers Kafka | dispatch-only (heavier) |

## Test plan
- [x] YAML validated
- [x] Smoke-ran `:benchmarks:jmh -Pjmh.includes=OffsetManagerBoxing -Pjmh.iterations=1` locally → `results.json` produced at the expected path
- [x] Summary `jq` expression verified against real output, including the `scoreError == "NaN"` (too-few-iterations) edge case → renders `n/a`
- [ ] After merge: trigger a manual `workflow_dispatch` run to confirm the Actions environment end-to-end