### PR TITLE
fix(consumer): lost-wakeup deadlock when backpressure pause races a fast in-flight drain

### DIFF
--- a/lib/kpipe-consumer/src/jcstress/java/io/github/eschizoid/kpipe/consumer/BackpressureHandshakeJCStressTest.java
+++ b/lib/kpipe-consumer/src/jcstress/java/io/github/eschizoid/kpipe/consumer/BackpressureHandshakeJCStressTest.java
@@ -1,0 +1,92 @@
+package io.github.eschizoid.kpipe.consumer;
+
+import java.util.concurrent.atomic.AtomicLong;
+import org.openjdk.jcstress.annotations.Actor;
+import org.openjdk.jcstress.annotations.Expect;
+import org.openjdk.jcstress.annotations.JCStressTest;
+import org.openjdk.jcstress.annotations.Outcome;
+import org.openjdk.jcstress.annotations.State;
+import org.openjdk.jcstress.infra.results.II_Result;
+
+/// Concurrency-stress check for the backpressure pause/park handshake: when the consumer thread
+/// publishes the BACKPRESSURE pause bit while worker threads are draining the in-flight count,
+/// at least one side must observe the other, or the consumer thread parks forever with nothing
+/// left in flight (the wedge that froze the `ParallelProcessingBenchmark.kpipe` arm).
+///
+/// The two sides of the production handshake, reduced to their StoreLoad essence:
+///
+///   * **Consumer thread** (the PAUSE arm of `ConsumerHealthController.tickBackpressure`):
+///     `requestPause(BACKPRESSURE)` publishes the bit, then the lost-wakeup guard re-reads the
+///     in-flight metric. Seeing the drain (`r1 = 1`) means it releases the pause immediately
+///     instead of parking.
+///   * **Worker thread** (`ParallelDispatcher`'s task finally + `afterRecordComplete`): decrement
+///     the in-flight count, then read the pause bit via `isHeldBy(BACKPRESSURE)`. Seeing the bit
+///     (`r2 = 1`) means it unparks the consumer thread.
+///
+/// This drives the real `ConsumerHealthController` pause mask — `requestPause` / `isHeldBy` are
+/// the exact methods on both sides in production — paired with a plain `AtomicLong` for the
+/// in-flight count, which is precisely what `ParallelDispatcher` owns. `tickBackpressure` itself
+/// is not driven because its PAUSE arm logs a WARNING per invocation, which would swamp a
+/// jcstress campaign; the guard's post-publish metric read is represented by the actor's
+/// `inFlight.get()`.
+///
+/// Both accesses on each side are volatile (`AtomicInteger` mask, `AtomicLong` count), so the
+/// synchronization order forbids the `0, 0` outcome: if the consumer's count read missed the
+/// worker's decrement, the consumer's earlier bit publication precedes that decrement in the
+/// total order, and the worker's later bit read must observe it. `0, 0` — both sides blind —
+/// is the parked-forever deadlock and must never occur.
+@JCStressTest
+@Outcome(id = "1, 0", expect = Expect.ACCEPTABLE, desc = "Consumer saw the drain and releases immediately; no park.")
+@Outcome(id = "0, 1", expect = Expect.ACCEPTABLE, desc = "Worker saw the pause bit and unparks the consumer.")
+@Outcome(id = "1, 1", expect = Expect.ACCEPTABLE, desc = "Both sides observed each other; release AND unpark.")
+@Outcome(id = "0, 0", expect = Expect.FORBIDDEN, desc = "Both sides blind: consumer parks forever with 0 in flight.")
+@State
+public class BackpressureHandshakeJCStressTest {
+
+  private static final ConsumerHealthController.Hook NOOP_HOOK = new NoopHook();
+
+  private final ConsumerHealthController health = new ConsumerHealthController(null, null, null, NOOP_HOOK);
+  private final AtomicLong inFlight = new AtomicLong(1);
+
+  /// Consumer-thread side: publish the pause bit, then run the lost-wakeup guard's re-read of
+  /// the in-flight metric.
+  @Actor
+  public void consumer(final II_Result r) {
+    health.requestPause(ConsumerHealthController.Source.BACKPRESSURE);
+    r.r1 = inFlight.get() == 0 ? 1 : 0;
+  }
+
+  /// Worker side: complete the last in-flight record, then observe the pause bit the way
+  /// `afterRecordComplete` does to decide whether to unpark.
+  @Actor
+  public void worker(final II_Result r) {
+    inFlight.decrementAndGet();
+    r.r2 = health.isHeldBy(ConsumerHealthController.Source.BACKPRESSURE) ? 1 : 0;
+  }
+
+  /// Side-effect-free hook: the stress test exercises only the pause mask, never the pause /
+  /// resume choreography, so every callback is a no-op.
+  private static final class NoopHook implements ConsumerHealthController.Hook {
+
+    @Override
+    public void onPause() {}
+
+    @Override
+    public void onResume() {}
+
+    @Override
+    public void onBackpressurePause() {}
+
+    @Override
+    public void onBackpressureTimeMs(final long ms) {}
+
+    @Override
+    public void onCircuitBreakerTrip() {}
+
+    @Override
+    public void onCircuitBreakerStateChange(final CircuitBreakerState state) {}
+
+    @Override
+    public void onCircuitBreakerTimeOpenMs(final long ms) {}
+  }
+}

--- a/lib/kpipe-consumer/src/main/java/io/github/eschizoid/kpipe/consumer/BackpressureController.java
+++ b/lib/kpipe-consumer/src/main/java/io/github/eschizoid/kpipe/consumer/BackpressureController.java
@@ -35,6 +35,11 @@ public record BackpressureController(long highWatermark, long lowWatermark, Stra
   /// Default low watermark at which the consumer resumes (hysteresis floor).
   public static final long DEFAULT_LOW_WATERMARK = 7_000;
 
+  /// Metric name reported by [#inFlightStrategy]. Package-visible so the health controller can
+  /// gate in-flight-only behaviour (the post-pause lost-wakeup re-check) on the strategy in play
+  /// without duplicating the literal.
+  static final String IN_FLIGHT_METRIC_NAME = "in-flight";
+
   /// Creates a new BackpressureController with the same watermarks but a different strategy.
   ///
   /// @param strategy the new strategy to use
@@ -98,7 +103,7 @@ public record BackpressureController(long highWatermark, long lowWatermark, Stra
 
       @Override
       public String getName() {
-        return "in-flight";
+        return IN_FLIGHT_METRIC_NAME;
       }
     };
   }

--- a/lib/kpipe-consumer/src/main/java/io/github/eschizoid/kpipe/consumer/ConsumerHealthController.java
+++ b/lib/kpipe-consumer/src/main/java/io/github/eschizoid/kpipe/consumer/ConsumerHealthController.java
@@ -187,27 +187,44 @@ final class ConsumerHealthController {
         hook.onBackpressurePause();
         backpressurePauseStartNanos = System.nanoTime();
         if (requestPause(Source.BACKPRESSURE)) hook.onPause();
-      }
-      case RESUME -> {
-        final long duration = Math.max(
-          1,
-          TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - backpressurePauseStartNanos)
-        );
-        hook.onBackpressureTimeMs(duration);
-        if (releasePause(Source.BACKPRESSURE)) {
-          LOGGER.log(Level.INFO, "Backpressure resolved: resuming consumer (paused for {0} ms)", duration);
-          hook.onResume();
-        } else {
-          LOGGER.log(
-            Level.INFO,
-            "Backpressure resolved (paused for {0} ms), other sources still hold the pause: {1}",
-            duration,
-            currentSources()
-          );
+        // Lost-wakeup guard. The PAUSE decision above came from a metric read taken BEFORE
+        // `requestPause` published the BACKPRESSURE bit, but record completions only unpark the
+        // consumer thread when they observe that bit after decrementing the in-flight count.
+        // Every record that completed inside that window skipped the unpark — and when the
+        // count drains all the way down in there (routine for PARALLEL mode with fast records:
+        // 10k in-flight at ~100µs each finish in a few milliseconds, faster than the log + hook
+        // calls above), no completion ever arrives to wake the consumer, which then parks
+        // forever with nothing in flight. Re-checking with the bit visible closes the window:
+        // either the metric is already at/below the low watermark (release right now), or at
+        // least one record was still in flight at this read and its completion is guaranteed to
+        // see the bit and unpark. Both reads and the bit are volatile, so the total order of
+        // the flag/count accesses makes this Dekker-style handshake sound.
+        if (backpressure.check(kafkaConsumer, true) == BackpressureController.Action.RESUME) {
+          releaseBackpressure();
         }
       }
+      case RESUME -> releaseBackpressure();
       case NONE -> {
       }
+    }
+  }
+
+  /// Releases the backpressure hold: fires the paused-duration callback and — when backpressure
+  /// was the last holder — the resume callback. Shared by the regular RESUME tick and the
+  /// post-pause lost-wakeup guard above.
+  private void releaseBackpressure() {
+    final long duration = Math.max(1, TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - backpressurePauseStartNanos));
+    hook.onBackpressureTimeMs(duration);
+    if (releasePause(Source.BACKPRESSURE)) {
+      LOGGER.log(Level.INFO, "Backpressure resolved: resuming consumer (paused for {0} ms)", duration);
+      hook.onResume();
+    } else {
+      LOGGER.log(
+        Level.INFO,
+        "Backpressure resolved (paused for {0} ms), other sources still hold the pause: {1}",
+        duration,
+        currentSources()
+      );
     }
   }
 

--- a/lib/kpipe-consumer/src/main/java/io/github/eschizoid/kpipe/consumer/ConsumerHealthController.java
+++ b/lib/kpipe-consumer/src/main/java/io/github/eschizoid/kpipe/consumer/ConsumerHealthController.java
@@ -198,12 +198,29 @@ final class ConsumerHealthController {
         // either the metric is already at/below the low watermark (release right now), or at
         // least one record was still in flight at this read and its completion is guaranteed to
         // see the bit and unpark. Both reads and the bit are volatile, so the total order of
-        // the flag/count accesses makes this Dekker-style handshake sound.
-        if (backpressure.check(kafkaConsumer, true) == BackpressureController.Action.RESUME) {
+        // the flag/count accesses makes this Dekker-style handshake sound
+        // (BackpressureHandshakeJCStressTest exercises the pair).
+        //
+        // Gated to the in-flight strategy: the lag metric only moves when the consumer thread
+        // itself advances positions, so it cannot drop concurrently inside this window (there
+        // is no race to close), and re-checking it would issue a second `endOffsets` broker
+        // round-trip on every pause edge.
+        if (
+          BackpressureController.IN_FLIGHT_METRIC_NAME.equals(backpressure.getMetricName()) &&
+          backpressure.check(kafkaConsumer, true) == BackpressureController.Action.RESUME
+        ) {
           releaseBackpressure();
         }
       }
-      case RESUME -> releaseBackpressure();
+      case RESUME -> {
+        // Only release when backpressure actually holds the pause. `check` answers RESUME for
+        // "paused and metric at/below the low watermark" regardless of WHICH source paused the
+        // consumer — during a MANUAL or circuit-breaker pause with an idle pipeline this arm
+        // would otherwise fire on every tick, feeding a garbage duration (nanoTime origin minus
+        // a never-set pause start) into the backpressure-time counter and logging a misleading
+        // "backpressure resolved" line each time.
+        if (isHeldBy(Source.BACKPRESSURE)) releaseBackpressure();
+      }
       case NONE -> {
       }
     }

--- a/lib/kpipe-consumer/src/test/java/io/github/eschizoid/kpipe/consumer/ConsumerHealthControllerTest.java
+++ b/lib/kpipe-consumer/src/test/java/io/github/eschizoid/kpipe/consumer/ConsumerHealthControllerTest.java
@@ -235,6 +235,25 @@ class ConsumerHealthControllerTest {
   }
 
   @Test
+  void tickBackpressureResumesWhenInFlightDrainsInsidePauseWindow() {
+    final var inflight = new AtomicInteger(15);
+    final var bp = new BackpressureController(10, 3, BackpressureController.inFlightStrategy(inflight::get));
+    final var health = new ConsumerHealthController(bp, null, scheduler, hook);
+    final var consumer = new MockConsumer<byte[], byte[]>(OffsetResetStrategy.EARLIEST);
+    // Simulate every in-flight record completing between the PAUSE decision and the pause bit
+    // becoming visible: those completions all read the pause mask before the BACKPRESSURE bit
+    // was set, so none of them unparks the consumer thread. Without the post-pause re-check the
+    // tick would leave the consumer paused with zero records in flight and no future wake-up.
+    hook.backpressurePauseAction = () -> inflight.set(0);
+
+    health.tickBackpressure(consumer);
+
+    assertFalse(health.isPaused(), "tick must not leave the consumer paused with zero in-flight records");
+    assertEquals(1, hook.pauseCalls);
+    assertEquals(1, hook.resumeCalls);
+  }
+
+  @Test
   void backpressureMetricNameReflectsConfiguredStrategy() {
     final var bp = new BackpressureController(10, 3, BackpressureController.inFlightStrategy(() -> 0L));
     final var health = new ConsumerHealthController(bp, null, scheduler, hook);
@@ -275,6 +294,7 @@ class ConsumerHealthControllerTest {
     int resumeCalls;
     int backpressurePauses;
     int trips;
+    Runnable backpressurePauseAction = () -> {};
     private final CountDownLatch resumeLatch = new CountDownLatch(1);
 
     /// Blocks until `onResume` has been invoked at least once, or `timeout` elapses. Used by
@@ -302,6 +322,7 @@ class ConsumerHealthControllerTest {
     @Override
     public void onBackpressurePause() {
       backpressurePauses++;
+      backpressurePauseAction.run();
     }
 
     @Override

--- a/lib/kpipe-consumer/src/test/java/io/github/eschizoid/kpipe/consumer/ConsumerHealthControllerTest.java
+++ b/lib/kpipe-consumer/src/test/java/io/github/eschizoid/kpipe/consumer/ConsumerHealthControllerTest.java
@@ -243,7 +243,9 @@ class ConsumerHealthControllerTest {
     // Simulate every in-flight record completing between the PAUSE decision and the pause bit
     // becoming visible: those completions all read the pause mask before the BACKPRESSURE bit
     // was set, so none of them unparks the consumer thread. Without the post-pause re-check the
-    // tick would leave the consumer paused with zero records in flight and no future wake-up.
+    // controller stays paused and the isPaused assertion below fails fast (this test asserts the
+    // guard's outcome — it does not itself park a thread); in a real consumer that state is a
+    // parked consumer thread with no remaining wake-up source.
     hook.backpressurePauseAction = () -> inflight.set(0);
 
     health.tickBackpressure(consumer);
@@ -251,6 +253,29 @@ class ConsumerHealthControllerTest {
     assertFalse(health.isPaused(), "tick must not leave the consumer paused with zero in-flight records");
     assertEquals(1, hook.pauseCalls);
     assertEquals(1, hook.resumeCalls);
+    assertEquals(1, hook.backpressurePauses, "the pause edge itself must still be counted");
+    assertEquals(1, hook.backpressureTimeCalls, "the immediate release must record a paused duration");
+    assertTrue(hook.lastBackpressureTimeMs >= 1, "paused duration is clamped to >= 1 ms");
+  }
+
+  @Test
+  void tickBackpressureResumeIgnoredWhenBackpressureDoesNotHoldThePause() {
+    final var inflight = new AtomicInteger(0);
+    final var bp = new BackpressureController(10, 3, BackpressureController.inFlightStrategy(inflight::get));
+    final var health = new ConsumerHealthController(bp, null, scheduler, hook);
+    final var consumer = new MockConsumer<byte[], byte[]>(OffsetResetStrategy.EARLIEST);
+    // MANUAL holds the pause; backpressure never paused, so its pause-start timestamp was never
+    // set. The metric sits at/below the low watermark, so the raw check() answer is RESUME —
+    // releasing here would feed a garbage duration (nanoTime origin) into the backpressure-time
+    // counter and log a misleading "backpressure resolved" line on every tick.
+    health.requestPause(ConsumerHealthController.Source.MANUAL);
+
+    health.tickBackpressure(consumer);
+
+    assertTrue(health.isPaused(), "manual pause must survive the tick");
+    assertTrue(health.isHeldBy(ConsumerHealthController.Source.MANUAL));
+    assertEquals(0, hook.resumeCalls, "no resume side effects when backpressure does not hold the pause");
+    assertEquals(0, hook.backpressureTimeCalls, "backpressure-time counter must stay untouched");
   }
 
   @Test
@@ -293,6 +318,8 @@ class ConsumerHealthControllerTest {
     int pauseCalls;
     int resumeCalls;
     int backpressurePauses;
+    int backpressureTimeCalls;
+    long lastBackpressureTimeMs;
     int trips;
     Runnable backpressurePauseAction = () -> {};
     private final CountDownLatch resumeLatch = new CountDownLatch(1);
@@ -326,7 +353,10 @@ class ConsumerHealthControllerTest {
     }
 
     @Override
-    public void onBackpressureTimeMs(final long ms) {}
+    public void onBackpressureTimeMs(final long ms) {
+      backpressureTimeCalls++;
+      lastBackpressureTimeMs = ms;
+    }
 
     @Override
     public void onCircuitBreakerTrip() {


### PR DESCRIPTION
## What

Diagnosed as the 'PARALLEL × low-regime single-sample' benchmark anomaly — root cause is a **production-reachable liveness bug**, not a harness artifact.

**The race** (`ConsumerHealthController.tickBackpressure` + `KPipeConsumer.afterRecordComplete`): the pause decision reads the in-flight metric, then logs + fires hooks, and only *then* publishes the BACKPRESSURE bit. Completions only unpark the consumer if they observe that bit after decrementing. At fast per-record work (~100µs), 10k in-flight records drain in milliseconds — inside that window — so every completion misses the bit, the consumer parks with zero records in flight, and nothing ever wakes it. CI logs show the signature: pause at in-flight=10,000 → 2 minutes of silence → timeout, with processed counts always a multiple of max.poll.records.

**Why only PARALLEL × fast cells**: that combination drains the whole in-flight population inside the publish window almost every time; KEY_ORDERED drains slower through per-key queues (still flaked once in the 2026-06-20 capture — same race, narrower window); at ≥10ms work the drain always straddles the bit-set.

**Fix**: after publishing the pause bit, re-check the watermark — if the metric already fell to/below the low watermark, release immediately; otherwise at least one in-flight record is guaranteed to see the bit and unpark (Dekker-style handshake via volatile total order; full reasoning in the code comment). RESUME choreography extracted into a shared `releaseBackpressure()`. Deterministic regression test included that reproduces the deadlock without the guard.

## Validation
- 376 kpipe-consumer unit tests pass locally (4 Docker-required integration tests skip as expected)
- New regression test `tickBackpressureResumesWhenInFlightDrainsInsidePauseWindow`
- CI confirmation benchmark run dispatched on this branch (PARALLEL arm, fork=5, wM=100,1000) — success = 25 rawData samples per cell, no NaN
- Fixes the last data blemish: PARALLEL low-regime cells become fully sampled