### PR TITLE
chore: remove stray .idea profile + clear test/bench IDE warnings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -245,3 +245,4 @@ gradle-app.setting
 
 # jqwik property-test failure database
 .jqwik-database
+.idea/inspectionProfiles/

--- a/.idea/inspectionProfiles/Project_Default.xml
+++ b/.idea/inspectionProfiles/Project_Default.xml
@@ -1,7 +1,0 @@
-<component name="InspectionProjectProfileManager">
-  <profile version="1.0">
-    <option name="myName" value="Project Default" />
-    <inspection_tool class="JavaCollectionWithNullableTypeArgument" enabled="true" level="WARNING" enabled_by_default="true" />
-    <inspection_tool class="UsePropertyAccessSyntax" enabled="true" level="WEAK WARNING" enabled_by_default="true" />
-  </profile>
-</component>

--- a/benchmarks/src/jmh/java/io/github/eschizoid/kpipe/benchmarks/OffsetManagerBoxingBenchmark.java
+++ b/benchmarks/src/jmh/java/io/github/eschizoid/kpipe/benchmarks/OffsetManagerBoxingBenchmark.java
@@ -74,7 +74,6 @@ import org.openjdk.jmh.annotations.Warmup;
 public class OffsetManagerBoxingBenchmark {
 
   private static final String TOPIC = "kpipe-offsetmgr-bench";
-  private static final int PARTITION_COUNT = 8;
 
   /// Records driven through the manager per `@Benchmark` invocation. Sized to amortize the
   /// JMH per-invocation overhead while keeping the bench cell short enough that JIT/GC noise

--- a/lib/kpipe-api/src/test/java/io/github/eschizoid/kpipe/StreamParallelBatchIntegrationTest.java
+++ b/lib/kpipe-api/src/test/java/io/github/eschizoid/kpipe/StreamParallelBatchIntegrationTest.java
@@ -14,7 +14,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 import java.util.UUID;
-import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.TimeUnit;
 import org.apache.kafka.clients.admin.Admin;
 import org.apache.kafka.clients.admin.AdminClientConfig;
@@ -54,13 +53,9 @@ class StreamParallelBatchIntegrationTest {
     final var topic = "kpipe-parallel-batch-" + UUID.randomUUID().toString().substring(0, 8);
     createTopic(topic, PARTITIONS);
 
-    final var batches = new CopyOnWriteArrayList<List<Map<String, Object>>>();
     final var totalCaptured = Collections.synchronizedList(new ArrayList<Map<String, Object>>());
 
-    final BatchSink<Map<String, Object>> batchSink = BatchSink.ofVoid(batch -> {
-      batches.add(List.copyOf(batch));
-      totalCaptured.addAll(batch);
-    });
+    final BatchSink<Map<String, Object>> batchSink = BatchSink.ofVoid(totalCaptured::addAll);
 
     final var consumerProps = consumerProps("kpipe-parallel-batch-group-" + UUID.randomUUID());
     // maxSize=20 — 200 records will cause ~10 size-triggered flushes plus a final age/shutdown

--- a/lib/kpipe-consumer/src/test/java/io/github/eschizoid/kpipe/consumer/BatchPipelineWrapperCoverageContractTest.java
+++ b/lib/kpipe-consumer/src/test/java/io/github/eschizoid/kpipe/consumer/BatchPipelineWrapperCoverageContractTest.java
@@ -373,7 +373,7 @@ class BatchPipelineWrapperCoverageContractTest {
   ///
   /// 1. Every buffered record is flushed and reaches the sink.
   /// 2. Every record is then marked processed via
-  // [BatchPipelineWrapper.BatchCallbacks#markProcessed].
+  /// [BatchPipelineWrapper.BatchCallbacks#markProcessed].
   /// 3. All three markProcessed events are observed BEFORE a subsequent simulated
   ///    `OffsetManager.close()` call — pinning the ordering invariant that batch buffers
   ///    drain into the offset manager while it's still alive.

--- a/lib/kpipe-consumer/src/test/java/io/github/eschizoid/kpipe/consumer/CircuitBreakerTransitionTest.java
+++ b/lib/kpipe-consumer/src/test/java/io/github/eschizoid/kpipe/consumer/CircuitBreakerTransitionTest.java
@@ -20,29 +20,29 @@ import org.junit.jupiter.api.Test;
 
 /// Deterministic state-machine transition tests for the circuit breaker, driven directly through
 /// [ConsumerHealthController] with a recording [ConsumerHealthController.Hook] and a
-// hand-controlled
+/// hand-controlled
 /// scheduler. No Kafka, no `MockConsumer`, no timing-based `awaitCondition` — every transition is
 /// driven by an explicit `recordOutcome(...)` call or by firing the captured probe task by hand, so
 /// these assertions are race-free.
 ///
 /// `CircuitBreakerControllerTest` pins the pure `shouldTrip` predicate;
-// `KPipeCircuitBreakerIntegrationTest`
+/// `KPipeCircuitBreakerIntegrationTest`
 /// drives the happy-path CLOSED → OPEN → HALF_OPEN → CLOSED cycle end-to-end through a live
-// consumer.
+/// consumer.
 /// This file fills the edges neither pins deterministically:
 ///
 ///   * HALF_OPEN → OPEN on a failed probe (window restarts, a fresh probe is scheduled).
 ///   * HALF_OPEN → CLOSED on a successful probe (the window is genuinely reset, not merely
-// re-read).
+/// re-read).
 ///   * the trip-rate boundary at the state-machine level (exactly at vs just below threshold).
 ///   * window-not-full: no trip before `windowSize` samples regardless of failure rate.
 ///   * the one-shot OPEN → HALF_OPEN probe is a single scheduled task, fired exactly once.
 class CircuitBreakerTransitionTest {
 
   /// Records every Hook callback so a test can assert on the exact transition sequence. The
-  // CB-relevant
+  /// CB-relevant
   /// counters are the ones the state machine drives; pause/resume bookkeeping is recorded too
-  // because a
+  /// because a
   /// trip must pause and a successful probe must resume.
   private static final class RecordingHook implements ConsumerHealthController.Hook {
 
@@ -85,9 +85,9 @@ class CircuitBreakerTransitionTest {
   }
 
   /// A scheduler that does NOT run anything on its own. It captures each submitted task plus the
-  // delay
+  /// delay
   /// so a test can assert how many probe timers were armed and fire them by hand,
-  // deterministically.
+  /// deterministically.
   private static final class CapturingScheduler implements ScheduledExecutorService {
 
     final List<Runnable> scheduled = new ArrayList<>();
@@ -230,7 +230,7 @@ class CircuitBreakerTransitionTest {
   }
 
   /// Builds a controller wired to the supplied hook + scheduler. windowSize=4, threshold=0.5 keeps
-  // the
+  /// the
   /// arithmetic obvious: a full window of 4 needs 2 failures to hit exactly 50%.
   private static ConsumerHealthController newController(final RecordingHook hook, final CapturingScheduler scheduler) {
     final var cb = new CircuitBreakerController(0.5, 4, Duration.ofMillis(300));

--- a/lib/kpipe-consumer/src/test/java/io/github/eschizoid/kpipe/consumer/DlqSendFailureTest.java
+++ b/lib/kpipe-consumer/src/test/java/io/github/eschizoid/kpipe/consumer/DlqSendFailureTest.java
@@ -256,21 +256,6 @@ class DlqSendFailureTest {
     }
 
     @Override
-    public ConsumerRebalanceListener createRebalanceListener() {
-      return new ConsumerRebalanceListener() {
-        @Override
-        public void onPartitionsRevoked(final Collection<TopicPartition> partitions) {
-          // no-op
-        }
-
-        @Override
-        public void onPartitionsAssigned(final Collection<TopicPartition> partitions) {
-          // no-op
-        }
-      };
-    }
-
-    @Override
     public OffsetState getState() {
       return OffsetState.RUNNING;
     }

--- a/lib/kpipe-consumer/src/test/java/io/github/eschizoid/kpipe/consumer/KPipeConsumerTest.java
+++ b/lib/kpipe-consumer/src/test/java/io/github/eschizoid/kpipe/consumer/KPipeConsumerTest.java
@@ -691,13 +691,30 @@ class KPipeConsumerTest {
 
   @Test
   void processCommandsShouldHandleClose() {
-    // Arrange
+    // Arrange — wire the test's queue into the consumer so processCommands() actually drains it
+    // (the old version offered Close to a throwaway queue the consumer never read, so it only
+    // proved processCommands() tolerates an empty queue). pause() puts the consumer in a running
+    // state (PAUSED counts as running) that a Close can transition out of; clearing the Pause
+    // command pause() enqueues leaves only the Close to exercise — so processCommands() never
+    // calls kafkaConsumer.pause() and no live broker is needed.
     final var commandQueue = new ConcurrentLinkedQueue<ConsumerCommand>();
-    final var consumer = createConsumerWithMockProcessor();
+    final var consumer = KPipeConsumer.builder()
+      .withProperties(properties)
+      .withTopic(TOPIC)
+      .withPipeline(TestPipelines.sideEffect(mockProcessor::apply))
+      .withCommandQueue(commandQueue)
+      .build();
+    consumer.pause();
+    commandQueue.clear();
+    assertTrue(consumer.isRunning(), "precondition: consumer is running (paused) before the Close");
     commandQueue.offer(new ConsumerCommand.Close());
 
-    // Act & Assert
+    // Act
     assertDoesNotThrow(consumer::processCommands);
+
+    // Assert — the Close command drove the consumer out of the running state into CLOSING.
+    assertFalse(consumer.isRunning(), "processCommands must handle Close by initiating shutdown");
+    assertFalse(consumer.isPaused());
   }
 
   @Test

--- a/lib/kpipe-consumer/src/test/java/io/github/eschizoid/kpipe/consumer/KPipeConsumerTest.java
+++ b/lib/kpipe-consumer/src/test/java/io/github/eschizoid/kpipe/consumer/KPipeConsumerTest.java
@@ -552,7 +552,6 @@ class KPipeConsumerTest {
     final UnaryOperator<byte[]> failingProcessor = _ -> {
       throw new RuntimeException("Always failing");
     };
-    @SuppressWarnings("unchecked")
     final KPipeConsumer.ErrorHandler errorHandler = mock(KPipeConsumer.ErrorHandler.class);
     final var consumer = KPipeConsumer.builder()
       .withProperties(properties)

--- a/lib/kpipe-consumer/src/test/java/io/github/eschizoid/kpipe/consumer/KPipeDlqTest.java
+++ b/lib/kpipe-consumer/src/test/java/io/github/eschizoid/kpipe/consumer/KPipeDlqTest.java
@@ -279,13 +279,6 @@ class KPipeDlqTest {
     };
   }
 
-  private static Properties stringProperties() {
-    return buildProperties(
-      "org.apache.kafka.common.serialization.StringDeserializer",
-      "org.apache.kafka.common.serialization.StringDeserializer"
-    );
-  }
-
   private static Properties byteProperties() {
     return buildProperties(
       "org.apache.kafka.common.serialization.ByteArrayDeserializer",

--- a/lib/kpipe-consumer/src/test/java/io/github/eschizoid/kpipe/consumer/OffsetConcurrencyStressTest.java
+++ b/lib/kpipe-consumer/src/test/java/io/github/eschizoid/kpipe/consumer/OffsetConcurrencyStressTest.java
@@ -62,7 +62,7 @@ class OffsetConcurrencyStressTest {
   /// No commit past a gap under parallel marking: N virtual threads each own a disjoint contiguous
   /// slice of offsets on the SAME partition. Each thread tracks its whole slice, then marks them in
   /// a deterministic but per-thread-shuffled order, so at every instant there are gaps spread
-  // across
+  /// across
   /// the partition.
   ///
   /// The load-bearing assertion is the concurrent probe: a separate thread continuously reads the
@@ -232,7 +232,7 @@ class OffsetConcurrencyStressTest {
   ///
   /// Assertions: no exception escapes any thread; a revoke followed by no further marks leaves a
   /// cleared partition (commit point `-1`); and at no point does the partition report a commit
-  // point
+  /// point
   /// that skips a still-pending offset (revive-after-revoke must still obey lowest-pending).
   @Test
   void i5_revokeDuringProcessingIsCleanAndNeverCorrupts() throws Exception {

--- a/lib/kpipe-schema-registry-confluent/src/test/java/io/github/eschizoid/kpipe/schemaregistry/confluent/CachedSchemaResolverTest.java
+++ b/lib/kpipe-schema-registry-confluent/src/test/java/io/github/eschizoid/kpipe/schemaregistry/confluent/CachedSchemaResolverTest.java
@@ -111,12 +111,12 @@ class CachedSchemaResolverTest {
 
   @Test
   void failedLookupIsNotCachedAndIsRetriedOnNextCall() {
-    /// First call's delegate throws; second call's delegate succeeds.
-    /// If the cache poisoned itself with a sentinel on failure, the second call would either
-    /// throw again (sentinel re-raised) or skip the delegate entirely (sentinel served as a
-    /// silent success). Either way the topic would be pinned into a permanent decode-error
-    /// state. Confluent SR schema IDs are immutable, so the "cache forever" rule only applies
-    /// AFTER a successful lookup — failures must propagate without leaving residue.
+    // First call's delegate throws; second call's delegate succeeds.
+    // If the cache poisoned itself with a sentinel on failure, the second call would either
+    // throw again (sentinel re-raised) or skip the delegate entirely (sentinel served as a
+    // silent success). Either way the topic would be pinned into a permanent decode-error
+    // state. Confluent SR schema IDs are immutable, so the "cache forever" rule only applies
+    // AFTER a successful lookup — failures must propagate without leaving residue.
     final var calls = new AtomicInteger();
     final var shouldFail = new AtomicReference<>(Boolean.TRUE);
     final SchemaResolver flaky = id -> {
@@ -147,10 +147,10 @@ class CachedSchemaResolverTest {
 
   @Test
   void concurrentMissOnSameIdCollapsesToOneDelegateCall() throws InterruptedException {
-    /// Two virtual threads race a miss on the same id; the delegate is slow enough that the
-    /// second thread blocks inside `computeIfAbsent` waiting for the first. `computeIfAbsent`
-    /// must collapse concurrent misses to a single delegate call — anything else would amplify
-    /// HTTP load to the registry under deserializer fan-in.
+    // Two virtual threads race a miss on the same id; the delegate is slow enough that the
+    // second thread blocks inside `computeIfAbsent` waiting for the first. `computeIfAbsent`
+    // must collapse concurrent misses to a single delegate call — anything else would amplify
+    // HTTP load to the registry under deserializer fan-in.
     final var delegateCalls = new AtomicInteger();
     final var inDelegate = new CountDownLatch(1);
     final var releaseDelegate = new CountDownLatch(1);
@@ -177,8 +177,8 @@ class CachedSchemaResolverTest {
         done.countDown();
       }
     });
-    /// Wait for t1 to be inside the delegate, then start t2 — guarantees t2 hits the
-    /// `computeIfAbsent` bucket while t1 still holds it.
+    // Wait for t1 to be inside the delegate, then start t2 — guarantees t2 hits the
+    // `computeIfAbsent` bucket while t1 still holds it.
     assertTrue(inDelegate.await(5, TimeUnit.SECONDS), "first thread should enter delegate");
     final var t2 = Thread.ofVirtual().start(() -> {
       try {
@@ -201,12 +201,12 @@ class CachedSchemaResolverTest {
 
   @Test
   void concurrentFailureOnSameIdDoesNotPoisonCache() throws InterruptedException {
-    /// N virtual threads concurrently race a miss on the same id where the delegate throws.
-    /// After all failures settle the delegate is flipped to success and one more call is made.
-    /// If a regression ever wrote a sentinel into the map BEFORE the delegate exception unwound
-    /// (e.g. a future "negative-cache" optimization), the recovery call would either throw or
-    /// skip the delegate. The success on the recovery call proves the cache stayed clean
-    /// through the failure storm.
+    // N virtual threads concurrently race a miss on the same id where the delegate throws.
+    // After all failures settle the delegate is flipped to success and one more call is made.
+    // If a regression ever wrote a sentinel into the map BEFORE the delegate exception unwound
+    // (e.g. a future "negative-cache" optimization), the recovery call would either throw or
+    // skip the delegate. The success on the recovery call proves the cache stayed clean
+    // through the failure storm.
     final var threads = 16;
     final var delegateCalls = new AtomicInteger();
     final var shouldFail = new AtomicReference<>(Boolean.TRUE);
@@ -250,7 +250,7 @@ class CachedSchemaResolverTest {
 
     assertEquals("{\"type\":\"record\",\"name\":\"S7\",\"fields\":[]}", recovered);
     assertEquals(1, cached.size(), "successful recovery must populate the cache normally");
-    /// One more lookup proves the success is now cached — no further delegate call.
+    // One more lookup proves the success is now cached — no further delegate call.
     final var callsAfterRecovery = delegateCalls.get();
     cached.lookupById(7);
     assertEquals(callsAfterRecovery, delegateCalls.get(), "post-recovery lookups must hit the cache");


### PR DESCRIPTION
Post-#238 follow-up. Three cleanups:

## 1. Remove accidentally-committed `.idea/inspectionProfiles/Project_Default.xml`
A `git add -A` in #238 swept this untracked IDE-local inspection profile into the tree. It was never meant to ship. Removed + added `.idea/inspectionProfiles/` to `.gitignore` so it can't recur.

## 2. Clear genuine IDE warnings in test/bench code
The production `lib/` tree was cleared in #238; this finishes the job on the test/benchmark/example tree (full IntelliJ sweep over all 249 files).

**Dangling-Javadoc (real bug class):**
- Restored contiguity of `///` doc blocks fragmented by stray `//` continuation lines — `CircuitBreakerTransitionTest`, `OffsetConcurrencyStressTest`, `BatchPipelineWrapperCoverageContractTest`.
- Converted in-method `///` comments to `//` — `CachedSchemaResolverTest`.

**Dead code:**
- Unused `PARTITION_COUNT` constant, unused `stringProperties()` helper, redundant `@SuppressWarnings`, a byte-identical `createRebalanceListener()` override, and a write-only `batches` collection (+ orphaned import).

Everything else the sweep flagged is unavoidable test idiom (Mockito `unchecked`, deadline-poll busy-waits, JMH reflection, `@AfterEach`-managed resources) and is left as-is.

## 3. Fix a mis-wired test the sweep surfaced
`processCommandsShouldHandleClose()` offered its `Close` command to a throwaway local queue the consumer never read (the consumer had its own queue), so `processCommands()` ran on an empty queue — it only proved the method tolerates an empty queue, never that it *handles* Close. Rewired via `withCommandQueue`, established a running state with `pause()`, and asserted the Close drives the consumer into `CLOSING`. The `assertTrue(isRunning())` precondition gives it teeth. This also resolves the dead-`commandQueue` warning by making the field genuinely used.

Verified: affected modules compile; all changed non-Docker tests pass locally, including the rewired Close test.