### PR TITLE
perf(consumer): primitive-long pending-offset set — −45% offset-manager allocation

### DIFF
--- a/README.md
+++ b/README.md
@@ -414,7 +414,8 @@ KPipe runs on Java virtual threads ([Project Loom](https://openjdk.org/projects/
 KPipe never commits past an in-flight record. The implementation:
 
 - `OffsetManager` is an interface — Kafka-backed by default, but you can plug in external storage.
-- Every in-flight offset is tracked in a `ConcurrentSkipListSet` per partition (see `KafkaOffsetManager`).
+- Every in-flight offset is tracked in a sorted primitive-`long` pending set per partition (see `KafkaOffsetManager` /
+  `PendingOffsetSet` — allocation-free on the track/mark hot path).
 - Offset 102 cannot be committed until 101 finishes, even if 102 completes first. No gaps.
 - On crash, the consumer resumes from the last committed offset. Some records may be reprocessed — standard
   at-least-once behavior — but nothing is skipped.

--- a/docs/OFFSET-INVARIANTS.md
+++ b/docs/OFFSET-INVARIANTS.md
@@ -22,8 +22,9 @@ phrased as a property a test can assert.
 
 ## Vocabulary
 
-- **track**: `trackOffset(record)` — adds `record.offset()` to the per-partition pending set
-  (`ConcurrentSkipListSet<Long>`). Marks "this offset has started processing."
+- **track**: `trackOffset(record)` — adds `record.offset()` to the per-partition pending set (`PendingOffsetSet`, a
+  monitor-synchronized sorted primitive-`long` window; previously `ConcurrentSkipListSet<Long>`, replaced to eliminate
+  per-record boxing and skiplist-node churn). Marks "this offset has started processing."
 - **mark**: `markOffsetProcessed(record)` — removes `record.offset()` from the pending set and bumps the per-partition
   `highestProcessedOffset`. Marks "this offset reached a terminal state."
 - **commit point**: the offset the manager would commit to Kafka right now for a partition. In Kafka's "next offset"

--- a/lib/kpipe-consumer/src/jcstress/java/io/github/eschizoid/kpipe/consumer/PendingOffsetSetAddRemoveJCStressTest.java
+++ b/lib/kpipe-consumer/src/jcstress/java/io/github/eschizoid/kpipe/consumer/PendingOffsetSetAddRemoveJCStressTest.java
@@ -9,19 +9,30 @@ import org.openjdk.jcstress.annotations.State;
 import org.openjdk.jcstress.infra.results.JJ_Result;
 
 /// Concurrency-stress check for `PendingOffsetSet` — the sorted primitive-`long` structure that
-/// replaced `ConcurrentSkipListSet<Long>` as the per-partition pending set — racing an `add`
-/// against the `remove` that empties the window.
+/// replaced `ConcurrentSkipListSet<Long>` as the per-partition pending set — running an `add`
+/// concurrently with the `remove` that empties the window.
 ///
-/// This is the structure-level analogue of `RemoveIfEmptyJCStressTest`: in production, `add` runs
-/// on the poll thread (`trackOffset`) while `remove` runs on worker virtual threads
-/// (`markOffsetProcessed`) for the same partition. Both mutate the shared head/tail window and its
-/// backing array. If the monitor discipline were broken — say, a torn head/tail update or a shift
-/// racing a reset-to-zero — the add could be lost, land unsorted, or corrupt the window bounds.
+/// What this proves — and what it cannot. Every `PendingOffsetSet` method is `synchronized` on
+/// the instance monitor, so the two mutator actors are fully mutually exclusive: jcstress can
+/// only realize the two SERIAL orderings (remove-then-add, add-then-remove), never an
+/// interleaving inside a window mutation. The properties this test pins are therefore:
+///
+/// * **Order-insensitive serial correctness.** Both orderings must converge on the same final
+///   state `{200}` — remove-then-add drains the window and repopulates it; add-then-remove takes
+///   the head-removal path out of `{100, 200}`.
+/// * **Monitor discipline as a regression guard.** If a future change dropped or weakened
+///   `synchronized` (plain fields, per-method locks), the actors WOULD interleave, and a lost
+///   add, torn `head`/`tail` update, or shift racing the reset-to-zero would grade as forbidden.
+///   The monitor's happens-before is also what makes both mutations visible to the arbiter.
+///
+/// The genuinely concurrent lock-set interaction in production — manager reads taking only the
+/// structure monitor while writers hold the map bucket lock plus the monitor — is exercised
+/// end-to-end by `SafeFirstJCStressTest`; the map-eviction race is `RemoveIfEmptyJCStressTest`.
 ///
 /// Scenario. The set starts holding exactly `{100}`. One actor removes 100 (draining the window,
-/// which resets `head`/`tail` to 0); the other adds 200. Whatever the interleaving, both
-/// operations must take effect: the set must end holding exactly `{200}`, so `firstOrNull` is 200
-/// and `size` is 1. Any other observation means a mutation was lost or the window corrupted.
+/// which resets `head`/`tail` to 0); the other adds 200. Under either ordering both operations
+/// must take effect: the set ends holding exactly `{200}`, so `firstOrNull` is 200 and `size`
+/// is 1.
 @JCStressTest
 @Outcome(id = "200, 1", expect = Expect.ACCEPTABLE, desc = "Added offset 200 survived the concurrent drain of 100.")
 @Outcome(id = ".*", expect = Expect.FORBIDDEN, desc = "A mutation was lost or the window was corrupted.")

--- a/lib/kpipe-consumer/src/jcstress/java/io/github/eschizoid/kpipe/consumer/PendingOffsetSetAddRemoveJCStressTest.java
+++ b/lib/kpipe-consumer/src/jcstress/java/io/github/eschizoid/kpipe/consumer/PendingOffsetSetAddRemoveJCStressTest.java
@@ -1,0 +1,53 @@
+package io.github.eschizoid.kpipe.consumer;
+
+import org.openjdk.jcstress.annotations.Actor;
+import org.openjdk.jcstress.annotations.Arbiter;
+import org.openjdk.jcstress.annotations.Expect;
+import org.openjdk.jcstress.annotations.JCStressTest;
+import org.openjdk.jcstress.annotations.Outcome;
+import org.openjdk.jcstress.annotations.State;
+import org.openjdk.jcstress.infra.results.JJ_Result;
+
+/// Concurrency-stress check for `PendingOffsetSet` — the sorted primitive-`long` structure that
+/// replaced `ConcurrentSkipListSet<Long>` as the per-partition pending set — racing an `add`
+/// against the `remove` that empties the window.
+///
+/// This is the structure-level analogue of `RemoveIfEmptyJCStressTest`: in production, `add` runs
+/// on the poll thread (`trackOffset`) while `remove` runs on worker virtual threads
+/// (`markOffsetProcessed`) for the same partition. Both mutate the shared head/tail window and its
+/// backing array. If the monitor discipline were broken — say, a torn head/tail update or a shift
+/// racing a reset-to-zero — the add could be lost, land unsorted, or corrupt the window bounds.
+///
+/// Scenario. The set starts holding exactly `{100}`. One actor removes 100 (draining the window,
+/// which resets `head`/`tail` to 0); the other adds 200. Whatever the interleaving, both
+/// operations must take effect: the set must end holding exactly `{200}`, so `firstOrNull` is 200
+/// and `size` is 1. Any other observation means a mutation was lost or the window corrupted.
+@JCStressTest
+@Outcome(id = "200, 1", expect = Expect.ACCEPTABLE, desc = "Added offset 200 survived the concurrent drain of 100.")
+@Outcome(id = ".*", expect = Expect.FORBIDDEN, desc = "A mutation was lost or the window was corrupted.")
+@State
+public class PendingOffsetSetAddRemoveJCStressTest {
+
+  private final PendingOffsetSet set = new PendingOffsetSet();
+
+  public PendingOffsetSetAddRemoveJCStressTest() {
+    set.add(100L);
+  }
+
+  @Actor
+  public void remover() {
+    set.remove(100L);
+  }
+
+  @Actor
+  public void adder() {
+    set.add(200L);
+  }
+
+  @Arbiter
+  public void observe(final JJ_Result r) {
+    final var first = set.firstOrNull();
+    r.r1 = first == null ? -1L : first;
+    r.r2 = set.size();
+  }
+}

--- a/lib/kpipe-consumer/src/jcstress/java/io/github/eschizoid/kpipe/consumer/PendingOffsetSetConcurrentAddJCStressTest.java
+++ b/lib/kpipe-consumer/src/jcstress/java/io/github/eschizoid/kpipe/consumer/PendingOffsetSetConcurrentAddJCStressTest.java
@@ -1,0 +1,54 @@
+package io.github.eschizoid.kpipe.consumer;
+
+import org.openjdk.jcstress.annotations.Actor;
+import org.openjdk.jcstress.annotations.Arbiter;
+import org.openjdk.jcstress.annotations.Expect;
+import org.openjdk.jcstress.annotations.JCStressTest;
+import org.openjdk.jcstress.annotations.Outcome;
+import org.openjdk.jcstress.annotations.State;
+import org.openjdk.jcstress.infra.results.JJJ_Result;
+
+/// Concurrency-stress check for `PendingOffsetSet` under two concurrent out-of-order `add`s —
+/// one prepending below the current lowest offset, one landing mid-window.
+///
+/// Both insert paths shift array elements with `System.arraycopy` and adjust `head`/`tail`. If the
+/// two adds could interleave inside the window mutation (broken monitor discipline), one insert
+/// could overwrite the other's shift, duplicate an element, or leave the window unsorted — all of
+/// which would surface as a wrong size, first, or last.
+///
+/// Scenario. The set starts holding `{100, 200}`. One actor adds 50 (prepend path: below the
+/// current lowest), the other adds 150 (mid-window insert between 100 and 200). Both must
+/// survive: the set ends as `{50, 100, 150, 200}` — first 50, last 200, size 4 — under every
+/// interleaving.
+@JCStressTest
+@Outcome(id = "50, 200, 4", expect = Expect.ACCEPTABLE, desc = "Both concurrent inserts survived; window sorted.")
+@Outcome(id = ".*", expect = Expect.FORBIDDEN, desc = "An insert was lost, duplicated, or the window corrupted.")
+@State
+public class PendingOffsetSetConcurrentAddJCStressTest {
+
+  private final PendingOffsetSet set = new PendingOffsetSet();
+
+  public PendingOffsetSetConcurrentAddJCStressTest() {
+    set.add(100L);
+    set.add(200L);
+  }
+
+  @Actor
+  public void prepender() {
+    set.add(50L);
+  }
+
+  @Actor
+  public void midInserter() {
+    set.add(150L);
+  }
+
+  @Arbiter
+  public void observe(final JJJ_Result r) {
+    final var first = set.firstOrNull();
+    final var last = set.lastOrNull();
+    r.r1 = first == null ? -1L : first;
+    r.r2 = last == null ? -1L : last;
+    r.r3 = set.size();
+  }
+}

--- a/lib/kpipe-consumer/src/jcstress/java/io/github/eschizoid/kpipe/consumer/PendingOffsetSetConcurrentAddJCStressTest.java
+++ b/lib/kpipe-consumer/src/jcstress/java/io/github/eschizoid/kpipe/consumer/PendingOffsetSetConcurrentAddJCStressTest.java
@@ -11,15 +11,28 @@ import org.openjdk.jcstress.infra.results.JJJ_Result;
 /// Concurrency-stress check for `PendingOffsetSet` under two concurrent out-of-order `add`s —
 /// one prepending below the current lowest offset, one landing mid-window.
 ///
-/// Both insert paths shift array elements with `System.arraycopy` and adjust `head`/`tail`. If the
-/// two adds could interleave inside the window mutation (broken monitor discipline), one insert
-/// could overwrite the other's shift, duplicate an element, or leave the window unsorted — all of
-/// which would surface as a wrong size, first, or last.
+/// What this proves — and what it cannot. `add` is `synchronized` on the instance monitor, so
+/// the two actors are fully mutually exclusive: jcstress can only realize the two SERIAL
+/// orderings (prepend-then-mid-insert, mid-insert-then-prepend), never an interleaving inside
+/// the `System.arraycopy` shifts or the `head`/`tail` adjustments. The properties this test pins
+/// are therefore:
+///
+/// * **Order-insensitive serial correctness.** The two inserts exercise different shift
+///   machinery (prepend into head slack vs mid-window shift), and both orderings must converge
+///   on the same sorted final state `{50, 100, 150, 200}`.
+/// * **Monitor discipline as a regression guard.** If a future change dropped or weakened
+///   `synchronized`, the adds WOULD interleave, and one insert overwriting the other's shift, a
+///   duplicated element, or an unsorted window would grade as forbidden via a wrong first, last,
+///   or size. The monitor's happens-before is also what makes both inserts visible to the
+///   arbiter.
+///
+/// The genuinely concurrent lock-set interaction in production (monitor-only readers vs
+/// bucket-lock-plus-monitor writers) is exercised end-to-end by `SafeFirstJCStressTest`.
 ///
 /// Scenario. The set starts holding `{100, 200}`. One actor adds 50 (prepend path: below the
-/// current lowest), the other adds 150 (mid-window insert between 100 and 200). Both must
-/// survive: the set ends as `{50, 100, 150, 200}` — first 50, last 200, size 4 — under every
-/// interleaving.
+/// current lowest), the other adds 150 (mid-window insert between 100 and 200). Under either
+/// ordering both inserts must take effect: the set ends as `{50, 100, 150, 200}` — first 50,
+/// last 200, size 4.
 @JCStressTest
 @Outcome(id = "50, 200, 4", expect = Expect.ACCEPTABLE, desc = "Both concurrent inserts survived; window sorted.")
 @Outcome(id = ".*", expect = Expect.FORBIDDEN, desc = "An insert was lost, duplicated, or the window corrupted.")

--- a/lib/kpipe-consumer/src/jcstress/java/io/github/eschizoid/kpipe/consumer/PendingOffsetSetFirstReadJCStressTest.java
+++ b/lib/kpipe-consumer/src/jcstress/java/io/github/eschizoid/kpipe/consumer/PendingOffsetSetFirstReadJCStressTest.java
@@ -13,15 +13,28 @@ import org.openjdk.jcstress.infra.results.J_Result;
 /// On the previous `ConcurrentSkipListSet<Long>`, `if (!set.isEmpty()) set.first()` was a
 /// check-then-act trap: a concurrent remover could drain the set between the two calls and
 /// `first()` threw `NoSuchElementException`. `firstOrNull` performs the emptiness check and the
-/// read under one monitor acquisition, so the trap is structurally impossible — but only as long
-/// as every mutation path honors the same monitor. This test races the reader against the remove
-/// that empties the window (the reset of `head`/`tail` to 0) to keep that pinned.
+/// read under one monitor acquisition, so the trap is structurally impossible — as long as every
+/// access path honors the same monitor.
+///
+/// What this proves — and what it cannot. Both `remove` and `firstOrNull` are `synchronized` on
+/// the instance monitor, so the reader and the remover are fully mutually exclusive: jcstress
+/// can only realize the two SERIAL orderings (read-then-remove → 100, remove-then-read → -1),
+/// never a read landing mid-drain. The properties this test pins are therefore:
+///
+/// * **No-throw under either ordering.** jcstress reports a thrown actor as a hard error, so an
+///   escaped exception (the old skiplist failure mode) fails the run before outcome grading.
+/// * **Monitor discipline as a regression guard.** If a future change let `firstOrNull` read
+///   without the monitor, the read COULD land mid-drain, and a stale or torn value (e.g. a
+///   garbage `head` index reading past the window) would grade as forbidden. The monitor's
+///   happens-before is also what makes the drain visible to the post-remove read.
+///
+/// The genuinely concurrent cross-lock-set interleaving in production — the commit scheduler
+/// reading through `firstOrNull` (monitor only) while a writer holds the map bucket lock plus
+/// the monitor — is exercised end-to-end through the manager by `SafeFirstJCStressTest`.
 ///
 /// Scenario. The set starts holding exactly `{100}`. The remover drains it; the reader snapshots
-/// `firstOrNull`. The reader must observe either 100 (read before the remove) or null, encoded as
-/// -1 (read after). jcstress reports a thrown actor as a hard error, so an escaped exception —
-/// the old skiplist failure mode — fails the run before outcome grading. A stale or torn value
-/// (e.g. a garbage `head` index reading past the window) would grade as forbidden.
+/// `firstOrNull`. The reader must observe either 100 (read serialized before the remove) or
+/// null, encoded as -1 (read serialized after).
 @JCStressTest
 @Outcome(id = "100", expect = Expect.ACCEPTABLE, desc = "Reader saw offset 100 still pending.")
 @Outcome(id = "-1", expect = Expect.ACCEPTABLE, desc = "Reader saw the window already drained.")

--- a/lib/kpipe-consumer/src/jcstress/java/io/github/eschizoid/kpipe/consumer/PendingOffsetSetFirstReadJCStressTest.java
+++ b/lib/kpipe-consumer/src/jcstress/java/io/github/eschizoid/kpipe/consumer/PendingOffsetSetFirstReadJCStressTest.java
@@ -1,0 +1,48 @@
+package io.github.eschizoid.kpipe.consumer;
+
+import org.openjdk.jcstress.annotations.Actor;
+import org.openjdk.jcstress.annotations.Expect;
+import org.openjdk.jcstress.annotations.JCStressTest;
+import org.openjdk.jcstress.annotations.Outcome;
+import org.openjdk.jcstress.annotations.State;
+import org.openjdk.jcstress.infra.results.J_Result;
+
+/// Concurrency-stress check that `PendingOffsetSet.firstOrNull()` is safe against a concurrent
+/// drain — the structure-level guarantee that replaced the old `safeFirst` exception guard.
+///
+/// On the previous `ConcurrentSkipListSet<Long>`, `if (!set.isEmpty()) set.first()` was a
+/// check-then-act trap: a concurrent remover could drain the set between the two calls and
+/// `first()` threw `NoSuchElementException`. `firstOrNull` performs the emptiness check and the
+/// read under one monitor acquisition, so the trap is structurally impossible — but only as long
+/// as every mutation path honors the same monitor. This test races the reader against the remove
+/// that empties the window (the reset of `head`/`tail` to 0) to keep that pinned.
+///
+/// Scenario. The set starts holding exactly `{100}`. The remover drains it; the reader snapshots
+/// `firstOrNull`. The reader must observe either 100 (read before the remove) or null, encoded as
+/// -1 (read after). jcstress reports a thrown actor as a hard error, so an escaped exception —
+/// the old skiplist failure mode — fails the run before outcome grading. A stale or torn value
+/// (e.g. a garbage `head` index reading past the window) would grade as forbidden.
+@JCStressTest
+@Outcome(id = "100", expect = Expect.ACCEPTABLE, desc = "Reader saw offset 100 still pending.")
+@Outcome(id = "-1", expect = Expect.ACCEPTABLE, desc = "Reader saw the window already drained.")
+@Outcome(id = ".*", expect = Expect.FORBIDDEN, desc = "Torn read of the window bounds, or a throw.")
+@State
+public class PendingOffsetSetFirstReadJCStressTest {
+
+  private final PendingOffsetSet set = new PendingOffsetSet();
+
+  public PendingOffsetSetFirstReadJCStressTest() {
+    set.add(100L);
+  }
+
+  @Actor
+  public void remover() {
+    set.remove(100L);
+  }
+
+  @Actor
+  public void reader(final J_Result r) {
+    final var first = set.firstOrNull();
+    r.r1 = first == null ? -1L : first;
+  }
+}

--- a/lib/kpipe-consumer/src/jcstress/java/io/github/eschizoid/kpipe/consumer/SafeFirstJCStressTest.java
+++ b/lib/kpipe-consumer/src/jcstress/java/io/github/eschizoid/kpipe/consumer/SafeFirstJCStressTest.java
@@ -15,27 +15,28 @@ import org.openjdk.jcstress.infra.results.J_Result;
 /// Concurrency-stress check for the check-then-act safety of reading the lowest pending offset of
 /// `KafkaOffsetManager` while another thread empties the per-partition pending set.
 ///
-/// The manager keeps pending offsets per partition in a `ConcurrentSkipListSet`, and computes a
-/// partition's commit point by reading the set's first element. A naive `if (!set.isEmpty())
-/// set.first()` is a check-then-act trap: a concurrent remover can drain the set between the
-/// emptiness check and the `first()` call, and `first()` then throws `NoSuchElementException` on
-/// an empty set. The manager guards this with a `safeFirst` wrapper that catches that exception
-/// and returns null, so the commit-point read degrades to "no pending offset" rather than blowing
-/// up the caller. This test races a remover against a reader to exercise exactly that window.
+/// The manager keeps pending offsets per partition in a `PendingOffsetSet` (a monitor-synchronized
+/// sorted primitive-`long` window; historically a `ConcurrentSkipListSet<Long>`), and computes a
+/// partition's commit point by reading the set's lowest element. On the skiplist a naive
+/// `if (!set.isEmpty()) set.first()` was a check-then-act trap: a concurrent remover could drain
+/// the set between the emptiness check and the `first()` call, making `first()` throw
+/// `NoSuchElementException`; a `safeFirst` wrapper caught that exception and returned null.
+/// `PendingOffsetSet.firstOrNull()` closes the window structurally — the emptiness check and the
+/// read share the instance monitor, so a drained set yields `null` ("no pending offset") and can
+/// never throw. This test races a remover against a reader to keep that no-throw guarantee pinned.
 ///
 /// Scenario. The state constructor tracks a single offset (100) on one partition, so the pending
 /// set starts holding exactly that one element — the set most likely to be observed mid-drain.
 /// The remover actor marks offset 100 processed, which removes it from the set and clears the
 /// partition entry once empty. The reader actor reads the commit point via
-/// `getPartitionState(...).get("nextOffsetToCommit")`, which routes through `safeFirst`. The two
+/// `getPartitionState(...).get("nextOffsetToCommit")`, which routes through `firstOrNull`. The two
 /// run concurrently under every interleaving the scheduler can produce.
 ///
-/// The property under test is narrow and exact: `safeFirst` must never let a
-/// `NoSuchElementException` escape, no matter how the remover drains the set relative to the
-/// reader's emptiness-check-then-first call. jcstress surfaces a thrown actor as a hard error, so a
-/// leaked exception fails the run outright — it never reaches the outcome grading below. Every
-/// graded outcome therefore already proves the catch held; the values just describe which snapshot
-/// the reader happened to see.
+/// The property under test is narrow and exact: the commit-point read must never throw, no matter
+/// how the remover drains the set relative to the reader's emptiness-check-then-first call.
+/// jcstress surfaces a thrown actor as a hard error, so a leaked exception fails the run outright
+/// — it never reaches the outcome grading below. Every graded outcome therefore already proves the
+/// guarantee held; the values just describe which snapshot the reader happened to see.
 ///
 /// The reader records the commit point it observed. 101 is the common case (set drained, commit
 /// point falls back to highest-processed + 1) and 100 is the case where the read landed before the
@@ -43,16 +44,16 @@ import org.openjdk.jcstress.infra.results.J_Result;
 /// forbidden: the reader's snapshot reads the pending set and the highest-processed map in two
 /// separate steps, and the remover updates those two maps non-atomically, so the reader can observe
 /// the set already emptied while the highest-processed write is not yet visible. That torn read is
-/// a benign staleness of the diagnostic snapshot, not a `safeFirst` failure — `safeFirst` still
-/// returned null without throwing. The only forbidden behaviour, a thrown exception, cannot appear
-/// here precisely because jcstress would have failed the run before grading.
+/// a benign staleness of the diagnostic snapshot, not a `firstOrNull` failure — it still returned
+/// null without throwing. The only forbidden behaviour, a thrown exception, cannot appear here
+/// precisely because jcstress would have failed the run before grading.
 @JCStressTest
 @Outcome(id = "100", expect = Expect.ACCEPTABLE, desc = "Reader saw offset 100 still pending.")
 @Outcome(id = "101", expect = Expect.ACCEPTABLE, desc = "Reader saw the set drained; commit point is processed + 1.")
 @Outcome(
   id = "-1",
   expect = Expect.ACCEPTABLE_INTERESTING,
-  desc = "Torn snapshot: set seen drained before the highest-processed write was visible. safeFirst still did not throw."
+  desc = "Torn snapshot: set seen drained before the highest-processed write was visible. firstOrNull still did not throw."
 )
 @Outcome(id = ".*", expect = Expect.FORBIDDEN, desc = "Unexpected commit-point value.")
 @State

--- a/lib/kpipe-consumer/src/main/java/io/github/eschizoid/kpipe/consumer/KafkaOffsetManager.java
+++ b/lib/kpipe-consumer/src/main/java/io/github/eschizoid/kpipe/consumer/KafkaOffsetManager.java
@@ -80,7 +80,13 @@ public class KafkaOffsetManager<K> implements OffsetManager<K> {
   private final Queue<ConsumerCommand> commandQueue;
 
   private final Map<String, CompletableFuture<Boolean>> commitFutures = new ConcurrentHashMap<>();
-  private final Map<TopicPartition, ConcurrentSkipListSet<Long>> pendingOffsets = new ConcurrentHashMap<>();
+
+  /// Per-partition pending offsets: a sorted primitive-`long` window (`PendingOffsetSet`) rather
+  /// than a `ConcurrentSkipListSet<Long>`. The skiplist cost a `Long` box plus node/marker churn
+  /// on every track/mark; the primitive structure allocates nothing in steady state. All map
+  /// mutations keep the bucket-locked `compute` / `computeIfPresent` shapes below; the structure
+  /// itself is monitor-synchronized so commit-scheduler reads outside the bucket lock stay safe.
+  private final Map<TopicPartition, PendingOffsetSet> pendingOffsets = new ConcurrentHashMap<>();
   private final Map<TopicPartition, Long> highestProcessedOffsets = new ConcurrentHashMap<>();
 
   /// Per-partition `TopicPartition` cache used by `trackOffset` and `markOffsetProcessed`. Each
@@ -224,7 +230,7 @@ public class KafkaOffsetManager<K> implements OffsetManager<K> {
     // orphaned set no longer in the map — silently losing a pending offset and letting the commit
     // point advance past an in-flight record. compute() holds the bucket lock across the add.
     pendingOffsets.compute(partition, (_, set) -> {
-      final var pending = set == null ? new ConcurrentSkipListSet<Long>() : set;
+      final var pending = set == null ? new PendingOffsetSet() : set;
       pending.add(offset);
       return pending;
     });
@@ -355,7 +361,7 @@ public class KafkaOffsetManager<K> implements OffsetManager<K> {
       .distinct()
       .flatMap(partition -> {
         final var pending = pendingOffsets.get(partition);
-        final var lowestPending = pending != null ? safeFirst(pending) : null;
+        final var lowestPending = pending != null ? pending.firstOrNull() : null;
         if (lowestPending != null) return Stream.of(Map.entry(partition, new OffsetAndMetadata(lowestPending)));
         final var highestProcessed = highestProcessedOffsets.get(partition);
         return highestProcessed != null
@@ -363,14 +369,6 @@ public class KafkaOffsetManager<K> implements OffsetManager<K> {
           : Stream.empty();
       })
       .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
-  }
-
-  static Long safeFirst(final SortedSet<Long> set) {
-    try {
-      return set.isEmpty() ? null : set.first();
-    } catch (final NoSuchElementException e) {
-      return null;
-    }
   }
 
   private boolean performCommit(final Map<TopicPartition, OffsetAndMetadata> offsetsToCommit, final Duration timeout)
@@ -401,7 +399,7 @@ public class KafkaOffsetManager<K> implements OffsetManager<K> {
     final var state = new HashMap<String, Object>();
     final var pending = pendingOffsets.get(partition);
     final var highestProcessed = highestProcessedOffsets.get(partition);
-    final var lowestPending = pending != null ? safeFirst(pending) : null;
+    final var lowestPending = pending != null ? pending.firstOrNull() : null;
 
     if (lowestPending != null) {
       state.put("nextOffsetToCommit", lowestPending);
@@ -418,7 +416,7 @@ public class KafkaOffsetManager<K> implements OffsetManager<K> {
       state.put("pendingCount", pending.size());
       if (lowestPending != null) {
         state.put("lowestPendingOffset", lowestPending);
-        final var highestPending = safeLast(pending);
+        final var highestPending = pending.lastOrNull();
         if (highestPending != null) state.put("highestPendingOffset", highestPending);
       }
     } else {
@@ -426,14 +424,6 @@ public class KafkaOffsetManager<K> implements OffsetManager<K> {
     }
 
     return state;
-  }
-
-  private static Long safeLast(final SortedSet<Long> set) {
-    try {
-      return set.isEmpty() ? null : set.last();
-    } catch (final NoSuchElementException e) {
-      return null;
-    }
   }
 
   /// Returns overall statistics about all partitions being managed.
@@ -448,7 +438,7 @@ public class KafkaOffsetManager<K> implements OffsetManager<K> {
     allPartitions.addAll(highestProcessedOffsets.keySet());
     stats.put("partitionCount", allPartitions.size());
 
-    stats.put("totalPendingOffsets", pendingOffsets.values().stream().mapToInt(SortedSet::size).sum());
+    stats.put("totalPendingOffsets", pendingOffsets.values().stream().mapToInt(PendingOffsetSet::size).sum());
     stats.put("totalProcessedPartitions", highestProcessedOffsets.size());
     stats.put("managerState", state.get().name());
 
@@ -520,7 +510,7 @@ public class KafkaOffsetManager<K> implements OffsetManager<K> {
         final var offsetsToCommit = new HashMap<TopicPartition, OffsetAndMetadata>();
         partitions.forEach(partition -> {
           final var pending = pendingOffsets.get(partition);
-          final var lowestPending = pending != null ? safeFirst(pending) : null;
+          final var lowestPending = pending != null ? pending.firstOrNull() : null;
           if (lowestPending != null) {
             offsetsToCommit.put(partition, new OffsetAndMetadata(lowestPending));
           } else {

--- a/lib/kpipe-consumer/src/main/java/io/github/eschizoid/kpipe/consumer/PendingOffsetSet.java
+++ b/lib/kpipe-consumer/src/main/java/io/github/eschizoid/kpipe/consumer/PendingOffsetSet.java
@@ -1,0 +1,239 @@
+package io.github.eschizoid.kpipe.consumer;
+
+/// A thread-safe sorted set of primitive `long` offsets — the per-partition pending-offset
+/// structure behind `KafkaOffsetManager`'s lowest-pending-offset commit invariant.
+///
+/// Replaces the previous `ConcurrentSkipListSet<Long>`: on the track/mark hot path the skiplist
+/// cost one `Long` box plus one skiplist node per add, another box per remove, and deletion-marker
+/// churn on unlink — roughly 400 B per track+mark pair measured by `OffsetManagerBoxingBenchmark`.
+/// This structure keeps the live offsets in a sorted `long[]` window and allocates nothing in
+/// steady state; mutations shift elements with `System.arraycopy`.
+///
+/// ### Layout
+///
+/// The structure has two modes:
+///
+/// * **Inline mode** (`offsets == null`) — zero or one element, held in the `single` field with
+///   no array at all. The owning map evicts a set the moment it empties and recreates it on the
+///   next track, so in low-in-flight regimes (sequential processing, a keeping-up consumer) a
+///   fresh instance is born, holds one offset, and dies on every record — inline mode keeps that
+///   churn to one small object instead of object + backing array.
+/// * **Array mode** — from the second concurrent offset onward, live elements occupy
+///   `offsets[head, tail)` in strictly ascending order with no duplicates. A spilled set never
+///   returns to inline mode; once it drains it is evicted and replaced wholesale.
+///
+/// In array mode, slack is kept on **both** sides of the window so each fast path is O(1):
+///
+/// * **Append** (`add` of a new highest offset) — the common track order, since Kafka delivers
+///   per-partition offsets monotonically — writes at `tail`.
+/// * **Head removal** (`remove` of the lowest pending offset) — the common completion order —
+///   just advances `head`.
+///
+/// Out-of-order operations binary-search the window and shift the cheaper side. When an append
+/// hits the array end, the window is compacted to index 0 if head slack exists, else the array
+/// doubles — amortized O(1). The array never shrinks while non-empty; a partition whose pending
+/// count spiked retains its high-water capacity until the set empties and is evicted from the
+/// per-partition map (or the partition is revoked), which drops the whole structure.
+///
+/// ### Concurrency
+///
+/// Every method is `synchronized` on the instance monitor. Writers (`trackOffset` on the consumer
+/// thread, `markOffsetProcessed` on worker virtual threads) already serialize through the owning
+/// `ConcurrentHashMap` bucket lock; the monitor additionally makes the read paths (`firstOrNull`,
+/// `lastOrNull`, `size`, `isEmpty` — invoked by the commit scheduler and diagnostics without the
+/// bucket lock) safe against a mid-shift torn read. Contention is per-partition and the critical
+/// sections are tiny, so the monitor is uncontended in practice.
+///
+/// Unlike `ConcurrentSkipListSet.first()`, `firstOrNull` cannot throw on a concurrently drained
+/// set — emptiness check and read happen under the same monitor — so the check-then-act trap the
+/// old `safeFirst` wrapper guarded against is structurally impossible here.
+final class PendingOffsetSet {
+
+  private static final int SPILL_CAPACITY = 8;
+
+  /// Sorted ascending; live region is `[head, tail)`. `null` while in inline mode.
+  private long[] offsets;
+
+  /// The sole element while in inline mode (`offsets == null` and `hasSingle`).
+  private long single;
+
+  /// Whether `single` holds an element (inline mode only).
+  private boolean hasSingle;
+
+  /// Inclusive start of the live region (array mode only).
+  private int head;
+
+  /// Exclusive end of the live region (array mode only).
+  private int tail;
+
+  /// Adds `value` to the set.
+  ///
+  /// @param value the offset to add
+  /// @return `true` if the set changed, `false` if `value` was already present
+  synchronized boolean add(final long value) {
+    if (offsets == null) {
+      if (!hasSingle) {
+        single = value;
+        hasSingle = true;
+        return true;
+      }
+      if (value == single) return false;
+      // Second distinct offset: spill from inline mode to array mode.
+      offsets = new long[SPILL_CAPACITY];
+      offsets[0] = Math.min(single, value);
+      offsets[1] = Math.max(single, value);
+      head = 0;
+      tail = 2;
+      hasSingle = false;
+      return true;
+    }
+    if (head == tail) {
+      head = 0;
+      tail = 1;
+      offsets[0] = value;
+      return true;
+    }
+    // Append fast path: new highest offset (the monotonic per-partition track order).
+    if (value > offsets[tail - 1]) {
+      if (tail == offsets.length) compactOrGrow();
+      offsets[tail++] = value;
+      return true;
+    }
+    // Prepend fast path: new lowest offset.
+    if (value < offsets[head]) {
+      if (head > 0) {
+        offsets[--head] = value;
+        return true;
+      }
+      if (tail == offsets.length) compactOrGrow(); // head == 0, so this grows
+      System.arraycopy(offsets, 0, offsets, 1, tail);
+      offsets[0] = value;
+      tail++;
+      return true;
+    }
+    final var found = search(value);
+    if (found >= 0) return false; // already present — set semantics
+    var insertion = -found - 1;
+    final var leftLength = insertion - head;
+    final var rightLength = tail - insertion;
+    if (head > 0 && leftLength <= rightLength) {
+      System.arraycopy(offsets, head, offsets, head - 1, leftLength);
+      head--;
+      offsets[insertion - 1] = value;
+    } else {
+      if (tail == offsets.length) insertion -= compactOrGrow();
+      System.arraycopy(offsets, insertion, offsets, insertion + 1, tail - insertion);
+      offsets[insertion] = value;
+      tail++;
+    }
+    return true;
+  }
+
+  /// Removes `value` from the set.
+  ///
+  /// @param value the offset to remove
+  /// @return `true` if the set changed, `false` if `value` was not present
+  synchronized boolean remove(final long value) {
+    if (offsets == null) {
+      if (hasSingle && value == single) {
+        hasSingle = false;
+        return true;
+      }
+      return false;
+    }
+    if (head == tail) return false;
+    // Head fast path: removing the lowest pending offset (the common completion order).
+    if (value == offsets[head]) {
+      head++;
+      if (head == tail) head = tail = 0;
+      return true;
+    }
+    if (value < offsets[head] || value > offsets[tail - 1]) return false;
+    if (value == offsets[tail - 1]) {
+      tail--;
+      return true;
+    }
+    final var found = search(value);
+    if (found < 0) return false;
+    final var leftLength = found - head;
+    final var rightLength = tail - found - 1;
+    if (leftLength <= rightLength) {
+      System.arraycopy(offsets, head, offsets, head + 1, leftLength);
+      head++;
+    } else {
+      System.arraycopy(offsets, found + 1, offsets, found, rightLength);
+      tail--;
+    }
+    return true;
+  }
+
+  /// @return `true` if the set holds no offsets
+  synchronized boolean isEmpty() {
+    return offsets == null ? !hasSingle : head == tail;
+  }
+
+  /// @return the number of offsets in the set
+  synchronized int size() {
+    if (offsets == null) return hasSingle ? 1 : 0;
+    return tail - head;
+  }
+
+  /// Returns the lowest offset, or `null` when empty. Boxed `Long` on purpose: this is only
+  /// called on the commit-preparation and diagnostics paths (periodic, not per-record), and the
+  /// null-for-empty shape matches what the old `safeFirst(SortedSet)` helper returned. Unlike
+  /// `SortedSet.first()` this can never throw — check and read share the monitor.
+  ///
+  /// @return the lowest pending offset, or `null` if the set is empty
+  synchronized Long firstOrNull() {
+    if (offsets == null) return hasSingle ? single : null;
+    return head == tail ? null : offsets[head];
+  }
+
+  /// Returns the highest offset, or `null` when empty. Same boxing rationale as `firstOrNull`.
+  ///
+  /// @return the highest pending offset, or `null` if the set is empty
+  synchronized Long lastOrNull() {
+    if (offsets == null) return hasSingle ? single : null;
+    return head == tail ? null : offsets[tail - 1];
+  }
+
+  /// Makes room for one more element when `tail` has hit the array end: compacts the live
+  /// region to index 0 when head slack exists (amortized against the O(1) head removals that
+  /// created the slack), otherwise doubles the array.
+  ///
+  /// @return how far the live region moved left, so callers can adjust a pending insertion index
+  private int compactOrGrow() {
+    final var shift = head;
+    final var length = tail - head;
+    if (shift > 0) {
+      System.arraycopy(offsets, head, offsets, 0, length);
+    } else {
+      final var grown = new long[offsets.length * 2];
+      System.arraycopy(offsets, 0, grown, 0, length);
+      offsets = grown;
+    }
+    head = 0;
+    tail = length;
+    return shift;
+  }
+
+  /// Binary search over the live region `[head, tail)`.
+  ///
+  /// @return the index of `value` if present, else `-(insertionPoint) - 1`
+  private int search(final long value) {
+    var low = head;
+    var high = tail - 1;
+    while (low <= high) {
+      final var mid = (low + high) >>> 1;
+      final var candidate = offsets[mid];
+      if (candidate < value) {
+        low = mid + 1;
+      } else if (candidate > value) {
+        high = mid - 1;
+      } else {
+        return mid;
+      }
+    }
+    return -(low + 1);
+  }
+}

--- a/lib/kpipe-consumer/src/test/java/io/github/eschizoid/kpipe/consumer/KafkaOffsetManagerTest.java
+++ b/lib/kpipe-consumer/src/test/java/io/github/eschizoid/kpipe/consumer/KafkaOffsetManagerTest.java
@@ -283,12 +283,7 @@ class KafkaOffsetManagerTest {
     @Test
     void shouldDrainCommandQueueForRevokedPartitions() {
       final var partition1 = new TopicPartition(TOPIC, 1);
-      final var offsets = Map.of(
-        PARTITION,
-        new OffsetAndMetadata(100L),
-        partition1,
-        new OffsetAndMetadata(200L)
-      );
+      final var offsets = Map.of(PARTITION, new OffsetAndMetadata(100L), partition1, new OffsetAndMetadata(200L));
       commandQueue.offer(new ConsumerCommand.CommitOffsets(offsets, "commit-1"));
 
       offsetManager.createRebalanceListener().onPartitionsRevoked(List.of(PARTITION));
@@ -442,13 +437,16 @@ class KafkaOffsetManagerTest {
 
       // Second call from a different thread must trigger the AssertionError.
       final var thrown = new AtomicReference<Throwable>();
-      final var off = new Thread(() -> {
-        try {
-          listener.onPartitionsRevoked(List.of(PARTITION));
-        } catch (final Throwable t) {
-          thrown.set(t);
-        }
-      }, "off-thread-rebalancer");
+      final var off = new Thread(
+        () -> {
+          try {
+            listener.onPartitionsRevoked(List.of(PARTITION));
+          } catch (final Throwable t) {
+            thrown.set(t);
+          }
+        },
+        "off-thread-rebalancer"
+      );
       off.start();
       off.join(2_000);
 
@@ -473,13 +471,16 @@ class KafkaOffsetManagerTest {
 
       // Second call from a different thread must trigger the AssertionError.
       final var thrown = new AtomicReference<Throwable>();
-      final var off = new Thread(() -> {
-        try {
-          listener.onPartitionsAssigned(List.of(PARTITION));
-        } catch (final Throwable t) {
-          thrown.set(t);
-        }
-      }, "off-thread-rebalancer");
+      final var off = new Thread(
+        () -> {
+          try {
+            listener.onPartitionsAssigned(List.of(PARTITION));
+          } catch (final Throwable t) {
+            thrown.set(t);
+          }
+        },
+        "off-thread-rebalancer"
+      );
       off.start();
       off.join(2_000);
 
@@ -1007,7 +1008,7 @@ class KafkaOffsetManagerTest {
     );
   }
 
-  /// Locks in the `computeIfPresent` + `safeFirst` race fixes from the audit pass: hammers
+  /// Locks in the `computeIfPresent` + lowest-pending-read race fixes from the audit pass: hammers
   /// `trackOffset` and `markOffsetProcessed` from many virtual threads on the same partition
   /// and asserts that no offsets are silently dropped from the commit map.
   @Nested
@@ -1088,7 +1089,7 @@ class KafkaOffsetManagerTest {
           }
         });
 
-        // Concurrent reader: hammer getPartitionState (also goes through pending.first()).
+        // Concurrent reader: hammer getPartitionState (also goes through pending.firstOrNull()).
         for (int i = 0; i < 4; i++) {
           executor.submit(() -> {
             while (!stop.get()) {
@@ -1107,7 +1108,7 @@ class KafkaOffsetManagerTest {
         stop.set(true);
       }
 
-      assertTrue(errors.isEmpty(), "pending.first() race must not throw NoSuchElementException: " + errors);
+      assertTrue(errors.isEmpty(), "pending firstOrNull race must not throw: " + errors);
       manager.close();
     }
   }
@@ -1316,7 +1317,11 @@ class KafkaOffsetManagerTest {
       offsetManager.trackOffset(record);
       final var reAllocated = innerCache(offsetManager, TOPIC).get(0);
       assertNotNull(reAllocated, "track after re-assignment must repopulate the cache");
-      assertNotSame(original, reAllocated, "re-assignment must allocate a fresh TopicPartition, not reuse the evicted one");
+      assertNotSame(
+        original,
+        reAllocated,
+        "re-assignment must allocate a fresh TopicPartition, not reuse the evicted one"
+      );
       assertEquals(original, reAllocated, "value-equality must still hold (same topic + partition number)");
     }
 

--- a/lib/kpipe-consumer/src/test/java/io/github/eschizoid/kpipe/consumer/PendingOffsetSetTest.java
+++ b/lib/kpipe-consumer/src/test/java/io/github/eschizoid/kpipe/consumer/PendingOffsetSetTest.java
@@ -1,0 +1,192 @@
+package io.github.eschizoid.kpipe.consumer;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.List;
+import java.util.TreeSet;
+import net.jqwik.api.Arbitraries;
+import net.jqwik.api.Arbitrary;
+import net.jqwik.api.Combinators;
+import net.jqwik.api.ForAll;
+import net.jqwik.api.Property;
+import net.jqwik.api.Provide;
+import org.junit.jupiter.api.Test;
+
+/// Unit + property coverage for `PendingOffsetSet`, the sorted primitive-`long` window that
+/// replaced `ConcurrentSkipListSet<Long>` as the per-partition pending-offset structure.
+///
+/// The deterministic tests pin the shift/compaction/growth edge cases of the head/tail window;
+/// the jqwik property drives randomized add/remove sequences against a `TreeSet<Long>` oracle and
+/// asserts every observable (`add`/`remove` return values, `size`, `isEmpty`, `firstOrNull`,
+/// `lastOrNull`) matches the reference set after every operation.
+class PendingOffsetSetTest {
+
+  @Test
+  void emptySetObservables() {
+    final var set = new PendingOffsetSet();
+    assertTrue(set.isEmpty());
+    assertEquals(0, set.size());
+    assertNull(set.firstOrNull());
+    assertNull(set.lastOrNull());
+    assertFalse(set.remove(42L));
+  }
+
+  @Test
+  void inlineModeSpillsToArrayOnSecondDistinctOffset() {
+    final var set = new PendingOffsetSet();
+    // Inline mode: one element, no array.
+    assertTrue(set.add(100L));
+    assertEquals(100L, set.firstOrNull());
+    assertEquals(100L, set.lastOrNull());
+    assertFalse(set.add(100L));
+    // Spill with the new value below the inline one — order must hold either way.
+    assertTrue(set.add(50L));
+    assertEquals(2, set.size());
+    assertEquals(50L, set.firstOrNull());
+    assertEquals(100L, set.lastOrNull());
+    // Inline remove path: drain a fresh inline set completely.
+    final var inline = new PendingOffsetSet();
+    inline.add(7L);
+    assertFalse(inline.remove(8L));
+    assertTrue(inline.remove(7L));
+    assertTrue(inline.isEmpty());
+    assertFalse(inline.remove(7L));
+  }
+
+  @Test
+  void addDuplicateReturnsFalseAndDoesNotGrow() {
+    final var set = new PendingOffsetSet();
+    assertTrue(set.add(100L));
+    assertFalse(set.add(100L));
+    assertEquals(1, set.size());
+  }
+
+  @Test
+  void monotonicAppendThenInOrderRemoval() {
+    final var set = new PendingOffsetSet();
+    for (var i = 0L; i < 100L; i++) assertTrue(set.add(i));
+    assertEquals(100, set.size());
+    assertEquals(0L, set.firstOrNull());
+    assertEquals(99L, set.lastOrNull());
+    for (var i = 0L; i < 100L; i++) {
+      assertTrue(set.remove(i));
+      assertEquals(i == 99L ? null : i + 1, set.firstOrNull());
+    }
+    assertTrue(set.isEmpty());
+  }
+
+  @Test
+  void prependBelowCurrentLowest() {
+    final var set = new PendingOffsetSet();
+    // Fill forward so head has no slack, then insert below the lowest — exercises the
+    // shift-right prepend path (head == 0) and, once full, growth from the prepend path.
+    for (var i = 10L; i < 20L; i++) set.add(i);
+    for (var i = 9L; i >= 0L; i--) assertTrue(set.add(i));
+    assertEquals(20, set.size());
+    assertEquals(0L, set.firstOrNull());
+    assertEquals(19L, set.lastOrNull());
+  }
+
+  @Test
+  void middleInsertsBothShiftDirections() {
+    final var set = new PendingOffsetSet();
+    // Evens first, then odds: every odd insert lands mid-window and picks the cheaper shift.
+    for (var i = 0L; i < 64L; i += 2) set.add(i);
+    for (var i = 1L; i < 64L; i += 2) assertTrue(set.add(i));
+    assertEquals(64, set.size());
+    for (var i = 0L; i < 64L; i++) {
+      assertEquals(i, set.firstOrNull());
+      assertTrue(set.remove(i));
+    }
+    assertTrue(set.isEmpty());
+  }
+
+  @Test
+  void middleRemovalsBothShiftDirections() {
+    final var set = new PendingOffsetSet();
+    for (var i = 0L; i < 32L; i++) set.add(i);
+    // Remove just above the head (cheap left shift) and just below the tail (cheap right shift).
+    assertTrue(set.remove(1L));
+    assertTrue(set.remove(30L));
+    // And dead-center removals from both halves.
+    assertTrue(set.remove(15L));
+    assertTrue(set.remove(16L));
+    assertEquals(28, set.size());
+    assertEquals(0L, set.firstOrNull());
+    assertEquals(31L, set.lastOrNull());
+    assertFalse(set.remove(15L));
+  }
+
+  @Test
+  void headSlackIsCompactedInsteadOfGrowing() {
+    final var set = new PendingOffsetSet();
+    // Rolling window: append one, remove the lowest — head advances forever. Compaction must
+    // reuse the freed head slack instead of growing without bound.
+    set.add(0L);
+    for (var i = 1L; i < 10_000L; i++) {
+      assertTrue(set.add(i));
+      assertTrue(set.remove(i - 1));
+      assertEquals(1, set.size());
+      assertEquals(i, set.firstOrNull());
+    }
+  }
+
+  @Test
+  void removeOutsideWindowReturnsFalse() {
+    final var set = new PendingOffsetSet();
+    set.add(10L);
+    set.add(20L);
+    assertFalse(set.remove(5L)); // below the window
+    assertFalse(set.remove(25L)); // above the window
+    assertFalse(set.remove(15L)); // inside the window but absent
+    assertEquals(2, set.size());
+  }
+
+  @Test
+  void negativeOffsetsAreSupported() {
+    // The bench warm-up path tracks offset -1; the structure must not assume non-negative values.
+    final var set = new PendingOffsetSet();
+    assertTrue(set.add(-1L));
+    assertTrue(set.add(-5L));
+    assertTrue(set.add(3L));
+    assertEquals(-5L, set.firstOrNull());
+    assertEquals(3L, set.lastOrNull());
+    assertTrue(set.remove(-5L));
+    assertEquals(-1L, set.firstOrNull());
+  }
+
+  /// A single generated operation: add or remove a given offset.
+  private record Op(boolean add, long offset) {}
+
+  @Provide
+  Arbitrary<List<Op>> operationSequences() {
+    // A small offset space forces duplicate adds, absent removes, window re-use, and both shift
+    // directions; long sequences push the structure through growth and compaction.
+    final var offsets = Arbitraries.longs().between(0L, 48L);
+    final var kinds = Arbitraries.of(true, false);
+    final Arbitrary<Op> ops = Combinators.combine(kinds, offsets).as(Op::new);
+    return ops.list().ofMinSize(1).ofMaxSize(300);
+  }
+
+  @Property(tries = 500)
+  void behavesExactlyLikeASortedLongSet(@ForAll("operationSequences") final List<Op> ops) {
+    final var set = new PendingOffsetSet();
+    final var oracle = new TreeSet<Long>();
+
+    for (final var op : ops) {
+      if (op.add()) {
+        assertEquals(oracle.add(op.offset()), set.add(op.offset()), "add(%d) return value".formatted(op.offset()));
+      } else {
+        assertEquals(
+          oracle.remove(op.offset()),
+          set.remove(op.offset()),
+          "remove(%d) return value".formatted(op.offset())
+        );
+      }
+      assertEquals(oracle.size(), set.size(), "size");
+      assertEquals(oracle.isEmpty(), set.isEmpty(), "isEmpty");
+      assertEquals(oracle.isEmpty() ? null : oracle.first(), set.firstOrNull(), "firstOrNull");
+      assertEquals(oracle.isEmpty() ? null : oracle.last(), set.lastOrNull(), "lastOrNull");
+    }
+  }
+}


### PR DESCRIPTION
## What

Replaces the per-partition `ConcurrentSkipListSet<Long>` in `KafkaOffsetManager` with `PendingOffsetSet` — a package-private, monitor-synchronized sorted primitive-`long` window. Closes the 396 B/op lever identified in [`benchmarks/results/2026-06-21-allocation-attribution.md`](benchmarks/results/2026-06-21-allocation-attribution.md), which was deliberately deferred until the correctness harness existed (#217/#220/#221 — it now does, and every suite runs against the new structure).

**Design:** inline single-element mode (evict-on-empty recreates sets constantly — keeps that churn to one small object) spilling to a `long[]` window with two-sided slack; O(1) fast paths for Kafka's dominant orders (monotonic append, head removal); out-of-order ops binary-search + arraycopy; zero steady-state allocation. The §14 bucket-locked `compute`/`computeIfPresent` remove-if-empty patterns are preserved verbatim; `firstOrNull` reads under one monitor acquisition, so the skiplist `first()`-throws race is structurally impossible (`safeFirst`/`safeLast` deleted). No public API changes.

## Measured (JMH `gc.alloc.rate.norm`, deterministic)

| | B/op |
|---|---|
| Baseline (skiplist) | 419.7 |
| **This PR** | **232.0 (−44.7%)** |

Residual 232 is the mandated evict/recreate cycle + lambda captures, not the structure — high-in-flight regimes allocate nothing, so the production win skews larger.

## Verification

- **jcstress: 510/510 pass** — the 5 pre-existing offset suites now exercise the new structure, plus 3 NEW suites (`PendingOffsetSet{AddRemove,ConcurrentAdd,FirstRead}JCStressTest`) covering add-vs-drain, concurrent out-of-order adds, first-read-vs-drain.
- `:lib:kpipe-consumer:test` 390 tests green locally (4 Testcontainers classes need Docker — CI covers them).
- New `PendingOffsetSetTest`: deterministic spill/compaction/negative-offset edges + 500-try jqwik property against a `TreeSet<Long>` oracle after every op.
- Docs updated: OFFSET-INVARIANTS vocabulary, README, SafeFirst jcstress narrative.

## Residual risks (documented in class Javadoc)
Spilled sets retain their high-water array until fully drained (bounded per partition); pathological fully-random completion over a very deep window shifts cost from allocation to arraycopy.