### PR TITLE
test: deterministic crash-restart harness (kpipe-test) + started-consumer DLQ cell

### DIFF
--- a/lib/kpipe-consumer/src/test/java/io/github/eschizoid/kpipe/consumer/DlqSendFailureTest.java
+++ b/lib/kpipe-consumer/src/test/java/io/github/eschizoid/kpipe/consumer/DlqSendFailureTest.java
@@ -264,6 +264,8 @@ class DlqSendFailureTest {
 
       assertEquals(1L, consumer.getMetrics().get("dlqFailed"), "per-record DLQ send failure must increment dlqFailed");
       assertEquals(0L, consumer.getMetrics().get("dlqSent"), "no successful DLQ send occurred");
+      // No race: on the DLQ-fail branch the offset is never marked, so once dlqFailed==1 is
+      // observed the record is permanently unmarked — the assertFalse below cannot flake.
       assertTrue(recorder.tracked.contains(5L), "record should have been tracked before dispatch");
       assertFalse(
         recorder.marked.contains(5L),

--- a/lib/kpipe-consumer/src/test/java/io/github/eschizoid/kpipe/consumer/DlqSendFailureTest.java
+++ b/lib/kpipe-consumer/src/test/java/io/github/eschizoid/kpipe/consumer/DlqSendFailureTest.java
@@ -214,6 +214,64 @@ class DlqSendFailureTest {
     }
   }
 
+  /// The per-record error path through a fully STARTED consumer (not `processRecord` in isolation):
+  /// the pipeline throws, the DLQ send then fails, so `handleProcessingError` must leave the offset
+  /// pending. Sibling to `failedDlqSendDoesNotMarkOffset` (which drives `processRecord` directly)
+  /// and to the batch-path started-consumer test above — this closes the per-record
+  // started-consumer
+  /// cell end to end: poll → dispatch → error → failed DLQ → offset held.
+  @Test
+  @SuppressWarnings("unchecked")
+  void failedDlqSendThroughStartedConsumerLeavesOffsetPending() throws Exception {
+    when(mockProducer.send(any(ProducerRecord.class))).thenThrow(new RuntimeException("dlq broker down"));
+
+    final var recorder = new RecordingOffsetManager();
+    final var mock = new MockConsumer<byte[], byte[]>("earliest") {
+      @Override
+      public synchronized void subscribe(final Collection<String> topics) {}
+
+      @Override
+      public synchronized void subscribe(final Collection<String> topics, final ConsumerRebalanceListener cb) {}
+    };
+    final var tp = new TopicPartition(TOPIC, 0);
+    mock.assign(List.of(tp));
+    mock.updateBeginningOffsets(Map.of(tp, 0L));
+    mock.addRecord(new ConsumerRecord<>(TOPIC, 0, 5L, "key".getBytes(UTF_8), "value".getBytes(StandardCharsets.UTF_8)));
+
+    try (
+      final var consumer = KPipeConsumer.builder()
+        .withProperties(byteProperties())
+        .withConsumer(() -> mock)
+        .withOffsetManager(recorder)
+        .withTopic(TOPIC)
+        .withPipeline(
+          TestPipelines.sideEffect(_ -> {
+            throw new RuntimeException("processor always fails");
+          })
+        )
+        .withRetry(0, Duration.ofMillis(1))
+        .withDeadLetterTopic(DLQ_TOPIC)
+        .withKafkaProducer(mockProducer)
+        .withPollTimeout(Duration.ofMillis(10))
+        .build()
+    ) {
+      consumer.start();
+
+      final var deadline = System.nanoTime() + Duration.ofSeconds(5).toNanos();
+      while (consumer.getMetrics().getOrDefault("dlqFailed", 0L) < 1 && System.nanoTime() < deadline) {
+        Thread.sleep(10);
+      }
+
+      assertEquals(1L, consumer.getMetrics().get("dlqFailed"), "per-record DLQ send failure must increment dlqFailed");
+      assertEquals(0L, consumer.getMetrics().get("dlqSent"), "no successful DLQ send occurred");
+      assertTrue(recorder.tracked.contains(5L), "record should have been tracked before dispatch");
+      assertFalse(
+        recorder.marked.contains(5L),
+        "per-record path: offset must NOT be marked when the DLQ send failed (record stays eligible for reprocessing)"
+      );
+    }
+  }
+
   private static Properties byteProperties() {
     final var props = new Properties();
     props.put("bootstrap.servers", "localhost:9092");

--- a/lib/kpipe-test/src/main/java/io/github/eschizoid/kpipe/test/CrashRestartHarness.java
+++ b/lib/kpipe-test/src/main/java/io/github/eschizoid/kpipe/test/CrashRestartHarness.java
@@ -1,0 +1,344 @@
+package io.github.eschizoid.kpipe.test;
+
+import io.github.eschizoid.kpipe.consumer.KPipeConsumer;
+import io.github.eschizoid.kpipe.consumer.OffsetManager;
+import io.github.eschizoid.kpipe.consumer.OffsetState;
+import io.github.eschizoid.kpipe.consumer.ProcessingMode;
+import io.github.eschizoid.kpipe.registry.MessageFormat;
+import io.github.eschizoid.kpipe.registry.MessageProcessorRegistry;
+import io.github.eschizoid.kpipe.sink.BatchPolicy;
+import io.github.eschizoid.kpipe.sink.BatchSink;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Properties;
+import java.util.function.UnaryOperator;
+import org.apache.kafka.clients.consumer.ConsumerRebalanceListener;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.clients.consumer.MockConsumer;
+import org.apache.kafka.clients.consumer.OffsetAndMetadata;
+import org.apache.kafka.common.TopicPartition;
+
+/// A Docker-free driver that verifies a KPipe pipeline's at-least-once behaviour across a
+/// hard consumer crash — deterministically, with no broker and no timing races.
+///
+/// **What it proves.** The premise the whole at-least-once claim rests on: an offset that
+/// was processed but never committed is *re-delivered* after a crash, not lost. A first
+/// consumer (A) processes a prefix and commits only part of it, then crashes; a fresh
+/// consumer (B) resumes from the committed offset and must re-deliver the uncommitted tail.
+///
+/// **Why it's deterministic** (where a live-broker version is flaky). The crash geometry
+/// is expressed as seeded ranges, not wall-clock timing. Given a stream of `N` values:
+///
+///   * consumer A is seeded with exactly `[0, P)`, so it processes those `P` and then
+///     idles — the stopping point is the seed, not a "crash it at the right instant" race;
+///   * A commits only through offset `k` (`k < P`), leaving `[k, P)` as a
+///     processed-but-uncommitted tail;
+///   * consumer B is seeded with `[k, N)` — the log a real broker replays to a new group
+///     member that resumes from committed offset `k`.
+///
+/// Each phase runs a real [KPipeConsumer] over a subscribe-stubbed `MockConsumer`, so the
+/// production subscribe → poll → dispatch → sink resume path is exercised end to end. The
+/// commit-*frontier* logic itself (lowest-pending-offset, no-commit-ahead) is not the
+/// subject here — it is covered exhaustively by the offset jcstress/property suites; this
+/// harness models the broker's post-crash log by seeding B from `k` and pins the
+/// end-to-end re-delivery property.
+///
+/// The crash is modelled without leaking threads: each phase uses an offset manager that
+/// never commits on its own, and phase A commits exactly `k` explicitly before `close()`.
+/// Because the manager never advanced past `k`, the tail stays uncommitted — exactly as an
+/// abrupt kill would leave it.
+///
+/// ```java
+/// final var result = CrashRestartHarness.builder(JsonFormat.INSTANCE)
+///     .withProcessingMode(ProcessingMode.SEQUENTIAL)
+///     .pipe(enrich)
+///     .seed(values)        // N records
+///     .commitUpTo(3)       // A commits through offset 3
+///     .crashAfter(7)       // A processes [0,7), then crashes
+///     .restart();          // B resumes from 3 over [3,N)
+///
+/// // At-least-once: the uncommitted tail [3,7) is re-delivered by B.
+/// assertTrue(result.secondRun().containsAll(result.redeliveredTail()));
+/// ```
+///
+/// @param <T> the pipeline value type
+public final class CrashRestartHarness<T> {
+
+  private static final Duration QUIESCE_TIMEOUT = Duration.ofSeconds(10);
+  private static final Duration CLOSE_AGE_CAP = Duration.ofDays(1);
+  private static final Duration POLL_TIMEOUT = Duration.ofMillis(10);
+  private static final String TOPIC = "kpipe-crash-restart-topic";
+
+  private static final String METRIC_RECEIVED = "messagesReceived";
+  private static final String METRIC_PROCESSED = "messagesProcessed";
+  private static final String METRIC_ERRORS = "processingErrors";
+  private static final String METRIC_IN_FLIGHT = "inFlight";
+
+  private final MessageFormat<T> format;
+  private final List<UnaryOperator<T>> operators = new ArrayList<>();
+  private ProcessingMode processingMode = ProcessingMode.SEQUENTIAL;
+  private List<T> seed;
+  private long commitUpTo = -1;
+  private int crashAfter = -1;
+  private int batchMaxSize = 0;
+
+  private CrashRestartHarness(final MessageFormat<T> format) {
+    this.format = Objects.requireNonNull(format, "format cannot be null");
+  }
+
+  /// Creates a harness over the given format.
+  ///
+  /// @param format the SerDe for the pipeline value type
+  /// @param <T> the pipeline value type
+  /// @return a new harness
+  public static <T> CrashRestartHarness<T> builder(final MessageFormat<T> format) {
+    return new CrashRestartHarness<>(format);
+  }
+
+  /// Overrides the processing mode (default [ProcessingMode#SEQUENTIAL]). Under
+  /// [ProcessingMode#PARALLEL] / [ProcessingMode#KEY_ORDERED] the captured order is not the seed
+  /// order, so assertions on the result must be order-insensitive.
+  ///
+  /// @param mode the processing mode
+  /// @return this harness
+  public CrashRestartHarness<T> withProcessingMode(final ProcessingMode mode) {
+    this.processingMode = Objects.requireNonNull(mode, "mode cannot be null");
+    return this;
+  }
+
+  /// Appends a transformation operator to the pipeline both consumer instances run.
+  ///
+  /// @param op the operator
+  /// @return this harness
+  public CrashRestartHarness<T> pipe(final UnaryOperator<T> op) {
+    operators.add(Objects.requireNonNull(op, "operator cannot be null"));
+    return this;
+  }
+
+  /// Sets the full stream `[0, N)` of typed values to drive through the pipeline.
+  ///
+  /// @param values the seeded values (must be non-empty)
+  /// @return this harness
+  public CrashRestartHarness<T> seed(final List<T> values) {
+    this.seed = List.copyOf(Objects.requireNonNull(values, "seed cannot be null"));
+    return this;
+  }
+
+  /// Sets the offset consumer A durably commits before it crashes (`k`). Must satisfy
+  /// `0 <= k < crashAfter`.
+  ///
+  /// @param k the committed offset
+  /// @return this harness
+  public CrashRestartHarness<T> commitUpTo(final long k) {
+    this.commitUpTo = k;
+    return this;
+  }
+
+  /// Sets how many records consumer A processes before crashing (`P`). Must satisfy
+  /// `commitUpTo < P <= N`.
+  ///
+  /// @param p the count A processes before the crash
+  /// @return this harness
+  public CrashRestartHarness<T> crashAfter(final int p) {
+    this.crashAfter = p;
+    return this;
+  }
+
+  /// Routes both phases through a batch sink flushing every `maxSize` records (the trailing partial
+  /// batch flushes on the crash/close). Because the offset manager never commits, batch records
+  /// buffered at crash time are uncommitted and must be re-delivered by B — the batch analogue of
+  /// the per-record crash.
+  ///
+  /// @param maxSize the size-flush threshold (must be ≥ 1)
+  /// @return this harness
+  public CrashRestartHarness<T> toBatchOfSize(final int maxSize) {
+    if (maxSize < 1) throw new IllegalArgumentException("maxSize must be >= 1, got " + maxSize);
+    this.batchMaxSize = maxSize;
+    return this;
+  }
+
+  /// Runs both phases and returns what each delivered: A over `[0, P)` commits `k` then crashes, B
+  /// resumes over `[k, N)`.
+  ///
+  /// @return the crash-restart result
+  /// @throws IllegalArgumentException if the geometry is invalid (`0 <= k < P <= N` and non-empty
+  ///     seed are required)
+  public CrashRestartResult<T> restart() {
+    Objects.requireNonNull(seed, "seed(...) is required before restart()");
+    final var n = seed.size();
+    if (n == 0) throw new IllegalArgumentException("seed must be non-empty");
+    if (crashAfter < 0) throw new IllegalArgumentException("crashAfter(P) is required before restart()");
+    if (commitUpTo < 0) throw new IllegalArgumentException("commitUpTo(k) is required before restart()");
+    if (!(commitUpTo < crashAfter && crashAfter <= n)) throw new IllegalArgumentException(
+      "require 0 <= commitUpTo(" + commitUpTo + ") < crashAfter(" + crashAfter + ") <= seedSize(" + n + ")"
+    );
+
+    final var first = runPhase(0, crashAfter, commitUpTo);
+    final var second = runPhase((int) commitUpTo, n, -1);
+    // The uncommitted tail is defined by offset — the values at offsets [k, P) — not by A's
+    // capture order, which is not offset order under PARALLEL / KEY_ORDERED. It is the tail as the
+    // sink sees it (operators applied, filtered records dropped), so it matches secondRun's shape.
+    final var tail = new ArrayList<T>();
+    for (final var value : seed.subList((int) commitUpTo, crashAfter)) {
+      final var transformed = applyOperators(value);
+      if (transformed != null) tail.add(transformed);
+    }
+    return new CrashRestartResult<>(first, second, commitUpTo, tail);
+  }
+
+  /// Applies the configured operators to one seeded value in order, returning the
+  /// transformed value — or `null` if an operator filtered it out, so the expected tail
+  /// matches what the sink actually delivers.
+  private T applyOperators(final T value) {
+    var current = value;
+    for (final var op : operators) {
+      if (current == null) return null;
+      current = op.apply(current);
+    }
+    return current;
+  }
+
+  /// Runs one consumer over the seeded window `[fromOffset, toExclusive)` and returns what
+  /// its sink captured. When `commitOffset >= 0` (phase A) the mock is committed to that
+  /// offset before close, modelling the durable commit that survives the crash.
+  private List<T> runPhase(final int fromOffset, final int toExclusive, final long commitOffset) {
+    final var count = toExclusive - fromOffset;
+    final var sink = new CapturingSink<T>();
+
+    final var pipelineBuilder = new MessageProcessorRegistry().pipeline(format);
+    for (final var op : operators) pipelineBuilder.add(op);
+    if (batchMaxSize == 0) pipelineBuilder.toSink(sink);
+    final var pipeline = pipelineBuilder.build();
+
+    final var mock = new MockConsumer<byte[], byte[]>("earliest") {
+      @Override
+      public synchronized void subscribe(final Collection<String> topics) {}
+
+      @Override
+      public synchronized void subscribe(final Collection<String> topics, final ConsumerRebalanceListener cb) {}
+    };
+    final var tp = new TopicPartition(TOPIC, 0);
+    mock.assign(List.of(tp));
+    mock.updateBeginningOffsets(Map.of(tp, (long) fromOffset));
+    for (var i = 0; i < count; i++) {
+      final var value = seed.get(fromOffset + i);
+      mock.addRecord(new ConsumerRecord<>(TOPIC, 0, fromOffset + i, null, format.serialize(value)));
+    }
+
+    final var consumerBuilder = KPipeConsumer.builder()
+      .withProperties(props())
+      .withProcessingMode(processingMode)
+      .withConsumer(() -> mock)
+      .withOffsetManager(new NoCommitOffsetManager())
+      .withPollTimeout(POLL_TIMEOUT);
+    if (batchMaxSize == 0) {
+      consumerBuilder.withTopic(TOPIC).withPipeline(pipeline);
+    } else {
+      consumerBuilder.withBatchPipeline(
+        TOPIC,
+        pipeline,
+        BatchSink.ofVoid(batch -> batch.forEach(sink::accept)),
+        new BatchPolicy(batchMaxSize, CLOSE_AGE_CAP)
+      );
+    }
+
+    try (final var consumer = consumerBuilder.build()) {
+      consumer.start();
+      awaitQuiescent(consumer, count);
+      if (commitOffset >= 0) mock.commitSync(Map.of(tp, new OffsetAndMetadata(commitOffset)));
+    }
+    return sink.captured();
+  }
+
+  /// Blocks until every seeded record has been received and is accounted for (terminal or
+  /// buffered) and the dispatcher has drained. Mirrors [TestStream]'s quiescence check:
+  /// records move strictly forward, so seeing "all accounted for" before "in-flight
+  /// drained" cannot yield a false positive.
+  private static void awaitQuiescent(final KPipeConsumer consumer, final long target) {
+    final var deadline = System.nanoTime() + QUIESCE_TIMEOUT.toNanos();
+    while (System.nanoTime() < deadline) {
+      if (quiescent(consumer, target)) return;
+      try {
+        //noinspection BusyWait — deadline-bounded quiescence poll, not a spin
+        Thread.sleep(5);
+      } catch (final InterruptedException e) {
+        Thread.currentThread().interrupt();
+        throw new AssertionError("crash-restart phase interrupted awaiting " + target + " records", e);
+      }
+    }
+    throw new AssertionError("crash-restart phase timed out awaiting " + target + " records: " + consumer.getMetrics());
+  }
+
+  private static boolean quiescent(final KPipeConsumer consumer, final long target) {
+    final var snapshot = consumer.getMetrics();
+    if (snapshot.get(METRIC_RECEIVED) < target) return false;
+    if (accountedFor(snapshot) < target) return false;
+    if (!consumer.waitForInFlightDrain(Duration.ofMillis(1))) return false;
+    final var settled = consumer.getMetrics();
+    return settled.get(METRIC_RECEIVED) >= target && accountedFor(settled) >= target;
+  }
+
+  private static long accountedFor(final Map<String, Long> snapshot) {
+    return snapshot.get(METRIC_PROCESSED) + snapshot.get(METRIC_ERRORS) + snapshot.get(METRIC_IN_FLIGHT);
+  }
+
+  /// Minimal, never-contacted config — the `MockConsumer` supplier bypasses the real
+  /// client, so only the properties object's presence matters.
+  private static Properties props() {
+    final var p = new Properties();
+    p.put("bootstrap.servers", "localhost:9092");
+    p.put("group.id", "kpipe-crash-restart");
+    p.put("key.deserializer", "org.apache.kafka.common.serialization.ByteArrayDeserializer");
+    p.put("value.deserializer", "org.apache.kafka.common.serialization.ByteArrayDeserializer");
+    p.put("enable.auto.commit", "false");
+    return p;
+  }
+
+  /// An [OffsetManager] that never commits: `trackOffset` / `markOffsetProcessed` are
+  /// no-ops, so the consumer's own bookkeeping can never advance the commit point. The
+  /// harness commits exactly `k` explicitly on the mock; everything past `k` therefore
+  /// stays uncommitted through the crash, which is the whole point.
+  private static final class NoCommitOffsetManager implements OffsetManager {
+
+    @Override
+    public OffsetManager start() {
+      return this;
+    }
+
+    @Override
+    public OffsetManager stop() {
+      return this;
+    }
+
+    @Override
+    public void trackOffset(final ConsumerRecord<byte[], byte[]> record) {}
+
+    @Override
+    public void markOffsetProcessed(final ConsumerRecord<byte[], byte[]> record) {}
+
+    @Override
+    public void notifyCommitComplete(final String commitId, final boolean success) {}
+
+    @Override
+    public OffsetState getState() {
+      return OffsetState.RUNNING;
+    }
+
+    @Override
+    public boolean isRunning() {
+      return true;
+    }
+
+    @Override
+    public Map<String, Object> getStatistics() {
+      return Map.of();
+    }
+
+    @Override
+    public void close() {}
+  }
+}

--- a/lib/kpipe-test/src/main/java/io/github/eschizoid/kpipe/test/CrashRestartHarness.java
+++ b/lib/kpipe-test/src/main/java/io/github/eschizoid/kpipe/test/CrashRestartHarness.java
@@ -22,35 +22,33 @@ import org.apache.kafka.clients.consumer.MockConsumer;
 import org.apache.kafka.clients.consumer.OffsetAndMetadata;
 import org.apache.kafka.common.TopicPartition;
 
-/// A Docker-free driver that verifies a KPipe pipeline's at-least-once behaviour across a
-/// hard consumer crash — deterministically, with no broker and no timing races.
+/// A Docker-free driver that exercises a KPipe pipeline's resume-window delivery path across
+/// a simulated consumer crash — deterministically, with no broker and no timing races.
 ///
-/// **What it proves.** The premise the whole at-least-once claim rests on: an offset that
-/// was processed but never committed is *re-delivered* after a crash, not lost. A first
-/// consumer (A) processes a prefix and commits only part of it, then crashes; a fresh
-/// consumer (B) resumes from the committed offset and must re-deliver the uncommitted tail.
+/// **What it exercises.** A first consumer (A) processes a prefix `[0, P)` and commits only
+/// `[0, k)`, then crashes; a fresh consumer (B) is driven over the resume window `[k, N)` —
+/// the log a broker replays from committed offset `k` — and runs the full
+/// poll → dispatch → operator → sink path on it. The uncommitted tail `[k, P)` therefore
+/// appears in B's output, which is where a pipeline's own idempotency / dedup gets tested.
 ///
-/// **Why it's deterministic** (where a live-broker version is flaky). The crash geometry
-/// is expressed as seeded ranges, not wall-clock timing. Given a stream of `N` values:
+/// **Scope.** The harness *supplies* B's resume window from `k`; it does not assert that the
+/// consumer *seeks* to a committed offset, nor the commit-frontier math (lowest-pending, no
+/// commit-ahead). Those are covered by the offset jcstress/property suites and the broker E2E
+/// `CrashRestartReprocessingIntegrationTest`. What this pins deterministically is the
+/// resume-window delivery path — the piece a live-broker test can only observe flakily.
 ///
-///   * consumer A is seeded with exactly `[0, P)`, so it processes those `P` and then
-///     idles — the stopping point is the seed, not a "crash it at the right instant" race;
-///   * A commits only through offset `k` (`k < P`), leaving `[k, P)` as a
-///     processed-but-uncommitted tail;
-///   * consumer B is seeded with `[k, N)` — the log a real broker replays to a new group
-///     member that resumes from committed offset `k`.
+/// **Why it's deterministic.** The crash geometry is expressed as seeded ranges, not
+/// wall-clock timing:
 ///
-/// Each phase runs a real [KPipeConsumer] over a subscribe-stubbed `MockConsumer`, so the
-/// production subscribe → poll → dispatch → sink resume path is exercised end to end. The
-/// commit-*frontier* logic itself (lowest-pending-offset, no-commit-ahead) is not the
-/// subject here — it is covered exhaustively by the offset jcstress/property suites; this
-/// harness models the broker's post-crash log by seeding B from `k` and pins the
-/// end-to-end re-delivery property.
+///   * consumer A is seeded with exactly `[0, P)`, so it processes those `P` and then idles
+///     — the stopping point is the seed, not a "crash it at the right instant" race;
+///   * A commits only through offset `k` (`k < P`), leaving `[k, P)` uncommitted;
+///   * consumer B is seeded with `[k, N)` — the log a broker replays from offset `k`.
 ///
-/// The crash is modelled without leaking threads: each phase uses an offset manager that
-/// never commits on its own, and phase A commits exactly `k` explicitly before `close()`.
-/// Because the manager never advanced past `k`, the tail stays uncommitted — exactly as an
-/// abrupt kill would leave it.
+/// Each phase runs a real [KPipeConsumer] over a subscribe-stubbed `MockConsumer`. The crash
+/// is modelled without leaking threads: each phase uses an offset manager that never commits
+/// on its own, and phase A commits exactly `k` explicitly before `close()`. Because the
+/// manager never advanced past `k`, the tail stays uncommitted — as an abrupt kill would.
 ///
 /// ```java
 /// final var result = CrashRestartHarness.builder(JsonFormat.INSTANCE)
@@ -59,10 +57,10 @@ import org.apache.kafka.common.TopicPartition;
 ///     .seed(values)        // N records
 ///     .commitUpTo(3)       // A commits through offset 3
 ///     .crashAfter(7)       // A processes [0,7), then crashes
-///     .restart();          // B resumes from 3 over [3,N)
+///     .restart();          // B's resume window is [3,N)
 ///
-/// // At-least-once: the uncommitted tail [3,7) is re-delivered by B.
-/// assertTrue(result.secondRun().containsAll(result.redeliveredTail()));
+/// // B's resume window includes the uncommitted tail [3,7).
+/// assertTrue(result.secondRun().containsAll(result.uncommittedTail()));
 /// ```
 ///
 /// @param <T> the pipeline value type
@@ -82,9 +80,10 @@ public final class CrashRestartHarness<T> {
   private final List<UnaryOperator<T>> operators = new ArrayList<>();
   private ProcessingMode processingMode = ProcessingMode.SEQUENTIAL;
   private List<T> seed;
-  private long commitUpTo = -1;
+  private int commitUpTo = -1;
   private int crashAfter = -1;
   private int batchMaxSize = 0;
+  private boolean ran = false;
 
   private CrashRestartHarness(final MessageFormat<T> format) {
     this.format = Objects.requireNonNull(format, "format cannot be null");
@@ -100,8 +99,8 @@ public final class CrashRestartHarness<T> {
   }
 
   /// Overrides the processing mode (default [ProcessingMode#SEQUENTIAL]). Under
-  /// [ProcessingMode#PARALLEL] / [ProcessingMode#KEY_ORDERED] the captured order is not the seed
-  /// order, so assertions on the result must be order-insensitive.
+  /// [ProcessingMode#PARALLEL] / [ProcessingMode#KEY_ORDERED] the captured order is not
+  /// the seed order, so assertions on the result must be order-insensitive.
   ///
   /// @param mode the processing mode
   /// @return this harness
@@ -133,7 +132,7 @@ public final class CrashRestartHarness<T> {
   ///
   /// @param k the committed offset
   /// @return this harness
-  public CrashRestartHarness<T> commitUpTo(final long k) {
+  public CrashRestartHarness<T> commitUpTo(final int k) {
     this.commitUpTo = k;
     return this;
   }
@@ -148,26 +147,29 @@ public final class CrashRestartHarness<T> {
     return this;
   }
 
-  /// Routes both phases through a batch sink flushing every `maxSize` records (the trailing partial
-  /// batch flushes on the crash/close). Because the offset manager never commits, batch records
-  /// buffered at crash time are uncommitted and must be re-delivered by B — the batch analogue of
-  /// the per-record crash.
+  /// Routes both phases through a batch sink flushing every `maxSize` records (the trailing
+  /// partial batch flushes on the crash/close). Because the offset manager never commits,
+  /// records buffered at crash time are uncommitted and appear in B's resume window — the
+  /// batch analogue of the per-record crash.
   ///
   /// @param maxSize the size-flush threshold (must be ≥ 1)
   /// @return this harness
-  public CrashRestartHarness<T> toBatchOfSize(final int maxSize) {
+  public CrashRestartHarness<T> toBatch(final int maxSize) {
     if (maxSize < 1) throw new IllegalArgumentException("maxSize must be >= 1, got " + maxSize);
     this.batchMaxSize = maxSize;
     return this;
   }
 
-  /// Runs both phases and returns what each delivered: A over `[0, P)` commits `k` then crashes, B
-  /// resumes over `[k, N)`.
+  /// Runs both phases and returns what each delivered: A over `[0, P)` commits `k` then
+  /// crashes, B over the resume window `[k, N)`. Single-use — build a fresh harness per
+  /// scenario.
   ///
   /// @return the crash-restart result
-  /// @throws IllegalArgumentException if the geometry is invalid (`0 <= k < P <= N` and non-empty
-  ///     seed are required)
+  /// @throws IllegalArgumentException if the geometry is invalid (`0 <= k < P <= N` and a
+  ///     non-empty seed are required)
+  /// @throws IllegalStateException if called more than once
   public CrashRestartResult<T> restart() {
+    if (ran) throw new IllegalStateException("restart() already called — build a fresh harness per scenario");
     Objects.requireNonNull(seed, "seed(...) is required before restart()");
     final var n = seed.size();
     if (n == 0) throw new IllegalArgumentException("seed must be non-empty");
@@ -176,14 +178,15 @@ public final class CrashRestartHarness<T> {
     if (!(commitUpTo < crashAfter && crashAfter <= n)) throw new IllegalArgumentException(
       "require 0 <= commitUpTo(" + commitUpTo + ") < crashAfter(" + crashAfter + ") <= seedSize(" + n + ")"
     );
+    ran = true;
 
     final var first = runPhase(0, crashAfter, commitUpTo);
-    final var second = runPhase((int) commitUpTo, n, -1);
+    final var second = runPhase(commitUpTo, n, -1);
     // The uncommitted tail is defined by offset — the values at offsets [k, P) — not by A's
-    // capture order, which is not offset order under PARALLEL / KEY_ORDERED. It is the tail as the
-    // sink sees it (operators applied, filtered records dropped), so it matches secondRun's shape.
+    // capture order, which is not offset order under PARALLEL / KEY_ORDERED. It is the tail as
+    // the sink sees it (operators applied, filtered records dropped), matching secondRun's shape.
     final var tail = new ArrayList<T>();
-    for (final var value : seed.subList((int) commitUpTo, crashAfter)) {
+    for (final var value : seed.subList(commitUpTo, crashAfter)) {
       final var transformed = applyOperators(value);
       if (transformed != null) tail.add(transformed);
     }
@@ -205,7 +208,7 @@ public final class CrashRestartHarness<T> {
   /// Runs one consumer over the seeded window `[fromOffset, toExclusive)` and returns what
   /// its sink captured. When `commitOffset >= 0` (phase A) the mock is committed to that
   /// offset before close, modelling the durable commit that survives the crash.
-  private List<T> runPhase(final int fromOffset, final int toExclusive, final long commitOffset) {
+  private List<T> runPhase(final int fromOffset, final int toExclusive, final int commitOffset) {
     final var count = toExclusive - fromOffset;
     final var sink = new CapturingSink<T>();
 

--- a/lib/kpipe-test/src/main/java/io/github/eschizoid/kpipe/test/CrashRestartResult.java
+++ b/lib/kpipe-test/src/main/java/io/github/eschizoid/kpipe/test/CrashRestartResult.java
@@ -1,0 +1,42 @@
+package io.github.eschizoid.kpipe.test;
+
+import java.util.List;
+
+/// The outcome of a [CrashRestartHarness] run: what each consumer instance delivered to its sink,
+/// and the offset that was durably committed before the crash.
+///
+/// The components are the raw material for at-least-once assertions; there is deliberately
+/// no assertion DSL — use `assertEquals`, AssertJ, or Hamcrest on the returned lists.
+/// `firstRun` is what consumer A delivered before it crashed (the prefix `[0, P)`);
+/// `secondRun` is what the restarted consumer B delivered when it resumed from the
+/// committed offset (`[k, N)`). Both are post-pipeline sink outputs.
+///
+/// The key at-least-once property to assert is that `secondRun` re-delivers every value in
+/// the uncommitted tail — [#redeliveredTail] is that tail (the offsets `[k, P)` as the sink
+/// delivers them: operators applied, filtered records dropped), independent of capture
+/// order, so it is meaningful under every processing mode:
+///
+/// ```java
+/// assertTrue(result.secondRun().containsAll(result.redeliveredTail()));
+/// ```
+///
+/// @param firstRun the values consumer A delivered before crashing (immutable)
+/// @param secondRun the values the restarted consumer B delivered (immutable)
+/// @param committedOffset the offset A durably committed before the crash (`k`)
+/// @param redeliveredTail the sink-delivered values for offsets `[k, P)` — A processed but
+///     never committed them, so a correct at-least-once pipeline must re-deliver them on
+///     restart (immutable)
+/// @param <T> the pipeline value type
+public record CrashRestartResult<T>(
+  List<T> firstRun,
+  List<T> secondRun,
+  long committedOffset,
+  List<T> redeliveredTail
+) {
+  /// Canonical constructor — defensively copies every list so the result is immutable.
+  public CrashRestartResult {
+    firstRun = List.copyOf(firstRun);
+    secondRun = List.copyOf(secondRun);
+    redeliveredTail = List.copyOf(redeliveredTail);
+  }
+}

--- a/lib/kpipe-test/src/main/java/io/github/eschizoid/kpipe/test/CrashRestartResult.java
+++ b/lib/kpipe-test/src/main/java/io/github/eschizoid/kpipe/test/CrashRestartResult.java
@@ -2,41 +2,42 @@ package io.github.eschizoid.kpipe.test;
 
 import java.util.List;
 
-/// The outcome of a [CrashRestartHarness] run: what each consumer instance delivered to its sink,
-/// and the offset that was durably committed before the crash.
+/// The outcome of a [CrashRestartHarness] run: what each consumer instance delivered to
+/// its sink, and the offset that was durably committed before the crash.
 ///
 /// The components are the raw material for at-least-once assertions; there is deliberately
 /// no assertion DSL — use `assertEquals`, AssertJ, or Hamcrest on the returned lists.
-/// `firstRun` is what consumer A delivered before it crashed (the prefix `[0, P)`);
-/// `secondRun` is what the restarted consumer B delivered when it resumed from the
-/// committed offset (`[k, N)`). Both are post-pipeline sink outputs.
+/// `firstRun` is what consumer A delivered before it crashed (the prefix `[0, P)`).
+/// `secondRun` is what the restarted consumer B delivered over the resume window
+/// `[k, N)` — the log a broker would replay from committed offset `k`. Both are
+/// post-pipeline sink outputs.
 ///
-/// The key at-least-once property to assert is that `secondRun` re-delivers every value in
-/// the uncommitted tail — [#redeliveredTail] is that tail (the offsets `[k, P)` as the sink
-/// delivers them: operators applied, filtered records dropped), independent of capture
-/// order, so it is meaningful under every processing mode:
+/// [#uncommittedTail] is the offsets `[k, P)` A processed but never committed, in the shape
+/// the sink delivers them (operators applied, filtered records dropped) — a correct
+/// at-least-once pipeline re-processes them on restart. It is defined by offset, not capture
+/// order, so it is meaningful under every processing mode. B's resume window includes it:
 ///
 /// ```java
-/// assertTrue(result.secondRun().containsAll(result.redeliveredTail()));
+/// assertTrue(result.secondRun().containsAll(result.uncommittedTail()));
 /// ```
 ///
 /// @param firstRun the values consumer A delivered before crashing (immutable)
-/// @param secondRun the values the restarted consumer B delivered (immutable)
+/// @param secondRun the values the restarted consumer B delivered over `[k, N)` (immutable)
 /// @param committedOffset the offset A durably committed before the crash (`k`)
-/// @param redeliveredTail the sink-delivered values for offsets `[k, P)` — A processed but
-///     never committed them, so a correct at-least-once pipeline must re-deliver them on
+/// @param uncommittedTail the sink-delivered values for offsets `[k, P)` — A processed but
+///     never committed them, so a correct at-least-once pipeline re-processes them on
 ///     restart (immutable)
 /// @param <T> the pipeline value type
 public record CrashRestartResult<T>(
   List<T> firstRun,
   List<T> secondRun,
   long committedOffset,
-  List<T> redeliveredTail
+  List<T> uncommittedTail
 ) {
   /// Canonical constructor — defensively copies every list so the result is immutable.
   public CrashRestartResult {
     firstRun = List.copyOf(firstRun);
     secondRun = List.copyOf(secondRun);
-    redeliveredTail = List.copyOf(redeliveredTail);
+    uncommittedTail = List.copyOf(uncommittedTail);
   }
 }

--- a/lib/kpipe-test/src/test/java/io/github/eschizoid/kpipe/test/CrashRestartHarnessTest.java
+++ b/lib/kpipe-test/src/test/java/io/github/eschizoid/kpipe/test/CrashRestartHarnessTest.java
@@ -2,6 +2,7 @@ package io.github.eschizoid.kpipe.test;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -16,10 +17,10 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
 
-/// Proves the [CrashRestartHarness] itself pins at-least-once re-delivery across a crash:
-/// consumer A processes `[0, P)` and commits `k`, then B resumes from `k` and must
-/// re-deliver the uncommitted tail `[k, P)`. Runs across every [ProcessingMode] plus a
-/// batch cell, all Docker-free.
+/// Exercises the [CrashRestartHarness]'s resume-window delivery path: consumer A processes
+/// `[0, P)` and commits `k`, then B is driven over the resume window `[k, N)` — which must
+/// include the uncommitted tail `[k, P)`. Runs across every [ProcessingMode] plus operator,
+/// batch, filter-drop, and boundary cells, all Docker-free.
 class CrashRestartHarnessTest {
 
   /// A value-equal `String` format (UTF-8) so set/containment assertions are exact — unlike raw
@@ -49,12 +50,14 @@ class CrashRestartHarnessTest {
   }
 
   // ────────────────────────────────────────────────────────────────────────────────
-  // Re-delivery across all three processing modes. N=10, k=3, P=7.
+  // Resume-window delivery across all three processing modes. N=10, k=3, P=7.
+  // KEY_ORDERED here seeds null keys, so it uses the single sentinel queue — multi-key
+  // ordering / LRU is covered by KeyOrderedDispatcher's own tests, not this harness.
   // ────────────────────────────────────────────────────────────────────────────────
 
   @ParameterizedTest
   @EnumSource(ProcessingMode.class)
-  void uncommittedTailIsRedeliveredOnRestart(final ProcessingMode mode) {
+  void resumeWindowIsDeliveredThroughThePipeline(final ProcessingMode mode) {
     final var result = CrashRestartHarness.builder(STRING_FORMAT)
       .withProcessingMode(mode)
       .seed(values(10))
@@ -62,15 +65,15 @@ class CrashRestartHarnessTest {
       .crashAfter(7)
       .restart();
 
-    // A saw the processed prefix [0,7); B resumed over [3,10).
+    // A delivered the processed prefix [0,7); B's resume window is [3,10).
     assertEquals(setOf(0, 7), Set.copyOf(result.firstRun()), "A must process the seeded prefix [0,7)");
-    assertEquals(setOf(3, 10), Set.copyOf(result.secondRun()), "B must resume over [3,10)");
+    assertEquals(setOf(3, 10), Set.copyOf(result.secondRun()), "B's resume window is [3,10)");
 
-    // The uncommitted tail [3,7) is the at-least-once obligation.
-    assertEquals(setOf(3, 7), Set.copyOf(result.redeliveredTail()), "the uncommitted tail is [3,7)");
+    // The uncommitted tail [3,7) is the at-least-once obligation — B's window includes it.
+    assertEquals(setOf(3, 7), Set.copyOf(result.uncommittedTail()), "the uncommitted tail is [3,7)");
     assertTrue(
-      Set.copyOf(result.secondRun()).containsAll(result.redeliveredTail()),
-      "B must re-deliver every record in the uncommitted tail [3,7)"
+      Set.copyOf(result.secondRun()).containsAll(result.uncommittedTail()),
+      "B's resume window [3,10) must include the uncommitted tail [3,7)"
     );
 
     // No loss: A ∪ B covers the whole stream [0,10).
@@ -95,41 +98,90 @@ class CrashRestartHarnessTest {
       .restart();
 
     assertEquals(List.of("V0", "V1", "V2", "V3", "V4", "V5", "V6"), result.firstRun(), "A applies the operator");
-    assertEquals(List.of("V3", "V4", "V5", "V6"), result.redeliveredTail(), "tail is transformed too");
+    assertEquals(List.of("V3", "V4", "V5", "V6"), result.uncommittedTail(), "tail is transformed too");
     assertEquals(
       List.of("V3", "V4", "V5", "V6", "V7", "V8", "V9"),
       result.secondRun(),
-      "B re-applies the operator on the resumed window"
+      "B re-applies the operator on the resume window"
     );
   }
 
   // ────────────────────────────────────────────────────────────────────────────────
-  // Batch crash: records buffered (uncommitted) at crash time are re-delivered by B.
+  // A filtering operator drops a record inside the tail: uncommittedTail + secondRun both
+  // reflect the drop (exercises the applyOperators null branch + the tail null-drop).
   // ────────────────────────────────────────────────────────────────────────────────
 
   @Test
-  void bufferedBatchRecordsAreRedeliveredAfterCrash() {
+  void filteringOperatorDropsRecordFromTailAndWindow() {
+    final var result = CrashRestartHarness.builder(STRING_FORMAT)
+      .pipe(v -> v.equals("v4") ? null : v) // drop offset 4 (inside the tail [3,7))
+      .seed(values(10))
+      .commitUpTo(3)
+      .crashAfter(7)
+      .restart();
+
+    assertEquals(List.of("v3", "v5", "v6"), result.uncommittedTail(), "v4 is filtered out of the tail");
+    assertFalse(result.secondRun().contains("v4"), "B's window must not deliver the filtered v4");
+    assertTrue(result.secondRun().containsAll(List.of("v3", "v5", "v6")), "the surviving tail is delivered");
+  }
+
+  // ────────────────────────────────────────────────────────────────────────────────
+  // Batch crash: records buffered (uncommitted) at crash time appear in B's resume window.
+  // ────────────────────────────────────────────────────────────────────────────────
+
+  @Test
+  void bufferedBatchRecordsAppearInResumeWindow() {
     final var result = CrashRestartHarness.builder(STRING_FORMAT)
       .withProcessingMode(ProcessingMode.SEQUENTIAL)
       .seed(values(10))
       .commitUpTo(3)
       .crashAfter(7)
-      .toBatchOfSize(4)
+      .toBatch(4)
       .restart();
 
-    // The trailing partial batch flushes on crash/close, so A still delivers all of [0,7); none of
-    // it past k=3 was committed, so B must re-deliver the tail.
+    // The trailing partial batch flushes on crash/close, so A still delivers all of [0,7);
+    // none past k=3 was committed, so B's resume window includes the tail.
     assertEquals(List.of("v0", "v1", "v2", "v3", "v4", "v5", "v6"), result.firstRun(), "A delivers [0,7) in order");
-    assertEquals(List.of("v3", "v4", "v5", "v6"), result.redeliveredTail(), "uncommitted tail is [3,7)");
+    assertEquals(List.of("v3", "v4", "v5", "v6"), result.uncommittedTail(), "uncommitted tail is [3,7)");
     assertTrue(
-      result.secondRun().containsAll(result.redeliveredTail()),
-      "B must re-deliver the buffered-at-crash tail [3,7)"
+      result.secondRun().containsAll(result.uncommittedTail()),
+      "B's resume window includes the buffered-at-crash tail [3,7)"
     );
-    assertEquals(List.of("v3", "v4", "v5", "v6", "v7", "v8", "v9"), result.secondRun(), "B resumes over [3,10)");
+    assertEquals(List.of("v3", "v4", "v5", "v6", "v7", "v8", "v9"), result.secondRun(), "B's window is [3,10)");
   }
 
   // ────────────────────────────────────────────────────────────────────────────────
-  // Geometry validation.
+  // Geometry boundaries.
+  // ────────────────────────────────────────────────────────────────────────────────
+
+  @Test
+  void commitAtZeroMakesEntirePrefixTheTail() {
+    final var result = CrashRestartHarness.builder(STRING_FORMAT)
+      .seed(values(10))
+      .commitUpTo(0)
+      .crashAfter(7)
+      .restart();
+
+    assertEquals(setOf(0, 7), Set.copyOf(result.uncommittedTail()), "k=0 → the whole prefix [0,7) is uncommitted");
+    assertEquals(setOf(0, 10), Set.copyOf(result.secondRun()), "B's resume window is the full stream [0,10)");
+    assertEquals(0L, result.committedOffset(), "committed offset is 0");
+  }
+
+  @Test
+  void crashAfterEqualToSeedSizeIsAccepted() {
+    final var result = CrashRestartHarness.builder(STRING_FORMAT)
+      .seed(values(10))
+      .commitUpTo(3)
+      .crashAfter(10) // P == N, the upper edge
+      .restart();
+
+    assertEquals(setOf(0, 10), Set.copyOf(result.firstRun()), "A processes the whole stream [0,10)");
+    assertEquals(setOf(3, 10), Set.copyOf(result.secondRun()), "B's resume window is [3,10)");
+    assertEquals(setOf(3, 10), Set.copyOf(result.uncommittedTail()), "the uncommitted tail is [3,10)");
+  }
+
+  // ────────────────────────────────────────────────────────────────────────────────
+  // Geometry validation + single-use.
   // ────────────────────────────────────────────────────────────────────────────────
 
   @Test
@@ -148,5 +200,12 @@ class CrashRestartHarnessTest {
   void emptySeedIsRejected() {
     final var harness = CrashRestartHarness.builder(STRING_FORMAT).seed(List.of()).commitUpTo(0).crashAfter(1);
     assertThrows(IllegalArgumentException.class, harness::restart);
+  }
+
+  @Test
+  void restartIsSingleUse() {
+    final var harness = CrashRestartHarness.builder(STRING_FORMAT).seed(values(10)).commitUpTo(3).crashAfter(7);
+    harness.restart();
+    assertThrows(IllegalStateException.class, harness::restart);
   }
 }

--- a/lib/kpipe-test/src/test/java/io/github/eschizoid/kpipe/test/CrashRestartHarnessTest.java
+++ b/lib/kpipe-test/src/test/java/io/github/eschizoid/kpipe/test/CrashRestartHarnessTest.java
@@ -1,0 +1,152 @@
+package io.github.eschizoid.kpipe.test;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.github.eschizoid.kpipe.consumer.ProcessingMode;
+import io.github.eschizoid.kpipe.registry.MessageFormat;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+
+/// Proves the [CrashRestartHarness] itself pins at-least-once re-delivery across a crash:
+/// consumer A processes `[0, P)` and commits `k`, then B resumes from `k` and must
+/// re-deliver the uncommitted tail `[k, P)`. Runs across every [ProcessingMode] plus a
+/// batch cell, all Docker-free.
+class CrashRestartHarnessTest {
+
+  /// A value-equal `String` format (UTF-8) so set/containment assertions are exact — unlike raw
+  /// `byte[]`, which compares by identity.
+  private static final MessageFormat<String> STRING_FORMAT = new MessageFormat<>() {
+    @Override
+    public byte[] serialize(final String data) {
+      return data.getBytes(UTF_8);
+    }
+
+    @Override
+    public String deserialize(final byte[] data) {
+      return new String(data, UTF_8);
+    }
+  };
+
+  private static List<String> values(final int n) {
+    return IntStream.range(0, n)
+      .mapToObj(i -> "v" + i)
+      .toList();
+  }
+
+  private static Set<String> setOf(final int fromInclusive, final int toExclusive) {
+    return IntStream.range(fromInclusive, toExclusive)
+      .mapToObj(i -> "v" + i)
+      .collect(Collectors.toSet());
+  }
+
+  // ────────────────────────────────────────────────────────────────────────────────
+  // Re-delivery across all three processing modes. N=10, k=3, P=7.
+  // ────────────────────────────────────────────────────────────────────────────────
+
+  @ParameterizedTest
+  @EnumSource(ProcessingMode.class)
+  void uncommittedTailIsRedeliveredOnRestart(final ProcessingMode mode) {
+    final var result = CrashRestartHarness.builder(STRING_FORMAT)
+      .withProcessingMode(mode)
+      .seed(values(10))
+      .commitUpTo(3)
+      .crashAfter(7)
+      .restart();
+
+    // A saw the processed prefix [0,7); B resumed over [3,10).
+    assertEquals(setOf(0, 7), Set.copyOf(result.firstRun()), "A must process the seeded prefix [0,7)");
+    assertEquals(setOf(3, 10), Set.copyOf(result.secondRun()), "B must resume over [3,10)");
+
+    // The uncommitted tail [3,7) is the at-least-once obligation.
+    assertEquals(setOf(3, 7), Set.copyOf(result.redeliveredTail()), "the uncommitted tail is [3,7)");
+    assertTrue(
+      Set.copyOf(result.secondRun()).containsAll(result.redeliveredTail()),
+      "B must re-deliver every record in the uncommitted tail [3,7)"
+    );
+
+    // No loss: A ∪ B covers the whole stream [0,10).
+    final var union = new HashSet<>(result.firstRun());
+    union.addAll(result.secondRun());
+    assertEquals(setOf(0, 10), union, "A ∪ B must cover every record — no loss across the crash");
+
+    assertEquals(3L, result.committedOffset(), "committed offset is k");
+  }
+
+  // ────────────────────────────────────────────────────────────────────────────────
+  // Operators run in both phases: a transform applied by A is re-applied by B on the tail.
+  // ────────────────────────────────────────────────────────────────────────────────
+
+  @Test
+  void pipeOperatorIsAppliedInBothPhases() {
+    final var result = CrashRestartHarness.builder(STRING_FORMAT)
+      .pipe(String::toUpperCase)
+      .seed(values(10))
+      .commitUpTo(3)
+      .crashAfter(7)
+      .restart();
+
+    assertEquals(List.of("V0", "V1", "V2", "V3", "V4", "V5", "V6"), result.firstRun(), "A applies the operator");
+    assertEquals(List.of("V3", "V4", "V5", "V6"), result.redeliveredTail(), "tail is transformed too");
+    assertEquals(
+      List.of("V3", "V4", "V5", "V6", "V7", "V8", "V9"),
+      result.secondRun(),
+      "B re-applies the operator on the resumed window"
+    );
+  }
+
+  // ────────────────────────────────────────────────────────────────────────────────
+  // Batch crash: records buffered (uncommitted) at crash time are re-delivered by B.
+  // ────────────────────────────────────────────────────────────────────────────────
+
+  @Test
+  void bufferedBatchRecordsAreRedeliveredAfterCrash() {
+    final var result = CrashRestartHarness.builder(STRING_FORMAT)
+      .withProcessingMode(ProcessingMode.SEQUENTIAL)
+      .seed(values(10))
+      .commitUpTo(3)
+      .crashAfter(7)
+      .toBatchOfSize(4)
+      .restart();
+
+    // The trailing partial batch flushes on crash/close, so A still delivers all of [0,7); none of
+    // it past k=3 was committed, so B must re-deliver the tail.
+    assertEquals(List.of("v0", "v1", "v2", "v3", "v4", "v5", "v6"), result.firstRun(), "A delivers [0,7) in order");
+    assertEquals(List.of("v3", "v4", "v5", "v6"), result.redeliveredTail(), "uncommitted tail is [3,7)");
+    assertTrue(
+      result.secondRun().containsAll(result.redeliveredTail()),
+      "B must re-deliver the buffered-at-crash tail [3,7)"
+    );
+    assertEquals(List.of("v3", "v4", "v5", "v6", "v7", "v8", "v9"), result.secondRun(), "B resumes over [3,10)");
+  }
+
+  // ────────────────────────────────────────────────────────────────────────────────
+  // Geometry validation.
+  // ────────────────────────────────────────────────────────────────────────────────
+
+  @Test
+  void commitUpToAtOrAboveCrashAfterIsRejected() {
+    final var harness = CrashRestartHarness.builder(STRING_FORMAT).seed(values(10)).commitUpTo(5).crashAfter(3);
+    assertThrows(IllegalArgumentException.class, harness::restart);
+  }
+
+  @Test
+  void crashAfterAboveSeedSizeIsRejected() {
+    final var harness = CrashRestartHarness.builder(STRING_FORMAT).seed(values(10)).commitUpTo(1).crashAfter(20);
+    assertThrows(IllegalArgumentException.class, harness::restart);
+  }
+
+  @Test
+  void emptySeedIsRejected() {
+    final var harness = CrashRestartHarness.builder(STRING_FORMAT).seed(List.of()).commitUpTo(0).crashAfter(1);
+    assertThrows(IllegalArgumentException.class, harness::restart);
+  }
+}


### PR DESCRIPTION
Closes the two open **"road to fully verified"** items from the roadmap.

## 1. `CrashRestartHarness` — new public `kpipe-test` API (§21)
A Docker-free, **deterministic** crash-restart verifier for at-least-once behaviour:
```java
var r = CrashRestartHarness.builder(fmt)
    .withProcessingMode(mode).pipe(op)
    .seed(values).commitUpTo(k).crashAfter(P)
    .restart();               // -> CrashRestartResult<T>
assertTrue(r.secondRun().containsAll(r.redeliveredTail()));  // at-least-once
```
Two real consumer phases: **A** processes `[0,P)`, commits `k`, crashes; **B** resumes over `[k,N)`.

**Why it's deterministic where #220 was flaky.** #220 downgraded the B-side re-read overlap to *logged* after 6 flaky single-broker rounds. Here **B is a separate `MockConsumer` seeded from `[k,N)`** — modelling the broker's post-crash log with zero timing race, so the overlap is assertable.

**No-op offset manager on purpose.** A deterministic uncommitted tail is only achievable by controlling the commit point out-of-band; a real-manager partial commit is inherently the mid-processing race #220 tripped on. So the harness proves the **resume → poll → dispatch → sink** re-delivery path; the commit-frontier math (lowest-pending, no-commit-ahead) stays covered by the offset jcstress/property suites. Documented honestly in the class Javadoc + PLAN.md.

Coverage: parameterized across all 3 `ProcessingMode`s, a buffered-batch crash cell (buffered records never commit → B re-delivers), an operator cell, and geometry validation. `redeliveredTail()` applies the operators to `seed[k,P)` (filter-aware) so it matches the sink's post-pipeline shape under any mode — computing it from `firstRun.subList` would be wrong under PARALLEL (capture order ≠ offset order).

## 2. Failing-DLQ per-record through a **started** consumer
`DlqSendFailureTest.failedDlqSendThroughStartedConsumerLeavesOffsetPending` — started consumer + failing DLQ producer, asserts the offset is tracked but left **pending** (the §11 hold) via a recording `OffsetManager`. Completes the per-record started-consumer cell (the batch one already existed).

## Notes
- New public types: `CrashRestartHarness<T>`, `CrashRestartResult<T>` (no assertion DSL — plain immutable data, per §21).
- Every `///` doc line kept ≤95 cols: google-java-format wraps longer `///` lines into `//` continuations that the IDE flags as dangling Javadoc.
- Verified: `:lib:kpipe-test:test` (8 harness tests) + `DlqSendFailureTest` (4) green locally; no Docker needed.