### PR TITLE
test(consumer): per-method broker for RebalanceAtScaleIntegrationTest — fix CI flake

### DIFF
--- a/lib/kpipe-consumer/src/test/java/io/github/eschizoid/kpipe/consumer/RebalanceAtScaleIntegrationTest.java
+++ b/lib/kpipe-consumer/src/test/java/io/github/eschizoid/kpipe/consumer/RebalanceAtScaleIntegrationTest.java
@@ -71,8 +71,13 @@ class RebalanceAtScaleIntegrationTest {
   private static final int PARTITIONS = 6;
   private static final int RECORD_COUNT = 600;
 
+  // Per-method broker (instance field, NOT static). Each of this class's three methods creates its
+  // own 6-partition topic plus consumer groups and never tears them down; sharing one static broker
+  // across all three let that state accumulate until a later method's producer could not get acks
+  // within delivery.timeout.ms and failed at the produce step during setup. A fresh broker per
+  // method keeps each test isolated. Do not make this static.
   @Container
-  static KafkaContainer kafka = new KafkaContainer(
+  final KafkaContainer kafka = new KafkaContainer(
     DockerImageName.parse("soldevelo/kafka:%s".formatted(KAFKA_VERSION)).asCompatibleSubstituteFor("apache/kafka")
   );
 


### PR DESCRIPTION
## Problem

`RebalanceAtScaleIntegrationTest` is the only test failing on `main` CI. Across **3 failing runs** (the #221-merge run + both attempts of the #218 `upload-artifact` run) the signature is identical:

```
RebalanceAtScaleIntegrationTest > atLeastOnceSurvivesCooperativeStickyRebalance()  FAILED
RebalanceAtScaleIntegrationTest > revokeRunsOnConsumerThreadUnderRealRebalance()   FAILED
    java.util.concurrent.ExecutionException at RebalanceAtScaleIntegrationTest.java:325
        Caused by: org.apache.kafka.common.errors.TimeoutException
```

Line 325 is `send.get(30s)` in the `produceRecords()` **setup** helper — the producer can't get acks. Always this one class, always at produce, always the later-ordered methods (`midFlight` passes).

## Root cause

The class shared **one static `KafkaContainer`** across its three `@Test` methods. Each method creates its own **6-partition** topic + consumer groups and never tears them down, so that state accumulates on the single broker until a later method's producer can't deliver within `delivery.timeout.ms` and fails at the produce step.

It's the only container test class heavy enough (3 methods × 6 partitions) to degrade its own broker this way — which is exactly why it's the **only** class that flakes. A runner-wide resource problem would scatter failures across the other five container classes; it doesn't (ruling out the "too many forks / not enough RAM" theory).

Not caused by the `upload-artifact` v4→v7 bump, and not by the kafka 4.3.1 client bump.

## Fix

Make the `@Container` field **non-static** so JUnit's default per-method lifecycle starts a **fresh broker per test**, isolating them. A why-comment on the field documents this so it isn't "optimized" back to static.

- Cost: ~2 extra broker startups (~40 s) for this one class.
- Scope: touches only `RebalanceAtScaleIntegrationTest`; the five healthy container classes are untouched.

## Verification

Testcontainers can't run locally (no Docker) — verified it **compiles**. CI is the confirmation; I'll re-run this branch a few times to confirm the rebalance tests stay green before merging.