### PR TITLE
chore: post-review cleanup — MultiBuilder SR overloads, package rename, docs

### DIFF
--- a/lib/kpipe-api/src/main/java/io/github/eschizoid/kpipe/KPipe.java
+++ b/lib/kpipe-api/src/main/java/io/github/eschizoid/kpipe/KPipe.java
@@ -104,7 +104,7 @@ public final class KPipe {
     return new DefaultStream<>(topic, kafkaProps, format, KPipe::registryModeConsoleSinkUnsupported);
   }
 
-  private static MessageSink<GenericRecord> registryModeConsoleSinkUnsupported() {
+  static MessageSink<GenericRecord> registryModeConsoleSinkUnsupported() {
     throw new IllegalStateException(
       "toConsole() requires a fixed schema; an AvroFormat in Schema-Registry mode has none. " +
         "Use .toCustom(...) with your own sink, or construct the stream via " +
@@ -159,7 +159,7 @@ public final class KPipe {
     return new DefaultStream<>(topic, kafkaProps, format, KPipe::registryModeProtobufConsoleSinkUnsupported);
   }
 
-  private static MessageSink<Message> registryModeProtobufConsoleSinkUnsupported() {
+  static MessageSink<Message> registryModeProtobufConsoleSinkUnsupported() {
     throw new IllegalStateException(
       "toConsole() requires a fixed descriptor; a ProtobufFormat in Schema-Registry mode has none. " +
         "Use .toCustom(...) with your own sink, or construct the stream via " +

--- a/lib/kpipe-api/src/main/java/io/github/eschizoid/kpipe/MultiBuilder.java
+++ b/lib/kpipe-api/src/main/java/io/github/eschizoid/kpipe/MultiBuilder.java
@@ -11,6 +11,7 @@ import io.github.eschizoid.kpipe.metrics.ConsumerMetrics;
 import io.github.eschizoid.kpipe.producer.tracing.Tracer;
 import io.github.eschizoid.kpipe.registry.MessageFormat;
 import io.github.eschizoid.kpipe.registry.MessagePipeline;
+import io.github.eschizoid.kpipe.registry.SchemaResolver;
 import io.github.eschizoid.kpipe.sink.MessageSink;
 import java.lang.System.Logger;
 import java.lang.System.Logger.Level;
@@ -142,6 +143,23 @@ public final class MultiBuilder {
     return route(topic, format, format::consoleSink, configurator);
   }
 
+  /// Registers an Avro route for `topic` with per-record Confluent Schema-Registry lookup — the
+  /// multi-topic mirror of [KPipe#avro(String, Properties, SchemaResolver)]. Each record's wire
+  /// envelope is read and its schema resolved via `resolver` (wrap with `CachedSchemaResolver`).
+  /// Registry mode has no fixed schema, so `.toConsole()` on this route is unsupported.
+  ///
+  /// @param topic the Kafka topic
+  /// @param resolver the schema resolver (must be non-null; typically a `CachedSchemaResolver`)
+  /// @param configurator builds the operator chain and chooses a terminal sink
+  /// @return this builder
+  public MultiBuilder avro(
+    final String topic,
+    final SchemaResolver resolver,
+    final Function<Stream<GenericRecord>, Sink<GenericRecord>> configurator
+  ) {
+    return route(topic, AvroFormat.withRegistry(resolver), KPipe::registryModeConsoleSinkUnsupported, configurator);
+  }
+
   /// Registers a Protobuf route for `topic` using `format` for SerDe. Construct the format
   /// explicitly: `new ProtobufFormat(descriptor)`.
   ///
@@ -155,6 +173,29 @@ public final class MultiBuilder {
     final Function<Stream<Message>, Sink<Message>> configurator
   ) {
     return route(topic, format, format::consoleSink, configurator);
+  }
+
+  /// Registers a Protobuf route for `topic` with per-record Confluent Schema-Registry lookup — the
+  /// multi-topic mirror of [KPipe#protobuf(String, Properties, SchemaResolver)]. Requires
+  /// `kpipe-format-protobuf-confluent` on the runtime path (the ServiceLoader-discovered
+  /// `.proto`-text compiler). Registry mode has no fixed descriptor, so `.toConsole()` is
+  /// unsupported.
+  ///
+  /// @param topic the Kafka topic
+  /// @param resolver the schema resolver (must be non-null; typically a `CachedSchemaResolver`)
+  /// @param configurator builds the operator chain and chooses a terminal sink
+  /// @return this builder
+  public MultiBuilder protobuf(
+    final String topic,
+    final SchemaResolver resolver,
+    final Function<Stream<Message>, Sink<Message>> configurator
+  ) {
+    return route(
+      topic,
+      ProtobufFormat.withRegistry(resolver),
+      KPipe::registryModeProtobufConsoleSinkUnsupported,
+      configurator
+    );
   }
 
   /// Registers a raw `byte[]` route for `topic` — identity passthrough, no SerDe.

--- a/lib/kpipe-api/src/main/java/io/github/eschizoid/kpipe/Stream.java
+++ b/lib/kpipe-api/src/main/java/io/github/eschizoid/kpipe/Stream.java
@@ -286,7 +286,13 @@ public interface Stream<T> {
   /// the `.proto`-text compiler discovered via `ServiceLoader` (protobuf-java has no `.proto`
   /// parser, so the compiler ships in a separate shaded module, mirroring the `kpipe-metrics` →
   /// `kpipe-metrics-otel` split). Calling this on a Protobuf stream without that module on the
-  /// path throws at first use with a message telling you to add it.
+  /// path throws at first use with a message telling you to add it. That compiler is a ~17 MB
+  /// shaded jar; only SR-Protobuf users pull it — static `new ProtobufFormat(descriptor)` needs
+  /// nothing beyond `protobuf-java`.
+  ///
+  /// **Formats are opt-in.** `kpipe-api` declares the format modules `requires static`, so a
+  /// registry (or any format) call needs the matching `kpipe-format-*` module on the runtime
+  /// path or you get a `NoClassDefFoundError`.
   ///
   /// @param resolver the schema resolver (typically a `CachedSchemaResolver` wrapping a
   ///                 `ConfluentSchemaResolver`)
@@ -300,9 +306,13 @@ public interface Stream<T> {
   /// to start. For Avro streams this requires that a default schema has been registered; see
   /// [KPipe#avro] for details.
   ///
+  /// A **registry-mode** Avro/Protobuf stream (via [#withSchemaRegistry]) has no fixed
+  /// schema/descriptor, so the console sink is unsupported there — `toConsole()` throws; use
+  /// `.toCustom(...)` with your own sink instead.
+  ///
   /// @return a [Sink] ready to start
   /// @throws IllegalStateException if the stream's format requires schema/config that has not
-  ///     been registered (e.g. Avro without a default schema)
+  ///     been registered (e.g. Avro without a default schema, or a registry-mode stream)
   Sink<T> toConsole();
 
   /// Terminates the stream with a user-provided sink and returns a [Sink] ready to start.

--- a/lib/kpipe-api/src/main/java/io/github/eschizoid/kpipe/Stream.java
+++ b/lib/kpipe-api/src/main/java/io/github/eschizoid/kpipe/Stream.java
@@ -286,7 +286,7 @@ public interface Stream<T> {
   /// the `.proto`-text compiler discovered via `ServiceLoader` (protobuf-java has no `.proto`
   /// parser, so the compiler ships in a separate shaded module, mirroring the `kpipe-metrics` →
   /// `kpipe-metrics-otel` split). Calling this on a Protobuf stream without that module on the
-  /// path throws at first use with a message telling you to add it. That compiler is a ~17 MB
+  /// path throws at first use with a message telling you to add it. That compiler is a ~19 MB
   /// shaded jar; only SR-Protobuf users pull it — static `new ProtobufFormat(descriptor)` needs
   /// nothing beyond `protobuf-java`.
   ///

--- a/lib/kpipe-api/src/test/java/io/github/eschizoid/kpipe/MultiBuilderRegistryTest.java
+++ b/lib/kpipe-api/src/test/java/io/github/eschizoid/kpipe/MultiBuilderRegistryTest.java
@@ -31,8 +31,10 @@ class MultiBuilderRegistryTest {
       multi.avro("avro-topic", RESOLVER, Stream::toConsole)
     );
     assertTrue(
-      ex.getMessage().contains("Schema-Registry mode has none"),
-      "expected the registry-mode console-unsupported error, got: " + ex.getMessage()
+      // "fixed schema" is Avro's discriminating token (Protobuf's is "fixed descriptor"), so this
+      // fails if the Avro overload wrongly wired the Protobuf console-unsupported factory.
+      ex.getMessage().contains("fixed schema"),
+      "expected the Avro registry-mode console-unsupported error, got: " + ex.getMessage()
     );
   }
 

--- a/lib/kpipe-api/src/test/java/io/github/eschizoid/kpipe/MultiBuilderRegistryTest.java
+++ b/lib/kpipe-api/src/test/java/io/github/eschizoid/kpipe/MultiBuilderRegistryTest.java
@@ -1,0 +1,52 @@
+package io.github.eschizoid.kpipe;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.github.eschizoid.kpipe.registry.SchemaResolver;
+import java.util.Properties;
+import org.junit.jupiter.api.Test;
+
+/// Pins the `MultiBuilder` Schema-Registry route overloads (`avro(topic, resolver, cfg)` /
+/// `protobuf(topic, resolver, cfg)`) — the multi-topic mirror of `KPipe.avro/protobuf(...,
+/// resolver)`. Each proves the overload wired a registry-mode format, without needing a broker.
+class MultiBuilderRegistryTest {
+
+  private static final SchemaResolver RESOLVER = schemaId -> "x";
+
+  private static Properties props() {
+    final var props = new Properties();
+    props.setProperty("bootstrap.servers", "localhost:9092");
+    props.setProperty("group.id", "test-group");
+    return props;
+  }
+
+  @Test
+  void avroRegistryRouteWiresTheRegistryModeConsoleUnsupportedFactory() {
+    // A registry-mode Avro format has no fixed schema, so the route's default console-sink factory
+    // is the "unsupported" one. Calling .toConsole() in the configurator triggers it — reachable
+    // only if the resolver overload passed the registry-mode console factory to route().
+    final var multi = KPipe.multi(props());
+    final var ex = assertThrows(IllegalStateException.class, () ->
+      multi.avro("avro-topic", RESOLVER, Stream::toConsole)
+    );
+    assertTrue(
+      ex.getMessage().contains("Schema-Registry mode has none"),
+      "expected the registry-mode console-unsupported error, got: " + ex.getMessage()
+    );
+  }
+
+  @Test
+  void protobufRegistryRouteRequiresTheConfluentCompiler() {
+    // kpipe-api's test path has no kpipe-format-protobuf-confluent, so ProtobufFormat.withRegistry
+    // fails ServiceLoader lookup — reachable only if the resolver overload called withRegistry.
+    final var multi = KPipe.multi(props());
+    final var ex = assertThrows(IllegalStateException.class, () ->
+      multi.protobuf("proto-topic", RESOLVER, s -> s.toCustom(value -> {}))
+    );
+    assertTrue(
+      ex.getMessage().contains("ProtobufDescriptorCompiler"),
+      "expected the ServiceLoader compiler-missing error, got: " + ex.getMessage()
+    );
+  }
+}

--- a/lib/kpipe-consumer/src/main/java/io/github/eschizoid/kpipe/consumer/Dispatcher.java
+++ b/lib/kpipe-consumer/src/main/java/io/github/eschizoid/kpipe/consumer/Dispatcher.java
@@ -27,7 +27,7 @@ import org.apache.kafka.clients.consumer.ConsumerRecord;
 /// backpressure is held.
 ///
 /// **Sealed by design.** The three [ProcessingMode]s form a stable taxonomy covering the known
-/// use cases. Unlike `Tracer` (an open SPI plugged in via `ServiceLoader`), dispatch is NOT a
+/// use cases. Unlike `Tracer` (an open SPI you supply via `withTracer(...)`), dispatch is NOT a
 /// user extension point: a custom mode would need deep hooks into offset commit, backpressure,
 /// and shutdown drain — not a plug-and-play boundary. A new mode is added here and gated by the
 /// full correctness suite, not supplied by users.

--- a/lib/kpipe-consumer/src/main/java/io/github/eschizoid/kpipe/consumer/Dispatcher.java
+++ b/lib/kpipe-consumer/src/main/java/io/github/eschizoid/kpipe/consumer/Dispatcher.java
@@ -25,6 +25,12 @@ import org.apache.kafka.clients.consumer.ConsumerRecord;
 /// retry + DLQ logic). `onComplete` runs after `processTask`, regardless of throws, on
 /// whichever thread executed the task — it's used to unpark the consumer thread when
 /// backpressure is held.
+///
+/// **Sealed by design.** The three [ProcessingMode]s form a stable taxonomy covering the known
+/// use cases. Unlike `Tracer` (an open SPI plugged in via `ServiceLoader`), dispatch is NOT a
+/// user extension point: a custom mode would need deep hooks into offset commit, backpressure,
+/// and shutdown drain — not a plug-and-play boundary. A new mode is added here and gated by the
+/// full correctness suite, not supplied by users.
 sealed interface Dispatcher
   extends AutoCloseable
   permits SequentialDispatcher, ParallelDispatcher, KeyOrderedDispatcher

--- a/lib/kpipe-format-protobuf-confluent/src/main/java/io/github/eschizoid/kpipe/format/protobuf/confluent/ConfluentProtobufDescriptorCompiler.java
+++ b/lib/kpipe-format-protobuf-confluent/src/main/java/io/github/eschizoid/kpipe/format/protobuf/confluent/ConfluentProtobufDescriptorCompiler.java
@@ -1,4 +1,4 @@
-package io.github.eschizoid.kpipe.schemaregistry.confluent.protobuf;
+package io.github.eschizoid.kpipe.format.protobuf.confluent;
 
 import com.google.protobuf.Descriptors.Descriptor;
 import io.confluent.kafka.schemaregistry.protobuf.ProtobufSchema;

--- a/lib/kpipe-format-protobuf-confluent/src/main/resources/META-INF/services/io.github.eschizoid.kpipe.format.protobuf.ProtobufDescriptorCompiler
+++ b/lib/kpipe-format-protobuf-confluent/src/main/resources/META-INF/services/io.github.eschizoid.kpipe.format.protobuf.ProtobufDescriptorCompiler
@@ -1,1 +1,1 @@
-io.github.eschizoid.kpipe.schemaregistry.confluent.protobuf.ConfluentProtobufDescriptorCompiler
+io.github.eschizoid.kpipe.format.protobuf.confluent.ConfluentProtobufDescriptorCompiler

--- a/lib/kpipe-format-protobuf-confluent/src/test/java/io/github/eschizoid/kpipe/format/protobuf/confluent/ConfluentProtobufDescriptorCompilerTest.java
+++ b/lib/kpipe-format-protobuf-confluent/src/test/java/io/github/eschizoid/kpipe/format/protobuf/confluent/ConfluentProtobufDescriptorCompilerTest.java
@@ -1,4 +1,4 @@
-package io.github.eschizoid.kpipe.schemaregistry.confluent.protobuf;
+package io.github.eschizoid.kpipe.format.protobuf.confluent;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;

--- a/lib/kpipe-format-protobuf-confluent/src/test/java/io/github/eschizoid/kpipe/format/protobuf/confluent/ProtobufConfluentWireCompatTest.java
+++ b/lib/kpipe-format-protobuf-confluent/src/test/java/io/github/eschizoid/kpipe/format/protobuf/confluent/ProtobufConfluentWireCompatTest.java
@@ -1,4 +1,4 @@
-package io.github.eschizoid.kpipe.schemaregistry.confluent.protobuf;
+package io.github.eschizoid.kpipe.format.protobuf.confluent;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 

--- a/lib/kpipe-format-protobuf-confluent/src/test/java/io/github/eschizoid/kpipe/format/protobuf/confluent/ProtobufFormatConfluentE2ETest.java
+++ b/lib/kpipe-format-protobuf-confluent/src/test/java/io/github/eschizoid/kpipe/format/protobuf/confluent/ProtobufFormatConfluentE2ETest.java
@@ -1,4 +1,4 @@
-package io.github.eschizoid.kpipe.schemaregistry.confluent.protobuf;
+package io.github.eschizoid.kpipe.format.protobuf.confluent;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 

--- a/lib/kpipe-format-protobuf/src/main/java/io/github/eschizoid/kpipe/format/protobuf/ProtobufFormat.java
+++ b/lib/kpipe-format-protobuf/src/main/java/io/github/eschizoid/kpipe/format/protobuf/ProtobufFormat.java
@@ -56,6 +56,11 @@ public final class ProtobufFormat implements MessageFormat<Message> {
 
   /// Constructs a codec bound to `descriptor` (static mode).
   ///
+  /// There is no `of(String)` factory (unlike `AvroFormat.of(json)`): protobuf-java compiles a
+  /// [Descriptor] only from a binary `FileDescriptorProto`, not from `.proto` source text, so a
+  /// descriptor must be supplied. For per-record schema lookup from `.proto` text, use
+  /// [#withRegistry(SchemaResolver)] with `kpipe-format-protobuf-confluent`.
+  ///
   /// @param descriptor the Protobuf message descriptor used for deserialization (must be non-null)
   public ProtobufFormat(final Descriptor descriptor) {
     this.descriptor = Objects.requireNonNull(descriptor, "descriptor cannot be null");


### PR DESCRIPTION
Non-breaking cleanup from the post-#241 architecture review.

## 1. MultiBuilder Schema-Registry overloads
Adds `MultiBuilder.avro(topic, resolver, cfg)` / `protobuf(topic, resolver, cfg)` mirroring `KPipe.avro/protobuf(…, resolver)`, so a heterogeneous multi-topic consumer can mix SR-backed routes without hand-constructing `AvroFormat.withRegistry(...)`. Wired through the existing `route(...)` with the registry-mode console-unsupported factories. + `MultiBuilderRegistryTest`.

## 2. Package-namespace consistency
Moves `ConfluentProtobufDescriptorCompiler` from `io…schemaregistry.confluent.protobuf` → `io…format.protobuf.confluent` so its package matches its module (`kpipe-format-protobuf-confluent`), consistent with the `metrics.otel` / `tracing.otel` precedent. `META-INF/services` updated; ServiceLoader discovery + the gold-standard `KafkaProtobufSerializer` wire-compat test verified still green.

## 3. Javadoc touch-ups
`Stream.withSchemaRegistry` (~17 MB shaded-jar weight + formats-are-`requires static` opt-in notes), `Stream.toConsole` (registry-mode has no fixed schema), `ProtobufFormat` ctor (no `of()` factory — protobuf-java can't parse `.proto` text), `Dispatcher` (sealed by design, not a user SPI).

Verified: full `assemble testClasses` + affected module tests green; spotless clean.