### PR TITLE
fix(consumer): paused consumer keeps polling — lag-pause park-forever + max.poll.interval eviction

### DIFF
--- a/lib/kpipe-consumer/src/main/java/io/github/eschizoid/kpipe/consumer/ConsumerHealthController.java
+++ b/lib/kpipe-consumer/src/main/java/io/github/eschizoid/kpipe/consumer/ConsumerHealthController.java
@@ -193,8 +193,9 @@ final class ConsumerHealthController {
         // Every record that completed inside that window skipped the unpark — and when the
         // count drains all the way down in there (routine for PARALLEL mode with fast records:
         // 10k in-flight at ~100µs each finish in a few milliseconds, faster than the log + hook
-        // calls above), no completion ever arrives to wake the consumer, which then parks
-        // forever with nothing in flight. Re-checking with the bit visible closes the window:
+        // calls above), no completion ever arrives to nudge the consumer, which then sits paused
+        // with nothing in flight until its next poll-cadence re-check (and, before the paused
+        // loop kept polling, parked forever). Re-checking with the bit visible closes the window:
         // either the metric is already at/below the low watermark (release right now), or at
         // least one record was still in flight at this read and its completion is guaranteed to
         // see the bit and unpark. Both reads and the bit are volatile, so the total order of

--- a/lib/kpipe-consumer/src/main/java/io/github/eschizoid/kpipe/consumer/KPipeConsumer.java
+++ b/lib/kpipe-consumer/src/main/java/io/github/eschizoid/kpipe/consumer/KPipeConsumer.java
@@ -1209,12 +1209,29 @@ public class KPipeConsumer<K> implements AutoCloseable {
             health.tickBackpressure(kafkaConsumer);
             if (!isRunning()) break;
             if (isPaused()) {
+              // Flush the Pause command queued by the transition above so
+              // `kafkaConsumer.pause()` executes before the poll below, then defensively
+              // re-pause the full assignment: pause state is per-partition and does not
+              // survive a revoke/assign cycle, so a rebalance inside an earlier poll can
+              // hand this consumer new, un-paused partitions.
               processCommands();
-              LockSupport.park();
-              if (Thread.interrupted()) break;
-              continue;
+              if (!isRunning() || Thread.interrupted()) break;
+              kafkaConsumer.pause(kafkaConsumer.assignment());
             }
 
+            // Paused or not, keep calling poll(). With every partition paused the fetch
+            // returns nothing, but the call keeps the group membership alive — a consumer
+            // that stops polling is evicted after max.poll.interval.ms, triggering a
+            // silent rebalance — and bounds each iteration to `pollTimeout`, so the
+            // `tickBackpressure` above re-evaluates the pause condition on a fixed
+            // cadence. An indefinite LockSupport.park() here wedged the lag strategy
+            // forever: a parked consumer's positions are frozen while the broker's end
+            // offsets only grow, so lag can only drop through external events (partition
+            // reassignment, retention truncation, manual offset reset) — none of which
+            // produce an unpark. Records can still arrive while paused when a mid-poll
+            // rebalance assigns new partitions after the re-pause above ran; the fetch
+            // has already advanced the positions past them, so dropping them would lose
+            // data — process them normally.
             final var records = pollRecords();
             if (records != null && !records.isEmpty()) processRecords(records);
           }
@@ -1247,6 +1264,10 @@ public class KPipeConsumer<K> implements AutoCloseable {
 
   /// Pauses consumption from the topic. Any in-flight messages will continue processing, but no new
   /// messages will be consumed until {@link #resume()} is called.
+  ///
+  /// While paused the consumer thread keeps calling `poll()` with every partition paused: the
+  /// polls fetch nothing but retain the group membership, so a long pause does not trigger a
+  /// `max.poll.interval.ms` eviction and the resulting rebalance.
   ///
   /// This method is idempotent - calling it multiple times has no additional effect.
   public void pause() {
@@ -1659,9 +1680,13 @@ public class KPipeConsumer<K> implements AutoCloseable {
 
   /// Runs after every record finishes (on whichever thread executed it). Unparks the consumer
   /// thread when backpressure is currently holding it — a record completion may have dropped
-  /// the in-flight count below the low watermark, so the consumer thread needs to re-evaluate
-  /// on its next iteration. Previously inlined into `processRecord`'s finally block; moved
-  /// here so the dispatcher owns the post-record callback uniformly across modes.
+  /// the in-flight count below the low watermark. This is a best-effort latency nudge, not a
+  /// liveness requirement: the paused loop no longer parks indefinitely (it keeps polling paused
+  /// partitions on a `pollTimeout` cadence and re-evaluates backpressure at the top of every
+  /// iteration), so the unpark only shortens the bounded `parkNanos` waits on the teardown drain
+  /// path and is a no-op while the consumer thread is blocked inside `poll()`. Previously inlined
+  /// into `processRecord`'s finally block; moved here so the dispatcher owns the post-record
+  /// callback uniformly across modes.
   private void afterRecordComplete() {
     if (health.isHeldBy(ConsumerHealthController.Source.BACKPRESSURE)) {
       final var thread = consumerThread.get();

--- a/lib/kpipe-consumer/src/test/java/io/github/eschizoid/kpipe/consumer/PausedPollLivenessTest.java
+++ b/lib/kpipe-consumer/src/test/java/io/github/eschizoid/kpipe/consumer/PausedPollLivenessTest.java
@@ -1,0 +1,223 @@
+package io.github.eschizoid.kpipe.consumer;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.time.Duration;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+import java.util.concurrent.atomic.AtomicLong;
+import org.apache.kafka.clients.consumer.ConsumerRebalanceListener;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.clients.consumer.ConsumerRecords;
+import org.apache.kafka.clients.consumer.MockConsumer;
+import org.apache.kafka.common.TopicPartition;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/// Liveness tests for the paused consumer loop.
+///
+/// Regression coverage for the lag-strategy wedge: in SEQUENTIAL mode the backpressure strategy
+/// is lag-based, and a backpressure pause used to `LockSupport.park()` the consumer thread
+/// indefinitely. Nothing ever unparked it — SEQUENTIAL has no asynchronous record completions
+/// (processing runs inline on the parked thread itself), and a paused consumer's positions are
+/// frozen while the broker's end offsets only grow, so the lag metric could never fall to the low
+/// watermark on its own. One WARNING was logged and the consumer sat parked forever; past
+/// `max.poll.interval.ms` the client also left the group, triggering a silent rebalance.
+///
+/// The fix keeps the paused consumer polling its (paused) partitions on the poll-timeout cadence:
+/// each loop iteration re-evaluates backpressure, so an external lag drop (partition
+/// reassignment, retention truncation, manual offset reset) resumes the consumer, and the
+/// continued polling keeps the group membership alive. These tests drive the real consumer loop
+/// through [MockConsumer]; every await is bounded so a regression fails fast instead of hanging.
+class PausedPollLivenessTest {
+
+  private static final String TOPIC = "test-topic";
+  private static final TopicPartition PARTITION = new TopicPartition(TOPIC, 0);
+  private static final Duration AWAIT = Duration.ofSeconds(5);
+
+  private Properties properties;
+
+  @BeforeEach
+  void setUp() {
+    properties = new Properties();
+    properties.put("bootstrap.servers", "localhost:9092");
+    properties.put("group.id", "test-group");
+    properties.put("key.deserializer", "org.apache.kafka.common.serialization.StringDeserializer");
+    properties.put("value.deserializer", "org.apache.kafka.common.serialization.StringDeserializer");
+  }
+
+  /// The wedge itself: a lag-triggered pause must not park the consumer forever. When the lag
+  /// drops externally (here: the test shrinks the broker end offsets, standing in for retention
+  /// truncation or a manual offset reset), the paused loop's periodic re-check must observe
+  /// lag ≤ low watermark, resume, and go back to delivering records.
+  @Test
+  void lagPauseResumesWhenLagDropsExternally() throws InterruptedException {
+    final var mockConsumer = pausableMockConsumer();
+    mockConsumer.updateEndOffsets(Map.of(PARTITION, 100L)); // lag = 100 - 0 >= high(5) -> PAUSE
+
+    final var consumer = KPipeConsumer.<String>builder()
+      .withProperties(properties)
+      .withTopic(TOPIC)
+      .withPipeline(TestPipelines.identity())
+      .withBackpressure(5, 2)
+      .withProcessingMode(ProcessingMode.SEQUENTIAL)
+      .withConsumer(() -> mockConsumer)
+      .build();
+
+    try {
+      consumer.start();
+
+      // The first loop iteration ticks backpressure before the first poll, so the pause is
+      // deterministic — no records have been fetched yet.
+      TestAwaits.pollUntil(() -> !mockConsumer.paused().isEmpty(), AWAIT, "lag backpressure pauses the consumer");
+      assertTrue(consumer.isPaused(), "Consumer state should be PAUSED");
+      assertTrue(consumer.getMetrics().get(KPipeConsumer.METRIC_BACKPRESSURE_PAUSE_COUNT) >= 1);
+
+      // External lag drop: end offsets shrink to the frozen position. Before the fix the
+      // consumer thread was parked here and never re-read the metric — this await timed out.
+      mockConsumer.updateEndOffsets(Map.of(PARTITION, 0L)); // lag = 0 <= low(2) -> RESUME
+
+      TestAwaits.pollUntil(() -> mockConsumer.paused().isEmpty(), AWAIT, "consumer resumes after external lag drop");
+      TestAwaits.pollUntil(() -> !consumer.isPaused(), AWAIT, "consumer state returns to RUNNING");
+
+      // Full liveness: a record produced after the resume must flow end to end.
+      mockConsumer.addRecord(new ConsumerRecord<>(TOPIC, 0, 0L, "k0", "v0".getBytes()));
+      mockConsumer.updateEndOffsets(Map.of(PARTITION, 1L));
+      TestAwaits.pollUntil(
+        () -> consumer.getMetrics().get("messagesProcessed") == 1L,
+        AWAIT,
+        "record produced after resume is processed"
+      );
+      assertEquals(1L, consumer.getMetrics().get("messagesProcessed"));
+    } finally {
+      consumer.close();
+    }
+  }
+
+  /// A lag-paused consumer must keep calling `poll()` — that is what keeps the group membership
+  /// alive (a consumer that stops polling is evicted after `max.poll.interval.ms`). The polls
+  /// must also fetch nothing: the records seeded below sit behind paused partitions the whole
+  /// time. Before the fix the thread parked after the pause and the poll count froze.
+  @Test
+  void lagPausedConsumerKeepsPollingWithoutFetching() throws InterruptedException {
+    final var polls = new AtomicLong();
+    final var mockConsumer = new MockConsumer<String, byte[]>("earliest") {
+      @Override
+      public synchronized void subscribe(final Collection<String> topics) {}
+
+      @Override
+      public synchronized void subscribe(final Collection<String> topics, final ConsumerRebalanceListener callback) {}
+
+      @Override
+      public synchronized ConsumerRecords<String, byte[]> poll(final Duration timeout) {
+        polls.incrementAndGet();
+        return super.poll(timeout);
+      }
+    };
+    mockConsumer.assign(List.of(PARTITION));
+    mockConsumer.updateBeginningOffsets(Map.of(PARTITION, 0L));
+    // Records are present, but the pause decision runs before the first poll, so none of them
+    // may ever be fetched while the pause holds.
+    for (int i = 0; i < 3; i++) {
+      mockConsumer.addRecord(new ConsumerRecord<>(TOPIC, 0, i, "k" + i, ("v" + i).getBytes()));
+    }
+    mockConsumer.updateEndOffsets(Map.of(PARTITION, 100L)); // lag = 100 >= high(5) -> PAUSE
+
+    final var consumer = KPipeConsumer.<String>builder()
+      .withProperties(properties)
+      .withTopic(TOPIC)
+      .withPipeline(TestPipelines.identity())
+      .withBackpressure(5, 2)
+      .withProcessingMode(ProcessingMode.SEQUENTIAL)
+      .withConsumer(() -> mockConsumer)
+      .build();
+
+    try {
+      consumer.start();
+      TestAwaits.pollUntil(() -> !mockConsumer.paused().isEmpty(), AWAIT, "lag backpressure pauses the consumer");
+
+      final var pollsAtPause = polls.get();
+      TestAwaits.pollUntil(
+        () -> polls.get() >= pollsAtPause + 5,
+        AWAIT,
+        "paused consumer keeps polling (group-membership liveness)"
+      );
+
+      // The pause contract still holds: all that polling fetched nothing.
+      assertTrue(consumer.isPaused(), "Consumer should still be paused while lag stays high");
+      assertEquals(0L, consumer.getMetrics().get("messagesReceived"), "No records may be fetched while paused");
+    } finally {
+      consumer.close();
+    }
+  }
+
+  /// The same eviction hazard existed for manual pauses (and circuit-breaker opens, which share
+  /// the pause path): a long `pause()` parked the thread until `resume()`, so past
+  /// `max.poll.interval.ms` the client silently left the group. A manually paused consumer must
+  /// keep polling its paused partitions too.
+  @Test
+  void manuallyPausedConsumerKeepsPolling() throws InterruptedException {
+    final var polls = new AtomicLong();
+    final var mockConsumer = new MockConsumer<String, byte[]>("earliest") {
+      @Override
+      public synchronized void subscribe(final Collection<String> topics) {}
+
+      @Override
+      public synchronized void subscribe(final Collection<String> topics, final ConsumerRebalanceListener callback) {}
+
+      @Override
+      public synchronized ConsumerRecords<String, byte[]> poll(final Duration timeout) {
+        polls.incrementAndGet();
+        return super.poll(timeout);
+      }
+    };
+    mockConsumer.assign(List.of(PARTITION));
+    mockConsumer.updateBeginningOffsets(Map.of(PARTITION, 0L));
+    mockConsumer.updateEndOffsets(Map.of(PARTITION, 0L));
+
+    final var consumer = KPipeConsumer.<String>builder()
+      .withProperties(properties)
+      .withTopic(TOPIC)
+      .withPipeline(TestPipelines.identity())
+      .withConsumer(() -> mockConsumer)
+      .build();
+
+    try {
+      consumer.start();
+      TestAwaits.pollUntil(() -> polls.get() > 0, AWAIT, "consumer loop starts polling");
+
+      consumer.pause();
+      TestAwaits.pollUntil(() -> !mockConsumer.paused().isEmpty(), AWAIT, "manual pause reaches the Kafka consumer");
+
+      final var pollsAtPause = polls.get();
+      TestAwaits.pollUntil(
+        () -> polls.get() >= pollsAtPause + 5,
+        AWAIT,
+        "manually paused consumer keeps polling (group-membership liveness)"
+      );
+      assertTrue(consumer.isPaused(), "Consumer should still be paused until resume()");
+
+      consumer.resume();
+      TestAwaits.pollUntil(() -> mockConsumer.paused().isEmpty(), AWAIT, "resume() unpauses the partitions");
+    } finally {
+      consumer.close();
+    }
+  }
+
+  /// MockConsumer with subscribe() stubbed to a no-op so the manual `assign` survives — the
+  /// same pattern as the other backpressure tests in this package.
+  private MockConsumer<String, byte[]> pausableMockConsumer() {
+    final var mc = new MockConsumer<String, byte[]>("earliest") {
+      @Override
+      public synchronized void subscribe(final Collection<String> topics) {}
+
+      @Override
+      public synchronized void subscribe(final Collection<String> topics, final ConsumerRebalanceListener callback) {}
+    };
+    mc.assign(List.of(PARTITION));
+    mc.updateBeginningOffsets(Map.of(PARTITION, 0L));
+    return mc;
+  }
+}


### PR DESCRIPTION
## What

Fixes the CRITICAL pre-existing liveness bug found by #228's adversarial review (finding A1): with the lag strategy (auto-derived in SEQUENTIAL mode), a backpressure pause parked the consumer thread with **no reachable wake source** — SEQUENTIAL has no async completions, and lag is monotonically non-decreasing while parked (frozen position vs growing endOffsets). One WARNING, then a permanently wedged consumer; and since a parked consumer stops calling `poll()`, it silently left the group after `max.poll.interval.ms` — a hazard shared by long manual and circuit-breaker pauses.

## Design: paused = keep polling (not bounded park)

The paused branch now flushes the command queue, defensively re-issues `pause(assignment())` (per-partition pause doesn't survive revoke/assign; also closes a state-flipped-before-command race), then falls through to the normal poll. Paused partitions fetch nothing, but:
- **group membership stays alive** — Kafka's documented pause+poll contract, fixing the eviction hazard for ALL pause sources (a bounded-park design would not)
- each iteration is bounded by `pollTimeout`, so `tickBackpressure` re-evaluates lag on a fixed cadence and resumes on external lag drops (reassignment, retention truncation, offset reset)
- records slipping through a mid-poll rebalance are processed, never dropped (positions already advanced — dropping would lose data on commit)
- single-writer discipline preserved; no public API changes

Documented tradeoff: resume latency is now ≤ `pollTimeout` (100ms default) instead of an instant unpark.

## Verification
- New `PausedPollLivenessTest` (3 tests, bounded awaits, MockConsumer): **all 3 verified failing against the old loop**, passing with the fix
- `:lib:kpipe-consumer:test`: 397/0/0 · jcstress: 16/16
- Residual (documented): sustained-high-lag pause still doesn't self-resume — inherent to lag-watermark semantics; the consumer is now live, in-group, resumable, and observable instead of wedged