### PR TITLE
feat: kpipe-test module — TestStream<T> for Docker-free pipeline testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,7 @@ snippets are in the catalog below.
 | `kpipe-format-json`               | `JsonFormat`, `JsonConsoleSink`                                                                                                                             |
 | `kpipe-format-avro`               | `AvroFormat`, `AvroConsoleSink`                                                                                                                             |
 | `kpipe-format-protobuf`           | `ProtobufFormat`, `ProtobufConsoleSink`                                                                                                                     |
+| `kpipe-test`                      | `TestStream<T>` + `CapturingSink<T>` — Docker-free pipeline unit tests over a real consumer (`testImplementation` scope)                                    |
 
 **Gradle (Kotlin) with BOM**
 
@@ -992,6 +993,33 @@ the explicit Builder and metrics paths.
 ---
 
 ## Testing
+
+### Testing your pipeline
+
+`kpipe-test` drives your pipeline through a real `KPipeConsumer` over an in-memory `MockConsumer` — no broker, no
+Docker, milliseconds per test. `flush()` is deterministic: it returns only once every sent record has fully settled, so
+assertions never race the consumer thread. Filtered records count as processed but never reach the sink; failures land
+in `driver.errors()`.
+
+```java
+final var captured = new CapturingSink<Map<String, Object>>();
+try (
+  final var driver = TestStream.<Map<String, Object>>builder(JsonFormat.INSTANCE)
+    .pipe(addTimestamp)
+    .filter(active)
+    .toCustom(captured)
+    .build()
+) {
+  driver.send(Map.of("id", "a", "active", true));
+  driver.flush();
+  assertEquals(1, captured.count());
+}
+```
+
+Pull it into your test scope with `testImplementation("io.github.eschizoid:kpipe-test")` — versionless via the
+`kpipe-bom` platform, or pinned to the same version as your other `kpipe-*` modules.
+
+### Integration testing against a real broker
 
 There's a `docker-compose.yaml` for spinning up Kafka (KRaft mode) and Confluent Schema Registry locally.
 

--- a/lib/kpipe-bom/build.gradle.kts
+++ b/lib/kpipe-bom/build.gradle.kts
@@ -15,5 +15,6 @@ dependencies {
     api(project(":lib:kpipe-format-avro"))
     api(project(":lib:kpipe-format-protobuf"))
     api(project(":lib:kpipe-api"))
+    api(project(":lib:kpipe-test"))
   }
 }

--- a/lib/kpipe-test/build.gradle.kts
+++ b/lib/kpipe-test/build.gradle.kts
@@ -1,0 +1,56 @@
+plugins {
+  `java-library`
+  jacoco
+}
+
+description = "KPipe test kit — TestStream driver and CapturingSink for Docker-free pipeline unit tests"
+
+java {
+  withSourcesJar()
+  withJavadocJar()
+  modularity.inferModulePath.set(true)
+  toolchain {
+    languageVersion = JavaLanguageVersion.of(25)
+  }
+}
+
+repositories {
+  mavenCentral()
+}
+
+dependencies {
+  api(project(":lib:kpipe-core"))
+  api(project(":lib:kpipe-consumer"))
+
+  implementation(libs.kafkaClients)
+
+  testImplementation(project(":lib:kpipe-format-json"))
+  testImplementation(platform(libs.junitBom))
+  testImplementation(libs.junitJupiter)
+  testRuntimeOnly(libs.junitPlatformLauncher)
+  testImplementation(libs.slf4jSimple)
+}
+
+tasks.test {
+  useJUnitPlatform()
+}
+
+tasks.jacocoTestReport {
+  reports {
+    csv.required.set(true)
+    xml.required.set(true)
+    html.required.set(true)
+  }
+}
+
+tasks.compileJava {
+  doFirst {
+    options.compilerArgs.addAll(listOf("--module-path", classpath.asPath))
+    classpath = files()
+  }
+}
+
+tasks.javadoc {
+  options.modulePath = classpath.toList()
+  classpath = files()
+}

--- a/lib/kpipe-test/src/main/java/io/github/eschizoid/kpipe/test/CapturingSink.java
+++ b/lib/kpipe-test/src/main/java/io/github/eschizoid/kpipe/test/CapturingSink.java
@@ -1,0 +1,51 @@
+package io.github.eschizoid.kpipe.test;
+
+import io.github.eschizoid.kpipe.sink.MessageSink;
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+/// A [MessageSink] that records every value it receives, for assertions in tests.
+///
+/// Thread-safe: values may arrive concurrently from parallel virtual-thread workers.
+/// [#captured] returns an immutable snapshot, so the assertion never observes a half-appended
+/// list. There is deliberately no assertion DSL here — use `assertEquals`, AssertJ, or Hamcrest
+/// on the returned list.
+///
+/// ```java
+/// final var captured = new CapturingSink<Map<String, Object>>();
+/// // ... drive records through a TestStream with .toCustom(captured) ...
+/// assertEquals(List.of(expected), captured.captured());
+/// ```
+///
+/// @param <T> the pipeline value type
+public final class CapturingSink<T> implements MessageSink<T> {
+
+  private final CopyOnWriteArrayList<T> values = new CopyOnWriteArrayList<>();
+
+  /// Records the delivered value.
+  ///
+  /// @param value the value delivered by the pipeline
+  @Override
+  public void accept(final T value) {
+    values.add(value);
+  }
+
+  /// Returns an immutable snapshot of every value captured so far, in delivery order.
+  ///
+  /// @return the captured values
+  public List<T> captured() {
+    return List.copyOf(values);
+  }
+
+  /// Returns the number of values captured so far.
+  ///
+  /// @return the capture count
+  public int count() {
+    return values.size();
+  }
+
+  /// Discards all captured values, so one sink instance can be reused across test phases.
+  public void clear() {
+    values.clear();
+  }
+}

--- a/lib/kpipe-test/src/main/java/io/github/eschizoid/kpipe/test/TestStream.java
+++ b/lib/kpipe-test/src/main/java/io/github/eschizoid/kpipe/test/TestStream.java
@@ -1,0 +1,402 @@
+package io.github.eschizoid.kpipe.test;
+
+import io.github.eschizoid.kpipe.consumer.KPipeConsumer;
+import io.github.eschizoid.kpipe.consumer.ProcessingMode;
+import io.github.eschizoid.kpipe.registry.MessageFormat;
+import io.github.eschizoid.kpipe.registry.MessageProcessorRegistry;
+import io.github.eschizoid.kpipe.registry.Operators;
+import io.github.eschizoid.kpipe.sink.BatchPolicy;
+import io.github.eschizoid.kpipe.sink.BatchSink;
+import io.github.eschizoid.kpipe.sink.MessageSink;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Properties;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.Consumer;
+import java.util.function.Predicate;
+import java.util.function.UnaryOperator;
+import org.apache.kafka.clients.consumer.ConsumerRebalanceListener;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.clients.consumer.MockConsumer;
+import org.apache.kafka.common.TopicPartition;
+
+/// A Docker-free test driver for KPipe pipelines. Wraps a real [KPipeConsumer] around a Kafka
+/// `MockConsumer`, so tests exercise the production dispatch, offset, and sink machinery without
+/// a broker — each test completes in milliseconds instead of the seconds a Testcontainers
+/// round-trip costs.
+///
+/// ```java
+/// final var captured = new CapturingSink<Map<String, Object>>();
+/// try (final var driver = TestStream.<Map<String, Object>>builder(JsonFormat.INSTANCE)
+///     .pipe(addTimestamp)
+///     .filter(active)
+///     .toCustom(captured)
+///     .build()) {
+///   driver.send(record1);
+///   driver.send(record2);
+///   driver.flush();
+///   assertEquals(List.of(expected), captured.captured());
+/// }
+/// ```
+///
+/// **Drive model.** `send` serializes the typed value through the configured [MessageFormat] and
+/// appends it to the mock partition; the running consumer polls it off and drives it through the
+/// same pipeline code paths production uses. Processing defaults to
+/// [ProcessingMode#SEQUENTIAL] so capture order matches send order; override with
+/// [Builder#withProcessingMode] to exercise parallel behaviour.
+///
+/// **Determinism.** [#flush] blocks until every sent record is accounted for — terminal
+/// (processed, filtered, or failed) or, in batch mode, buffered awaiting the size trigger — and
+/// the dispatcher's in-flight count has drained. Assertions after `flush()` never race the
+/// consumer thread.
+///
+/// **Batch semantics.** With [Builder#toBatch], full batches flush on the size trigger as records
+/// arrive (observable after `flush()`); the trailing partial batch flushes on [#close] — the same
+/// shutdown-drain guarantee the production consumer gives. There is no age-based flush: the
+/// policy's age cap is set beyond any sane test duration so size and shutdown are the only
+/// triggers.
+///
+/// @param <T> the pipeline value type
+public final class TestStream<T> implements AutoCloseable {
+
+  private static final Duration DEFAULT_FLUSH_TIMEOUT = Duration.ofSeconds(10);
+  private static final Duration CLOSE_AGE_CAP = Duration.ofDays(1);
+
+  // Public metric-map keys of KPipeConsumer.getMetrics(); see the metrics table in README.
+  private static final String METRIC_RECEIVED = "messagesReceived";
+  private static final String METRIC_PROCESSED = "messagesProcessed";
+  private static final String METRIC_ERRORS = "processingErrors";
+  private static final String METRIC_IN_FLIGHT = "inFlight";
+
+  private final String topic;
+  private final MessageFormat<T> format;
+  private final KPipeConsumer<String> consumer;
+  private final MockConsumer<String, byte[]> mockConsumer;
+  private final AtomicLong nextOffset = new AtomicLong(0);
+  private final AtomicBoolean closed = new AtomicBoolean(false);
+  private final CopyOnWriteArrayList<KPipeConsumer.ProcessingError<String>> errors;
+
+  private TestStream(
+    final String topic,
+    final MessageFormat<T> format,
+    final KPipeConsumer<String> consumer,
+    final MockConsumer<String, byte[]> mockConsumer,
+    final CopyOnWriteArrayList<KPipeConsumer.ProcessingError<String>> errors
+  ) {
+    this.topic = topic;
+    this.format = format;
+    this.consumer = consumer;
+    this.mockConsumer = mockConsumer;
+    this.errors = errors;
+  }
+
+  /// Creates a builder for a test stream over the given format.
+  ///
+  /// @param format the SerDe for the pipeline value type
+  /// @param <T> the pipeline value type
+  /// @return a new builder
+  public static <T> Builder<T> builder(final MessageFormat<T> format) {
+    return new Builder<>(format);
+  }
+
+  /// Serializes `value` through the stream's format and appends it to the mock partition with a
+  /// null key.
+  ///
+  /// @param value the typed record value (must not be null)
+  /// @return this stream for chaining
+  public TestStream<T> send(final T value) {
+    return send(null, value);
+  }
+
+  /// Serializes `value` through the stream's format and appends it to the mock partition.
+  ///
+  /// @param key the record key (nullable)
+  /// @param value the typed record value (must not be null)
+  /// @return this stream for chaining
+  public TestStream<T> send(final String key, final T value) {
+    Objects.requireNonNull(value, "value cannot be null — use sendRaw to exercise null-value error paths");
+    return sendRaw(key, format.serialize(value));
+  }
+
+  /// Appends raw bytes to the mock partition with a null key, bypassing the format's serializer.
+  /// Use this to exercise deserialization-failure paths with malformed payloads.
+  ///
+  /// @param rawValue the raw record value (nullable — a null value exercises the consumer's
+  ///                 null-record error path)
+  /// @return this stream for chaining
+  public TestStream<T> sendRaw(final byte[] rawValue) {
+    return sendRaw(null, rawValue);
+  }
+
+  /// Appends raw bytes to the mock partition, bypassing the format's serializer.
+  ///
+  /// @param key the record key (nullable)
+  /// @param rawValue the raw record value (nullable)
+  /// @return this stream for chaining
+  public TestStream<T> sendRaw(final String key, final byte[] rawValue) {
+    ensureOpen();
+    final var offset = nextOffset.getAndIncrement();
+    mockConsumer.addRecord(new ConsumerRecord<>(topic, 0, offset, key, rawValue));
+    return this;
+  }
+
+  /// Deterministically drains the stream with the default 10-second timeout. See
+  /// [#flush(Duration)].
+  ///
+  /// @return this stream for chaining
+  public TestStream<T> flush() {
+    return flush(DEFAULT_FLUSH_TIMEOUT);
+  }
+
+  /// Blocks until every record sent so far is accounted for: polled off the mock partition,
+  /// finished processing (dispatcher in-flight count drained to zero), and terminal — processed,
+  /// filtered, or failed. In batch mode records buffered awaiting the size trigger also count as
+  /// accounted for; the trailing partial batch flushes on [#close].
+  ///
+  /// @param timeout the maximum time to wait
+  /// @return this stream for chaining
+  /// @throws AssertionError if the stream does not quiesce within `timeout`
+  public TestStream<T> flush(final Duration timeout) {
+    ensureOpen();
+    final var target = nextOffset.get();
+    final var deadline = System.nanoTime() + timeout.toNanos();
+    while (System.nanoTime() < deadline) {
+      if (quiescent(target)) return this;
+      try {
+        Thread.sleep(5);
+      } catch (final InterruptedException e) {
+        Thread.currentThread().interrupt();
+        throw new AssertionError("flush() interrupted while waiting for " + target + " records: " + metrics(), e);
+      }
+    }
+    throw new AssertionError(
+      "flush(" + timeout + ") timed out waiting for " + target + " records to settle: " + metrics()
+    );
+  }
+
+  /// A snapshot of the underlying consumer's metrics (`messagesReceived`, `messagesProcessed`,
+  /// `processingErrors`, `inFlight`, ...), for assertions on filter and error paths.
+  ///
+  /// @return an immutable metrics snapshot
+  public Map<String, Long> metrics() {
+    return consumer.getMetrics();
+  }
+
+  /// Every [KPipeConsumer.ProcessingError] the consumer reported so far, in report order. Failed
+  /// operators, deserialization failures, and null-value records all land here — the same
+  /// terminal-error channel production error handlers observe.
+  ///
+  /// @return an immutable snapshot of the reported errors
+  public List<KPipeConsumer.ProcessingError<String>> errors() {
+    return List.copyOf(errors);
+  }
+
+  /// Closes the underlying consumer. In batch mode this drains the trailing partial batch (the
+  /// production shutdown-flush guarantee), so batch assertions covering every sent record belong
+  /// after `close()`. Idempotent.
+  @Override
+  public void close() {
+    if (closed.compareAndSet(false, true)) consumer.close();
+  }
+
+  /// All sent records are either terminal (processed / filtered / failed) or buffered in a batch
+  /// wrapper, and no dispatcher worker is mid-record. Checked in a deliberate order: records move
+  /// strictly forward (unpolled → in-flight → buffered/terminal), so observing "all accounted
+  /// for" *before* observing "in-flight drained" cannot yield a false positive — a record that
+  /// was still unpolled at the first check keeps the sum below target, and a record still
+  /// processing fails the drain check. The final re-read confirms the accounting after the drain.
+  private boolean quiescent(final long target) {
+    final var snapshot = metrics();
+    if (snapshot.get(METRIC_RECEIVED) < target) return false;
+    if (accountedFor(snapshot) < target) return false;
+    if (!consumer.waitForInFlightDrain(Duration.ofMillis(1))) return false;
+    final var settled = metrics();
+    return settled.get(METRIC_RECEIVED) >= target && accountedFor(settled) >= target;
+  }
+
+  /// Terminal records plus in-flight ones (`inFlight` = dispatcher pending + batch-buffered;
+  /// after a drain, pending is zero so the in-flight component is exactly the buffered count).
+  private static long accountedFor(final Map<String, Long> snapshot) {
+    return snapshot.get(METRIC_PROCESSED) + snapshot.get(METRIC_ERRORS) + snapshot.get(METRIC_IN_FLIGHT);
+  }
+
+  private void ensureOpen() {
+    if (closed.get()) throw new IllegalStateException("TestStream is closed");
+  }
+
+  /// Builder for [TestStream]. Mirrors the production facade's `pipe` / `filter` / `peek` /
+  /// `toCustom` vocabulary so a passing TestStream chain translates 1:1 to a `KPipe.X(...)`
+  /// chain.
+  ///
+  /// @param <T> the pipeline value type
+  public static final class Builder<T> {
+
+    private final MessageFormat<T> format;
+    private final List<UnaryOperator<T>> operators = new ArrayList<>();
+    private String topic = "kpipe-test-topic";
+    private MessageSink<T> sink;
+    private BatchSink<T> batchSink;
+    private int batchMaxSize;
+    private ProcessingMode processingMode = ProcessingMode.SEQUENTIAL;
+    private Consumer<KPipeConsumer.ProcessingError<String>> errorHandler;
+
+    private Builder(final MessageFormat<T> format) {
+      this.format = Objects.requireNonNull(format, "format cannot be null");
+    }
+
+    /// Overrides the synthetic topic name (default `kpipe-test-topic`). Only matters when an
+    /// operator or assertion inspects `ProcessingError.record().topic()`.
+    ///
+    /// @param topic the topic name
+    /// @return this builder
+    public Builder<T> withTopic(final String topic) {
+      Objects.requireNonNull(topic, "topic cannot be null");
+      if (topic.isBlank()) throw new IllegalArgumentException("topic cannot be blank");
+      this.topic = topic;
+      return this;
+    }
+
+    /// Appends a transformation operator to the pipeline.
+    ///
+    /// @param op the operator
+    /// @return this builder
+    public Builder<T> pipe(final UnaryOperator<T> op) {
+      operators.add(Objects.requireNonNull(op, "operator cannot be null"));
+      return this;
+    }
+
+    /// Appends a filter: records failing the predicate are dropped as intentional filtering
+    /// (counted processed, never delivered to the sink, no error reported).
+    ///
+    /// @param keep records pass through only when this predicate returns true
+    /// @return this builder
+    public Builder<T> filter(final Predicate<T> keep) {
+      Objects.requireNonNull(keep, "predicate cannot be null");
+      operators.add(Operators.filter(keep));
+      return this;
+    }
+
+    /// Appends a side-effect observer that passes the value through unchanged.
+    ///
+    /// @param sideEffect the observer
+    /// @return this builder
+    public Builder<T> peek(final Consumer<T> sideEffect) {
+      Objects.requireNonNull(sideEffect, "sideEffect cannot be null");
+      operators.add(Operators.peek(sideEffect));
+      return this;
+    }
+
+    /// Sets the terminal sink — typically a [CapturingSink]. Mutually exclusive with [#toBatch].
+    ///
+    /// @param sink the terminal sink
+    /// @return this builder
+    public Builder<T> toCustom(final MessageSink<T> sink) {
+      this.sink = Objects.requireNonNull(sink, "sink cannot be null");
+      return this;
+    }
+
+    /// Routes the stream through a batch sink flushing every `maxSize` records. The trailing
+    /// partial batch flushes when the stream closes. There is no age-based flush trigger.
+    /// Mutually exclusive with [#toCustom].
+    ///
+    /// @param sink the batch sink (wrap a void-style consumer with `BatchSink.ofVoid`)
+    /// @param maxSize the size-flush threshold (must be ≥ 1)
+    /// @return this builder
+    public Builder<T> toBatch(final BatchSink<T> sink, final int maxSize) {
+      this.batchSink = Objects.requireNonNull(sink, "sink cannot be null");
+      if (maxSize < 1) throw new IllegalArgumentException("maxSize must be >= 1, got " + maxSize);
+      this.batchMaxSize = maxSize;
+      return this;
+    }
+
+    /// Overrides the processing mode (default [ProcessingMode#SEQUENTIAL], which keeps capture
+    /// order identical to send order). Use [ProcessingMode#PARALLEL] or
+    /// [ProcessingMode#KEY_ORDERED] to exercise concurrent dispatch — assertions must then
+    /// compare order-insensitively.
+    ///
+    /// @param mode the processing mode
+    /// @return this builder
+    public Builder<T> withProcessingMode(final ProcessingMode mode) {
+      this.processingMode = Objects.requireNonNull(mode, "mode cannot be null");
+      return this;
+    }
+
+    /// Registers an additional error observer, invoked after the stream records the error for
+    /// [TestStream#errors].
+    ///
+    /// @param handler the error observer
+    /// @return this builder
+    public Builder<T> withErrorHandler(final Consumer<KPipeConsumer.ProcessingError<String>> handler) {
+      this.errorHandler = Objects.requireNonNull(handler, "handler cannot be null");
+      return this;
+    }
+
+    /// Builds and starts the stream: constructs the pipeline, seeds a `MockConsumer`, and starts
+    /// the [KPipeConsumer] poll loop. The returned stream is immediately ready for
+    /// [TestStream#send].
+    ///
+    /// @return a started test stream
+    public TestStream<T> build() {
+      if (sink != null && batchSink != null) throw new IllegalArgumentException(
+        "toCustom and toBatch are mutually exclusive — a stream terminates in exactly one sink shape"
+      );
+
+      final var pipelineBuilder = new MessageProcessorRegistry().pipeline(format);
+      for (final var op : operators) pipelineBuilder.add(op);
+      if (sink != null) pipelineBuilder.toSink(sink);
+      final var pipeline = pipelineBuilder.build();
+
+      final var mock = new MockConsumer<String, byte[]>("earliest") {
+        @Override
+        public synchronized void subscribe(final Collection<String> topics) {}
+
+        @Override
+        public synchronized void subscribe(final Collection<String> topics, final ConsumerRebalanceListener cb) {}
+      };
+      final var tp = new TopicPartition(topic, 0);
+      mock.assign(List.of(tp));
+      mock.updateBeginningOffsets(Map.of(tp, 0L));
+
+      final var errors = new CopyOnWriteArrayList<KPipeConsumer.ProcessingError<String>>();
+      final var userHandler = errorHandler;
+      final KPipeConsumer.ErrorHandler<String> recordingHandler = error -> {
+        errors.add(error);
+        if (userHandler != null) userHandler.accept(error);
+      };
+
+      final var consumerBuilder = KPipeConsumer.<String>builder()
+        .withProperties(props())
+        .withProcessingMode(processingMode)
+        .withErrorHandler(recordingHandler)
+        .withConsumer(() -> mock)
+        .withPollTimeout(Duration.ofMillis(10));
+      if (batchSink != null) {
+        consumerBuilder.withBatchPipeline(topic, pipeline, batchSink, new BatchPolicy(batchMaxSize, CLOSE_AGE_CAP));
+      } else {
+        consumerBuilder.withTopic(topic).withPipeline(pipeline);
+      }
+
+      final var consumer = consumerBuilder.build();
+      consumer.start();
+      return new TestStream<>(topic, format, consumer, mock, errors);
+    }
+
+    /// Minimal, never-contacted config — the `MockConsumer` supplier bypasses the real client, so
+    /// only the properties object's presence matters.
+    private static Properties props() {
+      final var p = new Properties();
+      p.put("bootstrap.servers", "localhost:9092");
+      p.put("group.id", "kpipe-test");
+      p.put("key.deserializer", "org.apache.kafka.common.serialization.StringDeserializer");
+      p.put("value.deserializer", "org.apache.kafka.common.serialization.ByteArrayDeserializer");
+      p.put("enable.auto.commit", "false");
+      return p;
+    }
+  }
+}

--- a/lib/kpipe-test/src/main/java/io/github/eschizoid/kpipe/test/package-info.java
+++ b/lib/kpipe-test/src/main/java/io/github/eschizoid/kpipe/test/package-info.java
@@ -1,0 +1,21 @@
+/// Docker-free unit-test primitives for KPipe pipelines.
+///
+/// The entry point is [io.github.eschizoid.kpipe.test.TestStream]: build a pipeline with the same
+/// `pipe` / `filter` / `toCustom` vocabulary as the production facade, `send` typed records, call
+/// `flush()` for a deterministic drain, and assert on a
+/// [io.github.eschizoid.kpipe.test.CapturingSink].
+///
+/// ```java
+/// final var captured = new CapturingSink<Map<String, Object>>();
+/// try (final var driver = TestStream.<Map<String, Object>>builder(JsonFormat.INSTANCE)
+///     .pipe(addTimestamp)
+///     .filter(active)
+///     .toCustom(captured)
+///     .build()) {
+///   driver.send(record1);
+///   driver.send(record2);
+///   driver.flush();
+///   assertEquals(List.of(expected), captured.captured());
+/// }
+/// ```
+package io.github.eschizoid.kpipe.test;

--- a/lib/kpipe-test/src/main/java/module-info.java
+++ b/lib/kpipe-test/src/main/java/module-info.java
@@ -1,0 +1,14 @@
+/// KPipe test module — Docker-free unit-test primitives for KPipe pipelines.
+///
+/// Provides [io.github.eschizoid.kpipe.test.TestStream], a `MockConsumer`-backed driver that runs
+/// records through a real [io.github.eschizoid.kpipe.consumer.KPipeConsumer], and
+/// [io.github.eschizoid.kpipe.test.CapturingSink] for asserting on sink deliveries. No broker, no
+/// Testcontainers — tests complete in milliseconds while still exercising the production consumer
+/// code paths.
+module io.github.eschizoid.kpipe.test {
+  requires transitive io.github.eschizoid.kpipe.core;
+  requires transitive io.github.eschizoid.kpipe.consumer;
+  requires transitive kafka.clients;
+
+  exports io.github.eschizoid.kpipe.test;
+}

--- a/lib/kpipe-test/src/test/java/io/github/eschizoid/kpipe/test/CapturingSinkTest.java
+++ b/lib/kpipe-test/src/test/java/io/github/eschizoid/kpipe/test/CapturingSinkTest.java
@@ -1,0 +1,74 @@
+package io.github.eschizoid.kpipe.test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.Test;
+
+class CapturingSinkTest {
+
+  @Test
+  void capturesInDeliveryOrder() {
+    final var sink = new CapturingSink<String>();
+    sink.accept("a");
+    sink.accept("b");
+    sink.accept("c");
+
+    assertEquals(List.of("a", "b", "c"), sink.captured());
+    assertEquals(3, sink.count());
+  }
+
+  @Test
+  void capturedReturnsAnImmutableSnapshot() {
+    final var sink = new CapturingSink<String>();
+    sink.accept("a");
+    final var snapshot = sink.captured();
+    sink.accept("b");
+
+    assertEquals(List.of("a"), snapshot, "a snapshot must not see later deliveries");
+    assertThrows(UnsupportedOperationException.class, () -> snapshot.add("x"));
+  }
+
+  @Test
+  void clearResetsTheSink() {
+    final var sink = new CapturingSink<String>();
+    sink.accept("a");
+    sink.clear();
+
+    assertEquals(List.of(), sink.captured());
+    assertEquals(0, sink.count());
+  }
+
+  @Test
+  void concurrentDeliveriesAreAllCaptured() throws InterruptedException {
+    // Real virtual threads, not CompletableFuture — mirrors how parallel-mode workers deliver.
+    final var sink = new CapturingSink<Integer>();
+    final var threads = 50;
+    final var start = new CountDownLatch(1);
+    final var done = new CountDownLatch(threads);
+    for (int i = 0; i < threads; i++) {
+      final var value = i;
+      Thread.ofVirtual().start(() -> {
+        try {
+          start.await();
+          sink.accept(value);
+        } catch (final InterruptedException e) {
+          Thread.currentThread().interrupt();
+        } finally {
+          done.countDown();
+        }
+      });
+    }
+    start.countDown();
+    assertTrue(done.await(5, TimeUnit.SECONDS), "virtual threads must finish");
+
+    final var seen = new HashSet<>(sink.captured());
+    assertEquals(threads, sink.count(), "no delivery may be lost under concurrency");
+    for (int i = 0; i < threads; i++) assertTrue(seen.contains(i));
+  }
+}

--- a/lib/kpipe-test/src/test/java/io/github/eschizoid/kpipe/test/TestStreamBatchTest.java
+++ b/lib/kpipe-test/src/test/java/io/github/eschizoid/kpipe/test/TestStreamBatchTest.java
@@ -1,0 +1,148 @@
+package io.github.eschizoid.kpipe.test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.github.eschizoid.kpipe.registry.MessageFormat;
+import io.github.eschizoid.kpipe.sink.BatchSink;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+import org.junit.jupiter.api.Test;
+
+/// Batch-mode coverage for [TestStream]: size-triggered flushes are observable after `flush()`,
+/// the trailing partial batch flushes on `close()` (the production shutdown-drain guarantee), and
+/// per-record processing errors inside a batch route surface through `errors()`.
+class TestStreamBatchTest {
+
+  private static byte[] bytes(final String s) {
+    return s.getBytes(StandardCharsets.UTF_8);
+  }
+
+  private static List<String> strings(final List<byte[]> batch) {
+    return batch
+      .stream()
+      .map(b -> new String(b, StandardCharsets.UTF_8))
+      .toList();
+  }
+
+  @Test
+  void sizeTriggeredBatchesFlushBeforeClose() {
+    final var batches = new CopyOnWriteArrayList<List<String>>();
+    final var driver = TestStream.builder(MessageFormat.bytes())
+      .toBatch(BatchSink.ofVoid(batch -> batches.add(strings(batch))), 3)
+      .build();
+    try {
+      for (int i = 0; i < 7; i++) driver.send(bytes("b" + i));
+      driver.flush();
+
+      // 7 records with size 3: two full batches flushed on the size trigger, one record buffered.
+      assertEquals(
+        List.of(List.of("b0", "b1", "b2"), List.of("b3", "b4", "b5")),
+        batches,
+        "full batches must flush on the size trigger, in order, before close"
+      );
+      assertEquals(6L, driver.metrics().get("messagesProcessed"), "only flushed records count as processed");
+      assertEquals(1L, driver.metrics().get("inFlight"), "the trailing record stays buffered until close");
+    } finally {
+      driver.close();
+    }
+
+    // Shutdown flush: the trailing partial batch drains on close.
+    assertEquals(3, batches.size(), "close() must flush the trailing partial batch");
+    assertEquals(List.of("b6"), batches.getLast());
+  }
+
+  @Test
+  void closeWithoutSizeTriggerFlushesEverything() {
+    final var batches = new CopyOnWriteArrayList<List<String>>();
+    final var driver = TestStream.builder(MessageFormat.bytes())
+      .toBatch(BatchSink.ofVoid(batch -> batches.add(strings(batch))), 5)
+      .build();
+    try {
+      driver.send(bytes("only-1"));
+      driver.send(bytes("only-2"));
+      driver.flush();
+
+      assertEquals(List.of(), batches, "below the size trigger nothing flushes before close");
+    } finally {
+      driver.close();
+    }
+
+    assertEquals(List.of(List.of("only-1", "only-2")), batches);
+  }
+
+  @Test
+  void exactMultipleOfBatchSizeLeavesNothingBuffered() {
+    final var batches = new CopyOnWriteArrayList<List<String>>();
+    try (
+      final var driver = TestStream.builder(MessageFormat.bytes())
+        .toBatch(BatchSink.ofVoid(batch -> batches.add(strings(batch))), 2)
+        .build()
+    ) {
+      for (int i = 0; i < 4; i++) driver.send(bytes("e" + i));
+      driver.flush();
+
+      assertEquals(List.of(List.of("e0", "e1"), List.of("e2", "e3")), batches);
+      assertEquals(0L, driver.metrics().get("inFlight"), "an exact multiple leaves no buffered records");
+      assertEquals(4L, driver.metrics().get("messagesProcessed"));
+    }
+  }
+
+  @Test
+  void operatorsRunBeforeBatchBuffering() {
+    final var batches = new CopyOnWriteArrayList<List<String>>();
+    try (
+      final var driver = TestStream.builder(MessageFormat.bytes())
+        .pipe(b -> (new String(b, StandardCharsets.UTF_8) + "!").getBytes(StandardCharsets.UTF_8))
+        .toBatch(BatchSink.ofVoid(batch -> batches.add(strings(batch))), 2)
+        .build()
+    ) {
+      driver.send(bytes("x")).send(bytes("y")).flush();
+
+      assertEquals(List.of(List.of("x!", "y!")), batches, "the batch sink sees post-pipeline values");
+    }
+  }
+
+  @Test
+  void filteredRecordsNeverEnterTheBatchBuffer() {
+    final var batches = new CopyOnWriteArrayList<List<String>>();
+    try (
+      final var driver = TestStream.builder(MessageFormat.bytes())
+        .filter(b -> !new String(b, StandardCharsets.UTF_8).startsWith("drop"))
+        .toBatch(BatchSink.ofVoid(batch -> batches.add(strings(batch))), 2)
+        .build()
+    ) {
+      driver.send(bytes("keep-1"));
+      driver.send(bytes("drop-1"));
+      driver.send(bytes("keep-2"));
+      driver.flush();
+
+      assertEquals(List.of(List.of("keep-1", "keep-2")), batches, "filtered records are terminal, not buffered");
+      assertEquals(3L, driver.metrics().get("messagesProcessed"), "filtered records still count as processed");
+      assertEquals(0L, driver.metrics().get("inFlight"));
+    }
+  }
+
+  @Test
+  void throwingBatchSinkReportsEveryRecordInTheBatch() {
+    final BatchSink<byte[]> failing = BatchSink.ofVoid(batch -> {
+      throw new IllegalStateException("batch sink down");
+    });
+    try (final var driver = TestStream.builder(MessageFormat.bytes()).toBatch(failing, 2).build()) {
+      driver.send(bytes("f1"));
+      driver.send(bytes("f2"));
+      driver.flush();
+
+      assertEquals(2L, driver.metrics().get("processingErrors"), "a throwing void batch sink fails the whole batch");
+      assertEquals(2, driver.errors().size());
+      assertTrue(
+        driver
+          .errors()
+          .stream()
+          .allMatch(e -> "batch sink down".equals(e.exception().getMessage())),
+        "every per-record error carries the batch failure cause"
+      );
+    }
+  }
+}

--- a/lib/kpipe-test/src/test/java/io/github/eschizoid/kpipe/test/TestStreamTest.java
+++ b/lib/kpipe-test/src/test/java/io/github/eschizoid/kpipe/test/TestStreamTest.java
@@ -43,6 +43,20 @@ class TestStreamTest {
     return m;
   }
 
+  private static List<Object> ids(final CapturingSink<Map<String, Object>> captured) {
+    return captured
+      .captured()
+      .stream()
+      .map(m -> m.get("id"))
+      .toList();
+  }
+
+  private static Set<String> decodedSet(final CapturingSink<byte[]> captured) {
+    final var seen = new HashSet<String>();
+    for (final var b : captured.captured()) seen.add(new String(b, StandardCharsets.UTF_8));
+    return seen;
+  }
+
   // ────────────────────────────────────────────────────────────────────────────────
   // The PLAN "target ergonomics" sketch, verbatim
   // ────────────────────────────────────────────────────────────────────────────────
@@ -152,15 +166,7 @@ class TestStreamTest {
       driver.send(record("keep-2", true));
       driver.flush();
 
-      assertEquals(
-        List.of("keep-1", "keep-2"),
-        captured
-          .captured()
-          .stream()
-          .map(m -> m.get("id"))
-          .toList(),
-        "only records passing the filter reach the sink"
-      );
+      assertEquals(List.of("keep-1", "keep-2"), ids(captured), "only records passing the filter reach the sink");
       assertEquals(4L, driver.metrics().get("messagesProcessed"), "filtered records still count as processed");
       assertEquals(0L, driver.metrics().get("processingErrors"), "intentional filtering is not an error");
       assertEquals(List.of(), driver.errors(), "intentional filtering must not report ProcessingErrors");
@@ -209,11 +215,7 @@ class TestStreamTest {
 
       assertEquals(
         List.of("ok", "also-ok"),
-        captured
-          .captured()
-          .stream()
-          .map(m -> m.get("id"))
-          .toList(),
+        ids(captured),
         "the failing record must not reach the sink, later records still flow"
       );
       assertEquals(2L, driver.metrics().get("messagesProcessed"));
@@ -235,15 +237,7 @@ class TestStreamTest {
       driver.send(record("valid", true));
       driver.flush();
 
-      assertEquals(
-        List.of("valid"),
-        captured
-          .captured()
-          .stream()
-          .map(m -> m.get("id"))
-          .toList(),
-        "the malformed record must not poison subsequent valid records"
-      );
+      assertEquals(List.of("valid"), ids(captured), "the malformed record must not poison subsequent valid records");
       assertEquals(1L, driver.metrics().get("processingErrors"));
       assertEquals(1, driver.errors().size());
       assertNotNull(driver.errors().getFirst().exception());
@@ -326,9 +320,7 @@ class TestStreamTest {
       }
       driver.flush();
 
-      final Set<String> seen = new HashSet<>();
-      for (final var b : captured.captured()) seen.add(new String(b, StandardCharsets.UTF_8));
-      assertEquals(expected, seen, "parallel mode must deliver every record exactly once");
+      assertEquals(expected, decodedSet(captured), "parallel mode must deliver every record exactly once");
     }
   }
 
@@ -348,9 +340,7 @@ class TestStreamTest {
       }
       driver.flush();
 
-      final Set<String> seen = new HashSet<>();
-      for (final var b : captured.captured()) seen.add(new String(b, StandardCharsets.UTF_8));
-      assertEquals(expected, seen);
+      assertEquals(expected, decodedSet(captured));
     }
   }
 

--- a/lib/kpipe-test/src/test/java/io/github/eschizoid/kpipe/test/TestStreamTest.java
+++ b/lib/kpipe-test/src/test/java/io/github/eschizoid/kpipe/test/TestStreamTest.java
@@ -1,0 +1,438 @@
+package io.github.eschizoid.kpipe.test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.github.eschizoid.kpipe.consumer.ProcessingMode;
+import io.github.eschizoid.kpipe.format.json.JsonFormat;
+import io.github.eschizoid.kpipe.registry.MessageFormat;
+import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.function.Predicate;
+import java.util.function.UnaryOperator;
+import org.junit.jupiter.api.Test;
+
+/// End-to-end coverage of the [TestStream] driver over a real `KPipeConsumer` + `MockConsumer`,
+/// with no Docker. The first test is the PLAN's target-ergonomics sketch verbatim; the rest cover
+/// ordering, filter, error (operator throw / malformed payload / null value), metrics, lifecycle,
+/// and non-sequential modes.
+class TestStreamTest {
+
+  private static final UnaryOperator<Map<String, Object>> ADD_TIMESTAMP = record -> {
+    final var copy = new HashMap<>(record);
+    copy.put("ts", 1234L);
+    return copy;
+  };
+
+  private static final Predicate<Map<String, Object>> ACTIVE = record -> Boolean.TRUE.equals(record.get("active"));
+
+  private static Map<String, Object> record(final String id, final boolean active) {
+    // fastjson2 deserializes JSON booleans/strings back to Boolean/String, so round-tripping
+    // through the format preserves equality for these value shapes.
+    final var m = new HashMap<String, Object>();
+    m.put("id", id);
+    m.put("active", active);
+    return m;
+  }
+
+  // ────────────────────────────────────────────────────────────────────────────────
+  // The PLAN "target ergonomics" sketch, verbatim
+  // ────────────────────────────────────────────────────────────────────────────────
+
+  @Test
+  void planTargetErgonomicsVerbatim() {
+    final var record1 = record("a", true);
+    final var record2 = record("b", false);
+    final var addTimestamp = ADD_TIMESTAMP;
+    final var active = ACTIVE;
+
+    final var captured = new CapturingSink<Map<String, Object>>();
+    final var driver = TestStream.<Map<String, Object>>builder(JsonFormat.INSTANCE)
+      .pipe(addTimestamp)
+      .filter(active)
+      .toCustom(captured)
+      .build();
+    driver.send(record1);
+    driver.send(record2);
+    driver.flush();
+    assertEquals(List.of(expectedWithTimestamp("a", true)), captured.captured());
+
+    driver.close();
+  }
+
+  private static Map<String, Object> expectedWithTimestamp(final String id, final boolean active) {
+    final var m = record(id, active);
+    m.put("ts", 1234L);
+    return m;
+  }
+
+  // ────────────────────────────────────────────────────────────────────────────────
+  // Ordering + pass-through
+  // ────────────────────────────────────────────────────────────────────────────────
+
+  @Test
+  void sequentialModePreservesSendOrder() {
+    final var captured = new CapturingSink<byte[]>();
+    try (final var driver = TestStream.builder(MessageFormat.bytes()).toCustom(captured).build()) {
+      for (int i = 0; i < 25; i++) {
+        driver.send(("m" + i).getBytes(StandardCharsets.UTF_8));
+      }
+      driver.flush();
+
+      final var seen = captured
+        .captured()
+        .stream()
+        .map(b -> new String(b, StandardCharsets.UTF_8))
+        .toList();
+      assertEquals(25, seen.size());
+      for (int i = 0; i < 25; i++) {
+        assertEquals("m" + i, seen.get(i), "sequential capture order must match send order");
+      }
+    }
+  }
+
+  @Test
+  void operatorsChainInDeclarationOrder() {
+    final var captured = new CapturingSink<byte[]>();
+    try (
+      final var driver = TestStream.builder(MessageFormat.bytes())
+        .pipe(b -> (new String(b, StandardCharsets.UTF_8) + "-first").getBytes(StandardCharsets.UTF_8))
+        .pipe(b -> (new String(b, StandardCharsets.UTF_8) + "-second").getBytes(StandardCharsets.UTF_8))
+        .toCustom(captured)
+        .build()
+    ) {
+      driver.send("x".getBytes(StandardCharsets.UTF_8)).flush();
+
+      assertEquals(1, captured.count());
+      assertEquals("x-first-second", new String(captured.captured().getFirst(), StandardCharsets.UTF_8));
+    }
+  }
+
+  @Test
+  void peekObservesWithoutMutating() {
+    final var peeked = new CopyOnWriteArrayList<String>();
+    final var captured = new CapturingSink<byte[]>();
+    try (
+      final var driver = TestStream.builder(MessageFormat.bytes())
+        .peek(b -> peeked.add(new String(b, StandardCharsets.UTF_8)))
+        .toCustom(captured)
+        .build()
+    ) {
+      driver.send("hello".getBytes(StandardCharsets.UTF_8)).flush();
+
+      assertEquals(List.of("hello"), peeked);
+      assertEquals("hello", new String(captured.captured().getFirst(), StandardCharsets.UTF_8));
+    }
+  }
+
+  // ────────────────────────────────────────────────────────────────────────────────
+  // Filter path — dropped records are processed, not errors, never reach the sink
+  // ────────────────────────────────────────────────────────────────────────────────
+
+  @Test
+  void filteredRecordsAreCountedProcessedNotErrored() {
+    final var captured = new CapturingSink<Map<String, Object>>();
+    try (
+      final var driver = TestStream.<Map<String, Object>>builder(JsonFormat.INSTANCE)
+        .filter(ACTIVE)
+        .toCustom(captured)
+        .build()
+    ) {
+      driver.send(record("keep-1", true));
+      driver.send(record("drop-1", false));
+      driver.send(record("drop-2", false));
+      driver.send(record("keep-2", true));
+      driver.flush();
+
+      assertEquals(
+        List.of("keep-1", "keep-2"),
+        captured
+          .captured()
+          .stream()
+          .map(m -> m.get("id"))
+          .toList(),
+        "only records passing the filter reach the sink"
+      );
+      assertEquals(4L, driver.metrics().get("messagesProcessed"), "filtered records still count as processed");
+      assertEquals(0L, driver.metrics().get("processingErrors"), "intentional filtering is not an error");
+      assertEquals(List.of(), driver.errors(), "intentional filtering must not report ProcessingErrors");
+    }
+  }
+
+  @Test
+  void pipeReturningNullFiltersTheRecord() {
+    final var captured = new CapturingSink<byte[]>();
+    try (
+      final var driver = TestStream.builder(MessageFormat.bytes())
+        .pipe(b -> b.length > 2 ? b : null)
+        .toCustom(captured)
+        .build()
+    ) {
+      driver.send("long-enough".getBytes(StandardCharsets.UTF_8));
+      driver.send("ab".getBytes(StandardCharsets.UTF_8));
+      driver.flush();
+
+      assertEquals(1, captured.count());
+      assertEquals(2L, driver.metrics().get("messagesProcessed"));
+      assertEquals(0L, driver.metrics().get("processingErrors"));
+    }
+  }
+
+  // ────────────────────────────────────────────────────────────────────────────────
+  // Error paths — operator throw, malformed payload, null value
+  // ────────────────────────────────────────────────────────────────────────────────
+
+  @Test
+  void throwingOperatorReportsErrorAndSkipsSink() {
+    final var captured = new CapturingSink<Map<String, Object>>();
+    try (
+      final var driver = TestStream.<Map<String, Object>>builder(JsonFormat.INSTANCE)
+        .pipe(m -> {
+          if ("boom".equals(m.get("id"))) throw new IllegalArgumentException("deliberate failure");
+          return m;
+        })
+        .toCustom(captured)
+        .build()
+    ) {
+      driver.send("k1", record("ok", true));
+      driver.send("k2", record("boom", true));
+      driver.send("k3", record("also-ok", true));
+      driver.flush();
+
+      assertEquals(
+        List.of("ok", "also-ok"),
+        captured
+          .captured()
+          .stream()
+          .map(m -> m.get("id"))
+          .toList(),
+        "the failing record must not reach the sink, later records still flow"
+      );
+      assertEquals(2L, driver.metrics().get("messagesProcessed"));
+      assertEquals(1L, driver.metrics().get("processingErrors"));
+
+      assertEquals(1, driver.errors().size());
+      final var error = driver.errors().getFirst();
+      assertEquals("k2", error.record().key(), "the error carries the original Kafka record");
+      assertInstanceOf(IllegalArgumentException.class, error.exception());
+      assertEquals("deliberate failure", error.exception().getMessage());
+    }
+  }
+
+  @Test
+  void malformedPayloadReportsDeserializationError() {
+    final var captured = new CapturingSink<Map<String, Object>>();
+    try (final var driver = TestStream.<Map<String, Object>>builder(JsonFormat.INSTANCE).toCustom(captured).build()) {
+      driver.sendRaw("this is not json{{{".getBytes(StandardCharsets.UTF_8));
+      driver.send(record("valid", true));
+      driver.flush();
+
+      assertEquals(
+        List.of("valid"),
+        captured
+          .captured()
+          .stream()
+          .map(m -> m.get("id"))
+          .toList(),
+        "the malformed record must not poison subsequent valid records"
+      );
+      assertEquals(1L, driver.metrics().get("processingErrors"));
+      assertEquals(1, driver.errors().size());
+      assertNotNull(driver.errors().getFirst().exception());
+    }
+  }
+
+  @Test
+  void nullValueRecordReportsError() {
+    final var captured = new CapturingSink<byte[]>();
+    try (final var driver = TestStream.builder(MessageFormat.bytes()).toCustom(captured).build()) {
+      driver.sendRaw((byte[]) null);
+      driver.flush();
+
+      assertEquals(0, captured.count());
+      assertEquals(1L, driver.metrics().get("processingErrors"));
+      assertEquals(1, driver.errors().size());
+    }
+  }
+
+  @Test
+  void customErrorHandlerRunsInAdditionToErrorRecording() {
+    final var observed = new CopyOnWriteArrayList<String>();
+    final var captured = new CapturingSink<byte[]>();
+    try (
+      final var driver = TestStream.builder(MessageFormat.bytes())
+        .pipe(b -> {
+          throw new IllegalStateException("always fails");
+        })
+        .withErrorHandler(error -> observed.add(error.exception().getMessage()))
+        .toCustom(captured)
+        .build()
+    ) {
+      driver.send("v".getBytes(StandardCharsets.UTF_8)).flush();
+
+      assertEquals(List.of("always fails"), observed, "the user handler must observe the failure");
+      assertEquals(1, driver.errors().size(), "the built-in recording must still happen");
+    }
+  }
+
+  @Test
+  void throwingUserErrorHandlerDoesNotBreakErrorRecording() {
+    final var captured = new CapturingSink<byte[]>();
+    try (
+      final var driver = TestStream.builder(MessageFormat.bytes())
+        .pipe(b -> {
+          throw new IllegalStateException("fails");
+        })
+        .withErrorHandler(error -> {
+          throw new RuntimeException("handler misbehaves");
+        })
+        .toCustom(captured)
+        .build()
+    ) {
+      driver.send("v1".getBytes(StandardCharsets.UTF_8));
+      driver.send("v2".getBytes(StandardCharsets.UTF_8));
+      driver.flush();
+
+      assertEquals(2, driver.errors().size(), "recording happens before the user handler, so both errors land");
+      assertEquals(2L, driver.metrics().get("processingErrors"));
+    }
+  }
+
+  // ────────────────────────────────────────────────────────────────────────────────
+  // Modes beyond SEQUENTIAL — same records, order-insensitive assertions
+  // ────────────────────────────────────────────────────────────────────────────────
+
+  @Test
+  void parallelModeDeliversEveryRecord() {
+    final var captured = new CapturingSink<byte[]>();
+    try (
+      final var driver = TestStream.builder(MessageFormat.bytes())
+        .withProcessingMode(ProcessingMode.PARALLEL)
+        .toCustom(captured)
+        .build()
+    ) {
+      final var expected = new HashSet<String>();
+      for (int i = 0; i < 40; i++) {
+        expected.add("p" + i);
+        driver.send(("p" + i).getBytes(StandardCharsets.UTF_8));
+      }
+      driver.flush();
+
+      final Set<String> seen = new HashSet<>();
+      for (final var b : captured.captured()) seen.add(new String(b, StandardCharsets.UTF_8));
+      assertEquals(expected, seen, "parallel mode must deliver every record exactly once");
+    }
+  }
+
+  @Test
+  void keyOrderedModeDeliversEveryRecord() {
+    final var captured = new CapturingSink<byte[]>();
+    try (
+      final var driver = TestStream.builder(MessageFormat.bytes())
+        .withProcessingMode(ProcessingMode.KEY_ORDERED)
+        .toCustom(captured)
+        .build()
+    ) {
+      final var expected = new HashSet<String>();
+      for (int i = 0; i < 20; i++) {
+        expected.add("k" + i);
+        driver.send("key-" + (i % 3), ("k" + i).getBytes(StandardCharsets.UTF_8));
+      }
+      driver.flush();
+
+      final Set<String> seen = new HashSet<>();
+      for (final var b : captured.captured()) seen.add(new String(b, StandardCharsets.UTF_8));
+      assertEquals(expected, seen);
+    }
+  }
+
+  // ────────────────────────────────────────────────────────────────────────────────
+  // Lifecycle + builder validation
+  // ────────────────────────────────────────────────────────────────────────────────
+
+  @Test
+  void flushWithNothingSentReturnsImmediately() {
+    try (final var driver = TestStream.builder(MessageFormat.bytes()).toCustom(new CapturingSink<>()).build()) {
+      driver.flush();
+    }
+  }
+
+  @Test
+  void sinkIsOptionalProcessOnlyStreamsWork() {
+    final var peeked = new CopyOnWriteArrayList<String>();
+    try (
+      final var driver = TestStream.builder(MessageFormat.bytes())
+        .peek(b -> peeked.add(new String(b, StandardCharsets.UTF_8)))
+        .build()
+    ) {
+      driver.send("no-sink".getBytes(StandardCharsets.UTF_8)).flush();
+      assertEquals(List.of("no-sink"), peeked);
+    }
+  }
+
+  @Test
+  void closeIsIdempotentAndRejectsFurtherSends() {
+    final var driver = TestStream.builder(MessageFormat.bytes()).toCustom(new CapturingSink<>()).build();
+    driver.send("v".getBytes(StandardCharsets.UTF_8)).flush();
+    driver.close();
+    driver.close();
+
+    assertThrows(IllegalStateException.class, () -> driver.send("late".getBytes(StandardCharsets.UTF_8)));
+    assertThrows(IllegalStateException.class, driver::flush);
+  }
+
+  @Test
+  void builderRejectsInvalidConfig() {
+    assertThrows(NullPointerException.class, () -> TestStream.builder(null));
+    assertThrows(NullPointerException.class, () -> TestStream.builder(MessageFormat.bytes()).pipe(null));
+    assertThrows(NullPointerException.class, () -> TestStream.builder(MessageFormat.bytes()).filter(null));
+    assertThrows(NullPointerException.class, () -> TestStream.builder(MessageFormat.bytes()).toCustom(null));
+    assertThrows(IllegalArgumentException.class, () -> TestStream.builder(MessageFormat.bytes()).withTopic(" "));
+    assertThrows(IllegalArgumentException.class, () ->
+      TestStream.builder(MessageFormat.bytes()).toBatch(batch -> null, 0)
+    );
+    assertThrows(IllegalArgumentException.class, () ->
+      TestStream.builder(MessageFormat.bytes())
+        .toCustom(new CapturingSink<>())
+        .toBatch(batch -> null, 3)
+        .build()
+    );
+  }
+
+  @Test
+  void customTopicFlowsThroughToProcessingErrors() {
+    try (
+      final var driver = TestStream.builder(MessageFormat.bytes())
+        .withTopic("orders")
+        .pipe(b -> {
+          throw new IllegalStateException("fail");
+        })
+        .build()
+    ) {
+      driver.send("v".getBytes(StandardCharsets.UTF_8)).flush();
+
+      assertEquals("orders", driver.errors().getFirst().record().topic());
+    }
+  }
+
+  @Test
+  void metricsExposeReceivedAndInFlightKeys() {
+    try (final var driver = TestStream.builder(MessageFormat.bytes()).toCustom(new CapturingSink<>()).build()) {
+      driver.send("v".getBytes(StandardCharsets.UTF_8)).flush();
+
+      final var metrics = driver.metrics();
+      assertEquals(1L, metrics.get("messagesReceived"));
+      assertEquals(1L, metrics.get("messagesProcessed"));
+      assertEquals(0L, metrics.get("inFlight"));
+      assertTrue(metrics.containsKey("processingErrors"));
+    }
+  }
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -13,6 +13,7 @@ include("lib:kpipe-format-json")
 include("lib:kpipe-format-avro")
 include("lib:kpipe-format-protobuf")
 include("lib:kpipe-api")
+include("lib:kpipe-test")
 
 include("examples")
 include("examples:bytes")


### PR DESCRIPTION
## What

The top adoption-friction item from the roadmap (P2 `#1`): testing a KPipe pipeline no longer requires Testcontainers/Docker or a hand-rolled MockConsumer harness.

```java
final var captured = new CapturingSink<Map<String, Object>>();
try (final var driver = TestStream.<Map<String, Object>>builder(JsonFormat.INSTANCE)
    .pipe(addTimestamp)
    .filter(active)
    .toCustom(captured)
    .build()) {
  driver.send(record1);
  driver.send(record2);
  driver.flush();
  assertEquals(List.of(...), captured.captured());
}
```

**Drive model (per the roadmap's recorded decision):** a real `KPipeConsumer` over a seeded `MockConsumer` — tests exercise the production dispatcher/offset/sink paths, not a simulation. Default SEQUENTIAL, PARALLEL/KEY_ORDERED overridable.

- **Deterministic `flush()`**: polled → accounted (processed+errors+inFlight) → drain, with post-drain re-read; `AssertionError` with metrics diagnostic on timeout — no sleeps, no flakes.
- **Batch v1**: size-flush + shutdown-flush (age trigger deliberately disabled — virtual-clock is the recorded follow-up).
- **`CapturingSink<T>`** — thread-safe, snapshot `captured()`, no assertion DSL (per the roadmap decision: users bring AssertJ/JUnit).
- Full compile artifact `lib/kpipe-test`, JPMS module `io.github.eschizoid.kpipe.test`, wired into settings/BOM/publishing like siblings.

## Tests

29 new, all Docker-free: the PLAN ergonomics sketch verbatim, ordering, operator chaining, filter semantics, operator-throw/malformed/null error paths, throwing error handler, PARALLEL & KEY_ORDERED delivery, lifecycle/builder validation, batch flush semantics, concurrent captures. Full `:lib:kpipe-consumer:test` suite green on the branch (392/392, exercises #229's PendingOffsetSet).

## Notes
- Additive-only extensions to the sketch surface (`peek`, `withProcessingMode`, `errors()`, etc.) — needed by the mandated error-path tests.
- Pre-existing gap left untouched: `kpipe-tracing-otel`/`kpipe-schema-registry-confluent` missing from the BOM.
- Docs (README module catalog + CLAUDE.md) being added to this branch before merge.