### PR TITLE
test(consumer): de-flake CB batch test — PARALLEL exposed a real pause-delivery race

### DIFF
--- a/lib/kpipe-consumer/src/test/java/io/github/eschizoid/kpipe/consumer/KPipeCircuitBreakerIntegrationTest.java
+++ b/lib/kpipe-consumer/src/test/java/io/github/eschizoid/kpipe/consumer/KPipeCircuitBreakerIntegrationTest.java
@@ -87,11 +87,23 @@ class KPipeCircuitBreakerIntegrationTest {
     // per-record path — otherwise a failing batch sink could never trip the breaker. ofSize(1)
     // flushes each record inline, so every record drives one failure outcome into the window;
     // windowSize=5 + threshold=0.5 trips once the window fills with all-failures.
+    //
+    // Sequential mode, same as every other test in this class: the trip (and its pause) then
+    // happens inline on the consumer thread, so the Pause command is queued before the poll loop
+    // re-checks isPaused(). Under the default PARALLEL mode the trip fires on a batch-flush
+    // worker thread, and internalPause flips the state to PAUSED before offering the Pause
+    // command — the consumer thread can observe PAUSED, drain a still-empty command queue, and
+    // park without ever calling kafkaConsumer.pause(). No unpark source exists for a
+    // circuit-breaker pause until the 30s half-open probe, so mc.paused() stays empty past any
+    // bounded await (the CI flake). The mode is orthogonal to what this test proves (batch
+    // outcomes feed the breaker); the cross-thread pause-delivery race is a product bug with its
+    // own fix and liveness test (paused-consumer-keeps-polling rework).
     final var mc = buildMockConsumer(12);
     final var controller = new CircuitBreakerController(0.5, 5, Duration.ofSeconds(30));
 
     final var consumer = KPipeConsumer.<String>builder()
       .withProperties(properties)
+      .withProcessingMode(ProcessingMode.SEQUENTIAL)
       .withBatchPipeline(
         TOPIC,
         TestPipelines.sideEffect(v -> v),


### PR DESCRIPTION
## The flake was a product bug

`sustainedBatchFailuresTripBreaker` (5 CI failures in 2 days, blocking unrelated PRs) was the ONLY test in the class running in default PARALLEL mode — so the breaker tripped on a batch-flush worker thread, exposing a real cross-thread race: `internalPause()` CAS-flips state to PAUSED **before** offering the Pause command. The consumer thread can observe `isPaused()`, drain a still-empty command queue, and `park()` without ever executing `kafkaConsumer.pause()` — and a CB pause has no unpark source until the half-open probe (30s here), so the 5s await expires.

**Evidence:** 400-repetition harness → **363/400** reproductions pre-fix (thread dump shows the consumer VT parked at the `isPaused()` branch with the Pause command undelivered); **0/400** in SEQUENTIAL; 4 consecutive `--rerun-tasks` suite runs green.

## Fix here vs fix of the bug

This PR: one line — `.withProcessingMode(ProcessingMode.SEQUENTIAL)`, matching every sibling test. Mode-orthogonal claim ("batch failures feed the breaker window") still fully asserted; the 400-rep harness also drops from 12m19s to 15s.

The **underlying product bug** (state-flipped-before-command-queued) is fixed by open **PR #233**, which retires the park path and defensively re-issues `pause(assignment())` — it names this exact race. This test fix is complementary, touches nothing #233 touches, and unblocks CI immediately.