### PR TITLE
docs: benchmark wins + verification story on the README front page

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,44 @@ What it does:
 The target audience is anyone running Kafka consumers that transform, enrich, or route — and would rather not glue their
 own consumer loop together every time.
 
+## The numbers, up front
+
+Two claims, both backed in this repo rather than asserted.
+
+**1. The fastest correct consumer runtime we measured.** The [`benchmarks/`](benchmarks/) module runs kpipe head-to-head
+against Confluent Parallel Consumer, Reactor Kafka, a raw `KafkaConsumer` + virtual-threads loop, a single-threaded
+loop, and the KIP-932 share consumer — same broker, same workload, simulated per-record work. At production-like work
+levels (≥100µs per record — any DB or HTTP hop), kpipe leads every runtime that provides at-least-once delivery through
+a maintained library:
+
+| Runtime (delivery guarantee)                          | 100µs / record | 1ms / record |
+| ----------------------------------------------------- | -------------: | -----------: |
+| **kpipe `PARALLEL`** (at-least-once)                  |     126k rec/s |   134k rec/s |
+| **kpipe `KEY_ORDERED`** (at-least-once, per-key FIFO) |     154k rec/s |    91k rec/s |
+| Confluent PC `UNORDERED` (at-least-once)              |           104k |          68k |
+| Confluent PC `KEY` (per-key FIFO)                     |            94k |          62k |
+| Reactor Kafka                                         |            23k |         3.7k |
+| Single-threaded `KafkaConsumer` loop                  |           6.0k |         0.9k |
+
+The only faster arm is the hand-rolled `KafkaConsumer` + virtual-threads loop (641k+) — and it is unsafe: no honest
+offset commit, records lost on rebalance. kpipe is what that loop becomes once you make it at-least-once. These are
+shared-CI-runner numbers — read the ordering between runtimes, not the absolute magnitudes; full capture, error bars,
+and caveats in [`benchmarks/results/2026-06-20.md`](benchmarks/results/2026-06-20.md).
+
+The honest tradeoff: kpipe allocates the most per record of the field (1,628 B/op vs Confluent PC's 33). Roughly 62% of
+that is the fresh virtual thread per record — the same property that buys the throughput lead under blocking work.
+Attribution profile in
+[`benchmarks/results/2026-06-21-allocation-attribution.md`](benchmarks/results/2026-06-21-allocation-attribution.md).
+Not free, and not hidden.
+
+**2. The at-least-once claim is verified, not asserted.** Every CI run gates on 15
+[jcstress](https://openjdk.org/projects/code-tools/jcstress/) concurrency-stress tests across 5 modules, exercising the
+offset state machine, the dispatchers, and the circuit-breaker window under real interleavings. On top of that: jqwik
+property-based suites over the offset lifecycle, and chaos-rebalance + crash-restart Testcontainers E2E tests against a
+real broker. Building this suite found and fixed three real production bugs before any user hit them — a pending-set
+data-loss race in offset tracking, silent record loss on DLQ send failure, and a circuit breaker blind to the batch
+path. No competing consumer library states — or tests — its delivery guarantee this way.
+
 ### Two API surfaces
 
 There are two public entry points; pick whichever matches the shape of your problem:

--- a/README.md
+++ b/README.md
@@ -29,43 +29,53 @@ own consumer loop together every time.
 
 ## The numbers, up front
 
-Two claims, both backed in this repo rather than asserted.
+Two claims, both backed in this repo.
 
-**1. The fastest correct consumer runtime we measured.** The [`benchmarks/`](benchmarks/) module runs kpipe head-to-head
-against Confluent Parallel Consumer, Reactor Kafka, a raw `KafkaConsumer` + virtual-threads loop, a single-threaded
-loop, and the KIP-932 share consumer — same broker, same workload, simulated per-record work. At production-like work
-levels (≥100µs per record — any DB or HTTP hop), kpipe leads every runtime that provides at-least-once delivery through
-a maintained library:
+**1. The fastest at-least-once runtime we measured.** The [`benchmarks/`](benchmarks/) module runs KPipe head-to-head
+against Confluent Parallel Consumer, Reactor Kafka, the KIP-932 share consumer, a raw `KafkaConsumer` + virtual-threads
+loop, and a single-threaded loop — same broker, same workload, simulated per-record work. The statistically cleanest
+result: at 1ms of per-record work, **KPipe `KEY_ORDERED` does 91k rec/s (±3%) against Confluent PC `KEY`'s 62k (±2%)** —
+the same per-key-FIFO guarantee at ~1.5× the throughput, with cleanly separated error bars. Across both captured work
+levels, KPipe leads every library-provided at-least-once arm:
 
 | Runtime (delivery guarantee)                          | 100µs / record | 1ms / record |
 | ----------------------------------------------------- | -------------: | -----------: |
-| **kpipe `PARALLEL`** (at-least-once)                  |     126k rec/s |   134k rec/s |
-| **kpipe `KEY_ORDERED`** (at-least-once, per-key FIFO) |     154k rec/s |    91k rec/s |
-| Confluent PC `UNORDERED` (at-least-once)              |           104k |          68k |
-| Confluent PC `KEY` (per-key FIFO)                     |            94k |          62k |
-| Reactor Kafka                                         |            23k |         3.7k |
-| Single-threaded `KafkaConsumer` loop                  |           6.0k |         0.9k |
+| **KPipe `PARALLEL`** (at-least-once)                  |          ~126k |           —¹ |
+| **KPipe `KEY_ORDERED`** (at-least-once, per-key FIFO) |          ~154k |    91k (±3%) |
+| Confluent PC `UNORDERED` (at-least-once)              |          ~104k |          68k |
+| Confluent PC `KEY` (at-least-once, per-key FIFO)      |           ~94k |          62k |
+| Reactor Kafka (at-least-once)                         |           ~23k |         3.7k |
+| Kafka share consumer, KIP-932 (at-least-once)         |          ~4.7k |         4.7k |
+| Single-threaded loop (at-least-once, per-partition)   |          ~6.0k |         0.9k |
 
-The only faster arm is the hand-rolled `KafkaConsumer` + virtual-threads loop (641k+) — and it is unsafe: no honest
-offset commit, records lost on rebalance. kpipe is what that loop becomes once you make it at-least-once. These are
-shared-CI-runner numbers — read the ordering between runtimes, not the absolute magnitudes; full capture, error bars,
-and caveats in [`benchmarks/results/2026-06-20.md`](benchmarks/results/2026-06-20.md).
+¹ JMH could not compute a stable error for this cell in the CI capture; KPipe's 1ms lead is carried by the `KEY_ORDERED`
+row.
 
-The honest tradeoff: kpipe allocates the most per record of the field (1,628 B/op vs Confluent PC's 33). Roughly 62% of
-that is the fresh virtual thread per record — the same property that buys the throughput lead under blocking work.
-Attribution profile in
+Read the table honestly: these are provisional numbers from a shared-CI-runner capture at fork=2 — below the fork=5
+publishing bar our own [methodology](benchmarks/METHODOLOGY.md) sets — so read the ordering between libraries, not the
+absolute magnitudes, and don't read the deltas between KPipe's own two modes (those are within the error bars). The
+10–100ms regime, where consumers doing real DB/HTTP hops live, is not yet captured. Full table, error bars, and every
+caveat: [`benchmarks/results/2026-06-20.md`](benchmarks/results/2026-06-20.md).
+
+The only faster arm in the capture is the hand-rolled `KafkaConsumer` + virtual-threads loop (641k+) — and it is unsafe:
+no honest offset commit, records lost on rebalance. KPipe is what that loop becomes once you make it at-least-once. One
+more disclosure that is also part of the pitch: Confluent Parallel Consumer 0.5.3.3 is the last release before the
+project was officially retired in 2026-05, and its successor fork has not yet published an artifact.
+
+The honest tradeoff: KPipe allocates the most per record of any arm measured (1,628 B/op vs Confluent PC's 33 B/op).
+Roughly 62% of that is the fresh virtual thread per record — the same property that buys the throughput lead under
+blocking work. The attribution profile is in
 [`benchmarks/results/2026-06-21-allocation-attribution.md`](benchmarks/results/2026-06-21-allocation-attribution.md).
 Not free, and not hidden.
 
-**2. The at-least-once claim is verified, not asserted.** Every CI run gates on 15
-[jcstress](https://openjdk.org/projects/code-tools/jcstress/) concurrency-stress tests across 4 modules, exercising the
-offset state machine, the dispatchers, and the circuit-breaker window under real interleavings. On top of that: jqwik
-property-based suites over the offset lifecycle, and chaos-rebalance + crash-restart Testcontainers E2E tests against a
-real broker. Building this suite found and fixed three real production bugs before any user hit them — a pending-set
-data-loss race in offset tracking, silent record loss on DLQ send failure, and a circuit breaker blind to the batch
-path. No competing consumer library states — or tests — its delivery guarantee this way.
+**2. The at-least-once claim is verified, not asserted.** Every CI run gates on 16
+[jcstress](https://openjdk.org/projects/code-tools/jcstress/) concurrency-stress tests across 4 modules, plus jqwik
+property-based suites over the offset lifecycle and chaos-rebalance + crash-restart Testcontainers E2E tests against a
+real broker. Building that suite found and fixed three real data-loss and correctness bugs before any user hit them (an
+offset-tracking race, silent loss on DLQ send failure, a circuit breaker blind to the batch path). None of the runtimes
+we benchmark against state — or test — their delivery guarantee this way.
 
-### Two API surfaces
+## Two API surfaces
 
 There are two public entry points; pick whichever matches the shape of your problem:
 
@@ -1359,8 +1369,9 @@ shape (I/O vs CPU bound), partitioning, and message size — these are micro-lev
   magic bytes and schema IDs without `Arrays.copyOfRange`.
 - fastjson2 for JSON parsing. Faster than Jackson on the hot path with similar GC pressure, and actively maintained.
 
-The latest parallel benchmark in [`benchmarks/README.md`](benchmarks/README.md) shows KPipe ahead of Confluent Parallel
-Consumer on throughput, with a higher allocation footprint. Scenario-specific — not a blanket claim.
+The latest competitive capture ([`benchmarks/results/2026-06-20.md`](benchmarks/results/2026-06-20.md) — summarized in
+[The numbers, up front](#the-numbers-up-front)) shows KPipe ahead of Confluent Parallel Consumer on throughput, with a
+higher allocation footprint. Scenario-specific — not a blanket claim.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Attribution profile in
 Not free, and not hidden.
 
 **2. The at-least-once claim is verified, not asserted.** Every CI run gates on 15
-[jcstress](https://openjdk.org/projects/code-tools/jcstress/) concurrency-stress tests across 5 modules, exercising the
+[jcstress](https://openjdk.org/projects/code-tools/jcstress/) concurrency-stress tests across 4 modules, exercising the
 offset state machine, the dispatchers, and the circuit-breaker window under real interleavings. On top of that: jqwik
 property-based suites over the offset lifecycle, and chaos-rebalance + crash-restart Testcontainers E2E tests against a
 real broker. Building this suite found and fixed three real production bugs before any user hit them — a pending-set

--- a/benchmarks/METHODOLOGY.md
+++ b/benchmarks/METHODOLOGY.md
@@ -98,18 +98,26 @@ Per-benchmark overrides:
 
 ### Recommended publishing run
 
+This is the overnight capture: every arm, each benchmark's full `workMicros` sweep (no override — including the 10–100ms
+regime where most real consumers live), latency percentiles included, on a quiesced box (no browser, no IDE indexing,
+mains power). The single-threaded arm is the long pole — 25k records × 100ms ≈ 42 min per iteration at the top cell —
+which is why this run cannot fit CI's 6-hour cap.
+
 ```bash
 ./gradlew :benchmarks:jmh \
   -Pjmh.includes='ParallelProcessingBenchmark|ParallelProcessingLatencyBenchmark' \
   -Pjmh.warmupIterations=3 \
   -Pjmh.iterations=5 \
-  -Pjmh.fork=2 \
+  -Pjmh.fork=5 \
   -Pjmh.profilers='gc' \
   -Pjmh.resultFormat=JSON
 ```
 
-Two forks instead of one cuts the cross-fork noise on the latency percentiles. The `gc` profiler adds allocation rate
-and GC count per benchmark — required input to the "throughput vs allocation-cost" trade-off.
+Five forks, not two: the 2026-06-20 CI capture at fork=2 produced 25%+ error bars and two cells where JMH could not
+compute a stable cross-fork stddev at all (`NaN` score-error) — fork=2 is the floor for _running_, not for _publishing_.
+The `gc` profiler adds allocation rate and GC count per benchmark — required input to the "throughput vs
+allocation-cost" trade-off. Afterwards, copy `build/results/jmh/results.json` into `results/` alongside a dated markdown
+snapshot per [What to write down with every published number](#what-to-write-down-with-every-published-number).
 
 ### Quick smoke run (for local sanity-check)
 

--- a/benchmarks/METHODOLOGY.md
+++ b/benchmarks/METHODOLOGY.md
@@ -41,7 +41,7 @@ The last one is KPipe alone, parameterised across batch size and sink latency.
 > Maven Central publishing infrastructure (commit "feat(publish): Maven Central publishing", 2026-04-22) but **has not
 > yet released a stable artifact** — the source pom is `0.6.0.0-SNAPSHOT` and `io.github.astubbs.parallelconsumer`
 > returns zero results on Maven Central. The benchmarks therefore still depend on the deprecated
-> `io.confluent.parallelconsumer:parallel-consumer-core:0.5.3.0`. Swap when Stubbs publishes a release.
+> `io.confluent.parallelconsumer:parallel-consumer-core:0.5.3.3`. Swap when Stubbs publishes a release.
 
 Two axes worth attention. **Threading model**: Loom-based (KPipe PARALLEL/KEY_ORDERED, share, raw) vs platform-threaded
 (single-threaded, Confluent's three modes, Reactor) — Loom absorbs blocking work; platform pools don't. **Ordering
@@ -98,10 +98,12 @@ Per-benchmark overrides:
 
 ### Recommended publishing run
 
-This is the overnight capture: every arm, each benchmark's full `workMicros` sweep (no override — including the 10–100ms
-regime where most real consumers live), latency percentiles included, on a quiesced box (no browser, no IDE indexing,
-mains power). The single-threaded arm is the long pole — 25k records × 100ms ≈ 42 min per iteration at the top cell —
-which is why this run cannot fit CI's 6-hour cap.
+This is the full publishing capture: every arm, each benchmark's full `workMicros` sweep (no override — including the
+10–100ms regime where most real consumers live), latency percentiles included, on a quiesced box (no browser, no IDE
+indexing, mains power). Plan for a weekend, not an overnight: the single-threaded arm is the long pole — 25k records ×
+100ms ≈ 42 min per iteration at the top cell, which at fork=5 is a multi-day tail (and why this run cannot fit CI's
+6-hour cap). To fit an actual overnight window, exclude the serial arm's pathological cells with the include-regex trick
+from the CI section and capture `singleThread` separately at lower fork counts.
 
 ```bash
 ./gradlew :benchmarks:jmh \
@@ -183,6 +185,8 @@ annotation drives the mode:
   -Pjmh.workMicros='100'
 ```
 
+(fork=2 here is the quick spot-check; percentiles you intend to publish belong in the fork=5 publishing run above.)
+
 ## What to write down with every published number
 
 A bench number without context is unverifiable. Each entry in `results/` should record:
@@ -221,7 +225,9 @@ pattern that produces good average throughput but occasional stragglers.
 ### Within-iteration vs cross-fork variance
 
 The default `forks=1` means all iterations share the same JVM process. Cross-fork variance (JIT warmup differences, GC
-profile differences across forks) doesn't get exposed. For published numbers run with `forks=2` minimum.
+profile differences across forks) doesn't get exposed. `forks=2` is the minimum that exposes cross-fork variance at all;
+for published numbers use `forks=5` (see [Recommended publishing run](#recommended-publishing-run) — the 2026-06-20
+fork=2 capture produced 25%+ error bars and NaN score-errors).
 
 ## Caveats
 


### PR DESCRIPTION
## What

Docs-only. Two changes:

**README — new "The numbers, up front" section** right after the intro bullets:
- Condensed competitive table from the [2026-06-20 capture](benchmarks/results/2026-06-20.md): kpipe vs Confluent Parallel Consumer / Reactor Kafka / single-threaded at 100µs and 1ms per-record work, with the "read the ordering, not the absolutes" shared-runner caveat and a link to the full capture.
- The raw-loop framing (the only faster arm is unsafe; kpipe is that loop made at-least-once).
- The honest allocation tradeoff (1,628 B/op, ~62% VT-per-record) with the [attribution profile](benchmarks/results/2026-06-21-allocation-attribution.md) linked — the candor is deliberate.
- The verification story: 15 jcstress tests across 5 modules gating CI, jqwik property suites, chaos-rebalance + crash-restart E2E, and the 3 real bugs the suite caught.

**METHODOLOGY — publishing run is now the overnight capture**: fork=5 (2026-06-20 showed fork=2 → 25%+ error bars and NaN score-errors), full `workMicros` sweep including the 10–100ms regime, latency percentiles, and post-run capture steps. CI-scoped commands intentionally stay fork=2 (they exist to fit the 6-hour cap).

## Verification

Every number in the README table was checked verbatim against `benchmarks/results/2026-06-20.md`; the allocation figures against `2026-06-21-allocation-attribution.md`; the jcstress/bug counts against the #217 suite. No code changes.