### PR TITLE
docs: fix OffsetManager SPI method list (getOffsetsToCommit doesn't exist)

### DIFF
--- a/docs/ESCAPE-HATCHES.md
+++ b/docs/ESCAPE-HATCHES.md
@@ -76,8 +76,10 @@ final var consumer = KPipeConsumer.builder()
   .build();
 ```
 
-`OffsetManager` is a thin SPI — implement `markOffsetProcessed`, `getOffsetsToCommit`, and `close`. The consumer threads
-call into it concurrently; implementations must be thread-safe.
+`OffsetManager` is a thin SPI — the load-bearing methods are `trackOffset` (a record entered the pipeline),
+`markOffsetProcessed` (it finished), `notifyCommitComplete` (a queued commit landed), and `close`, plus the `start` /
+`stop` / `isRunning` / `getState` / `getStatistics` lifecycle-and-introspection surface and the default
+`createRebalanceListener()`. The consumer threads call into it concurrently; implementations must be thread-safe.
 
 ### A custom rebalance listener
 


### PR DESCRIPTION
The custom-`OffsetManager` section of `docs/ESCAPE-HATCHES.md` named a non-existent `getOffsetsToCommit` method. Both the type-design and architecture review lenses on the 1.17.0 PR (#235) flagged it as pre-existing doc drift, out of scope for that delete-and-migrate PR — this is the tiny hygiene follow-up.

**Actual `OffsetManager` SPI surface** (verified against `lib/kpipe-consumer/.../OffsetManager.java`): `start` / `stop` / `trackOffset` / `markOffsetProcessed` / `notifyCommitComplete` / `isRunning` / `getState` / `getStatistics` / `createRebalanceListener` (default) / `close`. No `getOffsetsToCommit`.

Docs-only, no code change. Spotless-clean.