### PR TITLE
docs: PARALLEL sub-ms cells confirmed at full fork depth (post-#228)

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,9 +49,10 @@ That is **~10× Confluent PC at 10ms and ~47× at 100ms**. CPC's numbers sit exa
 workers divided by per-record work-time predicts 10,000 rec/s at 10ms and 1,000 at 100ms; the capture measured 9,639
 and 996. Platform pools saturate; virtual-thread-per-record doesn't. That's a threading-model verdict, not a tuning gap.
 
-The sub-millisecond regime tells the same story with smaller margins: at fork=5, KPipe `KEY_ORDERED` does 93.8k rec/s
-(±0.8%) against Confluent PC `KEY`'s 65.9k (±1%) at 1ms of per-record work — the same per-key-FIFO guarantee at 1.42×
-the throughput, with cleanly separated error bars. Full tables, error bars, and every caveat:
+The sub-millisecond regime tells the same story with smaller margins: at fork=5, KPipe `PARALLEL` does 145.4k rec/s
+(±7%) against Confluent PC `UNORDERED`'s 73.8k (±1%) at 1ms of per-record work (~2×), and KPipe `KEY_ORDERED` does 93.8k
+rec/s (±0.8%) against Confluent PC `KEY`'s 65.9k (±1%) — the same per-key-FIFO guarantee at 1.42× the throughput, with
+cleanly separated error bars. Full tables, error bars, and every caveat:
 [`benchmarks/results/2026-07-09.md`](benchmarks/results/2026-07-09.md), captured per the
 [methodology](benchmarks/METHODOLOGY.md).
 
@@ -67,8 +68,9 @@ blocking work. The attribution profile is in
 Not free, and not hidden.
 
 Caveats that carry: everything runs on a shared GitHub-hosted CI runner, so read the orderings and the error bars, not
-the absolute magnitudes. KPipe `PARALLEL`'s sub-millisecond cells are single-sample point estimates (a harness bug,
-documented in the snapshot); its 10–100ms numbers in the table above are fully sampled.
+the absolute magnitudes. (An earlier capture reported KPipe `PARALLEL`'s sub-millisecond cells as single-sample point
+estimates; that turned out to be a real pause/resume liveness bug the benchmark exposed — fixed in #228 and re-captured
+at full fork depth, 25/25 samples. Details in the snapshot's addendum.)
 
 **2. The at-least-once claim is verified, not asserted.** Every CI run gates on 16
 [jcstress](https://openjdk.org/projects/code-tools/jcstress/) concurrency-stress tests across 4 modules, plus jqwik

--- a/benchmarks/results/2026-07-09.md
+++ b/benchmarks/results/2026-07-09.md
@@ -1,9 +1,9 @@
 # Benchmark snapshot — 2026-07-09
 
 Three CI captures in one day, replacing the provisional 2026-06-20 numbers: the low regime re-measured at **fork=5**
-(fixing the fork=2 error bars), the **first CI/shared-runner high-regime capture** (10–100ms — the I/O-hop range where most real
-consumers live), and the first latency-mode run. Same caveat as always: GitHub-hosted shared 4-vCPU runner — the
-orderings and the error bars are the signal; treat absolute magnitudes as indicative.
+(fixing the fork=2 error bars), the **first CI/shared-runner high-regime capture** (10–100ms — the I/O-hop range where
+most real consumers live), and the first latency-mode run. Same caveat as always: GitHub-hosted shared 4-vCPU runner —
+the orderings and the error bars are the signal; treat absolute magnitudes as indicative.
 
 ## Environment
 
@@ -75,9 +75,27 @@ a per-record tail-latency distribution. Values at wM=1ms: KPipe/CPC/raw ≈ 0.00
 directionally consistent with the throughput data and nothing more. A true p99-per-record latency bench (timestamp at
 produce, measure at sink) is future work; do not quote these numbers as "p99 latency".
 
+## Addendum (2026-07-11) — the PARALLEL single-sample "harness bug" was a real consumer bug, now fixed
+
+Root-causing footnote 1 found a production lost-wakeup deadlock: the backpressure PAUSE decision published its pause bit
+after logging/hooks, and a fast in-flight drain inside that window left the consumer parked forever — which is what
+killed 24 of 25 JMH forks in the low-regime PARALLEL cells. Fixed in PR #228 (post-publish watermark re-check,
+Dekker-style handshake, jcstress-proven). The confirmation capture on the fix
+([run 29107846506](https://github.com/eschizoid/kpipe/actions/runs/29107846506), PARALLEL arm only, fork=5, same runner
+class and parameters as the low capture above) yields full samples with real error bars:
+
+| Runtime (post-#228) |     wM=100µs |       wM=1ms | samples |
+| ------------------- | -----------: | -----------: | ------: |
+| KPipe PARALLEL      | 155,696 ± 8% | 145,418 ± 7% |   25/25 |
+
+These supersede the footnote-1 point estimates (161,640 / 144,763): consistent central values, now with spread. PARALLEL
+at 1ms is ~2× CPC UNORDERED (73,847 ± 1%), and the expected ordering (PARALLEL above KEY_ORDERED's 93.8k) is restored
+once the deadlock stops selectively killing the fast arm's forks.
+
 ## Conclusions
 
 1. The front-page claims survive fork=5: every competitive ordering from 2026-06-20 reproduced with tight error bars.
 2. The 10–100ms regime is KPipe's strongest story — order-of-magnitude to 47× over CPC, with CPC's ceiling being
    architectural (measured at theory) rather than incidental.
-3. Two follow-ups filed: the PARALLEL × low-regime single-sample harness bug, and a real per-record latency benchmark.
+3. Two follow-ups filed: the PARALLEL × low-regime single-sample harness bug (RESOLVED — see the addendum), and a real
+   per-record latency benchmark (shipped in #230).


### PR DESCRIPTION
Docs-only. Closes the last data blemish: the PARALLEL low-regime 'single-sample harness bug' was the #228 lost-wakeup deadlock killing forks. The confirmation capture on the fix (run 29107846506, fork=5, same runner/params as the 2026-07-09 low capture) gives 25/25 samples: **155.7k ±8% @100µs, 145.4k ±7% @1ms** — ~2× CPC UNORDERED at 1ms, expected PARALLEL > KEY_ORDERED ordering restored. README: sub-ms paragraph now leads with the PARALLEL number; stale single-sample caveat replaced with the found-and-fixed story (which is itself the verification brand). Snapshot: dated addendum with the superseding table + provenance.