### PR TITLE
chore(consumer): reflow stranded comment lines in CrashRestartReprocessingIntegrationTest

### DIFF
--- a/lib/kpipe-consumer/src/test/java/io/github/eschizoid/kpipe/consumer/CrashRestartReprocessingIntegrationTest.java
+++ b/lib/kpipe-consumer/src/test/java/io/github/eschizoid/kpipe/consumer/CrashRestartReprocessingIntegrationTest.java
@@ -151,11 +151,10 @@ class CrashRestartReprocessingIntegrationTest {
     );
     final var observedByABeforeCrash = Set.copyOf(observedA);
 
-    // CRASH: stop the manager (no further commit; markOffsetProcessed becomes a no-op) and abandon
-    // A's consumer thread without a graceful drain — no shutdownGracefully(). On interrupt A's loop
-    // closes its Kafka consumer in its finally, which leaves the group promptly; B then inherits
-    // the
-    // partition and resumes from the manually-committed prefix.
+    // CRASH: stop the manager (no further commit; markOffsetProcessed becomes a no-op) and
+    // abandon A's consumer thread without a graceful drain (no shutdownGracefully()). On
+    // interrupt, A's loop closes its Kafka consumer in the finally, which leaves the group
+    // promptly; B then inherits the partition and resumes from the manually-committed prefix.
     offsetManagerA.get().stop();
     threadA.interrupt();
 
@@ -230,9 +229,9 @@ class CrashRestartReprocessingIntegrationTest {
       final var tp = entry.getKey();
       final var logEnd = entry.getValue();
       final var committedMeta = committedFinal.get(tp);
-      // A missing commit is an acceptable uncommitted tail (reprocessed on a later restart);
-      // no-loss
-      // above already covers it. Only bound-check partitions that actually committed.
+      // A missing commit is an acceptable uncommitted tail (reprocessed on a later
+      // restart); no-loss above already covers it. Only bound-check partitions that
+      // actually committed.
       if (committedMeta == null) {
         continue;
       }
@@ -312,13 +311,10 @@ class CrashRestartReprocessingIntegrationTest {
       .withProperties(consumerProperties(groupId))
       .withTopic(topic)
       // SEQUENTIAL on purpose: in-order processing means the committed prefix is a clean
-      // contiguous
-      // range, and combined with the small max.poll.records (see consumerProperties) the
-      // consumer
-      // drains the command queue between small batches so the manual commit lands as a
-      // bounded
-      // prefix. At-least-once is mode-independent; the PARALLEL path is covered by the offset
-      // property/stress/jcstress suites.
+      // contiguous range, and combined with the small max.poll.records (see
+      // consumerProperties) the consumer drains the command queue between small batches so
+      // the manual commit lands as a bounded prefix. At-least-once is mode-independent; the
+      // PARALLEL path is covered by the offset property/stress/jcstress suites.
       .withProcessingMode(ProcessingMode.SEQUENTIAL)
       .withPipeline(
         TestPipelines.sideEffect(value -> {


### PR DESCRIPTION
Cosmetic-only. Three `//` comment blocks in `CrashRestartReprocessingIntegrationTest` had mid-sentence single words stranded on their own lines (a spotless reflow artifact — it wraps at ~100 chars and pushes the overflow word to its own line). Re-wrapped each block so every line stays under the wrap width with natural multi-word continuations.

No code or assertion changes. Surfaced by the comment-analyzer lens during the #221 review; lives on main from #220. Sentence-final single-word lines (e.g. `// tail.`) are intentionally left as-is.