### PR TITLE
chore: top-5 architecture cleanup (BOM drift, observer leak, MultiBuilder mirrors, batch tracer/CB, benchmarks README)

### DIFF
--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -1,277 +1,145 @@
 # KPipe Benchmarks
 
-JMH benchmarks for KPipe — pipeline efficiency, Avro byte handling, parallel processing, and batch sink throughput. Each
-scenario pits KPipe against either a hand-rolled equivalent or a well-known alternative (Confluent Parallel Consumer) so
-the numbers mean something concrete.
+JMH benchmarks (plus one non-JMH latency harness) for KPipe. Two design-validation benches pit KPipe against a
+hand-rolled straw man; a competitive suite pits KPipe against the alternatives a JVM team would actually pick (Kafka
+Share Consumer, Confluent Parallel Consumer, Reactor Kafka, a raw `KafkaConsumer + virtual threads`, and a
+single-threaded consumer); and three micro-benches isolate internals.
 
-## Benchmark Scenarios
+**The numbers live in [`results/`](results/), dated per capture, not in this file.** Embedding a single run here is how
+the old README drifted out of sync. Read [`METHODOLOGY.md`](METHODOLOGY.md) before quoting any figure — it explains what
+each bench isolates, why fork count matters, and which comparisons are honest.
 
-### 1. JSON Pipeline Efficiency (`JsonPipelineBenchmark`)
+## Benchmark scenarios
 
-Compares KPipe's optimized "Single SerDe Cycle" against traditional byte-to-byte transformation chaining.
+### Design validation (in-memory, no broker)
 
-- **KPipe JSON Pipeline**: Deserializes a `byte[]` once, applies multiple `UnaryOperator<Map<String, Object>>`
-  transformations on the same object, and serializes once back to `byte[]`.
-- **Manual SerDe Chained**: Mimics a "naive" pipeline where each transformation step independently deserializes the
-  input and re-serializes the output (`byte[] -> Object -> byte[]`).
+These are KPipe-vs-straw-man. They show the design choices paid off; they are **not** competitive claims.
 
-### 2. Avro Zero-Copy Handling (`AvroPipelineBenchmark`)
+| Bench                   | `@Benchmark` arms                                                      | What it isolates                                                                                          |
+| ----------------------- | --------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------- |
+| `JsonPipelineBenchmark` | `kpipeJsonPipeline`, `manualJsonSingleSerDe`, `manualJsonSerDeChained` | KPipe's single-SerDe-cycle vs a naive byte→object→byte chain that re-serializes between every operator.   |
+| `AvroPipelineBenchmark` | `kpipeAvroMagicPipeline`, `kpipeAvroPipeline`, `manualAvroMagicHandling` | Zero-copy magic-byte offset handling vs stripping the 5-byte Confluent prefix with `Arrays.copyOfRange`. |
 
-Measures the efficiency of KPipe's magic byte offset handling vs. traditional byte array copying.
+### Competitive suite (Testcontainers `apache/kafka:4.3.0`, Docker required)
 
-- **KPipe Avro Magic Pipeline**: Uses the `offset` parameter in `processAvro` to skip Confluent's 5-byte magic prefix
-  without creating an intermediate array copy.
-- **Manual Avro Magic Handling**: Strips the magic bytes using `Arrays.copyOfRange` before deserialization.
+The broker runs in its own container (its own JVM, its own cores) so it isn't fighting the consumer under test for CPU.
+Each invocation processes **`TARGET_MESSAGES = 25,000`** records across **`TOPIC_PARTITIONS = 8`** partitions, and every
+arm carries `@OperationsPerInvocation(TARGET_MESSAGES)` so JMH reports processed **records/s** directly. A `workMicros`
+`@Param` — `{0, 100, 1000, 10000, 35000, 50000, 100000}` — injects per-record work via `LockSupport.parkNanos`, sweeping
+from pure framework overhead (0 µs) through local enrichment to multi-ms I/O hops. At `workMicros=0` the question is
+"who has the lowest per-record overhead?"; in the 10–100 ms regime it's "who schedules blocking work best?" — usually
+different winners.
 
-### 3. Parallel Processing — Competitive Suite (`ParallelProcessingBenchmark`)
+**`ParallelProcessingBenchmark` — throughput, 9 arms:**
 
-Four parallel-consumer runtimes drink from the same seeded topic on a **Testcontainers-managed Kafka 4.3.0 broker**
-(Docker; broker runs in its own JVM on its own cores so it isn't fighting the consumer under test for CPU):
+| Arm                  | Runtime                                                         | Ordering      |
+| -------------------- | -------------------------------------------------------------- | ------------- |
+| `kpipe`              | KPipe `PARALLEL` — virtual-thread-per-record (Loom), no pool   | none          |
+| `kpipeKeyOrdered`    | KPipe `KEY_ORDERED` — per-key serial queues, VT-drained        | per-key       |
+| `share`             | Kafka Share Consumer (KIP-932) + `newVirtualThreadPerTaskExecutor` | none      |
+| `confluent`          | Confluent Parallel Consumer, `ProcessingOrder.UNORDERED` (100-worker pool) | none |
+| `confluentKey`       | Confluent PC, `ProcessingOrder.KEY`                            | per-key       |
+| `confluentPartition` | Confluent PC, `ProcessingOrder.PARTITION`                     | per-partition |
+| `reactor`            | Reactor Kafka, `Flux.parallel(100)`                           | none          |
+| `raw`                | Raw `KafkaConsumer` + `newVirtualThreadPerTaskExecutor`      | none          |
+| `singleThread`       | Single-threaded `KafkaConsumer`, inline processing (the floor) | per-partition |
 
-- **KPipe** — virtual-thread-per-record on Loom; no pool, no queue.
-- **Confluent Parallel Consumer** — `ProcessingOrder.UNORDERED` with a 100-worker pool. The de-facto industry baseline.
-- **Reactor Kafka** — `Flux<ReceiverRecord>` on the Reactor `parallel` scheduler with a matching concurrency limit.
-- **Raw `KafkaConsumer` + `newVirtualThreadPerTaskExecutor`** — the hand-rolled baseline. No framework, no offset
-  manager. Establishes the floor of "what if I just wrote the loop myself?"
+**`ParallelProcessingLatencyBenchmark` — latency, 4 arms** (`kpipe`, `confluent`, `reactor`, `raw`): declares
+`@BenchmarkMode({SampleTime, AverageTime})` and reports p50/p95/p99 of **whole-invocation** completion time (batch
+amortized — divide by `TARGET_MESSAGES` for a rough per-record figure).
 
-A `workMicros` `@Param` (`0`, `100`, `1000`) injects per-record work via `LockSupport.parkNanos` so the bench covers
-three workload regimes: pure framework overhead (0 µs), local enrichment (100 µs), and blocking I/O round trip (1000
-µs). At `workMicros=0` the comparison is "who has the lowest per-record overhead?"; at `workMicros=1000` it's "who
-schedules blocking work best?" — those two questions usually have different winners.
+**`PerRecordLatencyHarness` — true per-record tail latency (NOT JMH).** A plain `main()` harness, because JMH can't
+ingest tens of thousands of externally-measured timestamp pairs. Producer stamps each record's intended send slot
+(coordinated-omission corrected); the sink measures `now − stamp` after the simulated work, retains every sample in a
+`long[]`, and sorts once for exact p50/p95/p99/max. Arms: `kpipeParallel`, `kpipeKeyOrdered`, `confluentUnordered`,
+`rawVirtualThreads`. See [Running](#running-benchmarks) below.
 
-Each invocation processes **25,000 records** across **8 partitions**. Because the broker is in its own container (not
-in-process), pushing the record count higher actually scales the consumer workload instead of bottlenecking on broker
-contention. **Docker must be running** before invoking the bench; Testcontainers will pull `apache/kafka:4.3.0` and
-start the container at trial setup.
+### Micro-benchmarks (MockConsumer, no broker)
 
-### 4. Batch Sink Throughput (`BatchSinkLatencyBenchmark`)
+| Bench                        | Arm / `@Benchmark` | `@Param` sweep                                                | What it isolates                                                                                            |
+| ---------------------------- | ------------------ | ------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------- |
+| `BatchSinkLatencyBenchmark`  | `run`              | `sinkLatencyMicros ∈ {10,100,1000}`, `batchSize ∈ {1,10,100}` | The `Stream.toBatch(...)` amortisation when the destination has a per-call cost (`batchSize=1` is the control). |
+| `KeyOrderedDispatchBenchmark`| `dispatch`         | `mode ∈ {PARALLEL, KEY_ORDERED}`, key cardinality `{1,100,10000}` | The single-`ReentrantLock` cost of the `KEY_ORDERED` dispatcher vs `PARALLEL` (the striped-locking baseline). |
+| `OffsetManagerBoxingBenchmark`| `trackAndMark`    | partitions `{8}`                                              | Allocation/boxing cost on the offset-tracking hot path.                                                     |
 
-Quantifies the win from `Stream.toBatch(...)` when the destination has nontrivial per-call cost. The benchmark
-parameterises over batch size (1 / 10 / 100) and a simulated sink latency (10 / 100 / 1000 µs) — the sink calls
-`LockSupport.parkNanos(latency)` once per batch regardless of size, mirroring JDBC commits, HTTP POSTs, and S3 PUTs
-where wall-clock cost is dominated by a per-call round trip rather than per-record CPU.
+## Running benchmarks
 
-A no-op sink would give a misleading result here (per-record overhead becomes the only cost), so the bench deliberately
-inserts the per-call latency to expose the amortisation that batching provides.
-
-#### Results (Apple Silicon, JDK 25.0.2, single fork, 3×2s warmup + 5×3s measurement)
-
-| batchSize | sinkLatencyMicros | Throughput (ops/s) | Speedup vs batchSize=1 |
-| --------: | ----------------: | -----------------: | ---------------------: |
-|         1 |                10 |             28,018 |                  1.00× |
-|         1 |               100 |              6,885 |                  1.00× |
-|         1 |              1000 |                788 |                  1.00× |
-|        10 |                10 |            264,606 |                   9.4× |
-|        10 |               100 |             63,813 |                   9.3× |
-|        10 |              1000 |              7,778 |                   9.9× |
-|       100 |                10 |            605,458 |                  21.6× |
-|       100 |               100 |            361,636 |                  52.5× |
-|       100 |              1000 |             66,059 |                  83.9× |
-
-The story is exactly what the design promised: at 1000 µs/call (think a slow JDBC commit) batching at size 100 is **~84×
-the throughput** of single-record processing. At 10 µs/call batching still helps, but the gain shrinks because per-call
-cost is no longer the bottleneck.
-
-## Running Benchmarks
-
-To run all benchmarks with default JMH settings:
+Run everything with the default JMH settings (warmup 3 · iterations 5 · fork 1 · threads 1):
 
 ```bash
 ./gradlew :benchmarks:jmh
 ```
 
-### Running Specific Benchmarks
-
-You can use regex to target specific benchmark classes using the `jmh.includes` property:
+Target specific benchmarks with a regex over the fully-qualified name (`@Param` values are **not** part of the FQN and
+can't be filtered this way):
 
 ```bash
-# Run only JSON benchmarks
+# A design-validation bench (no Docker needed)
 ./gradlew :benchmarks:jmh -Pjmh.includes='JsonPipelineBenchmark'
 
-# Run only Avro benchmarks
-./gradlew :benchmarks:jmh -Pjmh.includes='AvroPipelineBenchmark'
-
-# Run only Parallel Processing benchmarks
+# The whole competitive throughput suite (Docker required)
 ./gradlew :benchmarks:jmh -Pjmh.includes='ParallelProcessingBenchmark'
+
+# A single arm — the `$` anchor keeps `confluent` from also matching `confluentKey`/`confluentPartition`
+./gradlew :benchmarks:jmh -Pjmh.includes='ParallelProcessingBenchmark\.kpipe$' -Pjmh.fork=1 -Pjmh.iterations=1
 ```
 
-### Adjusting Benchmark Parameters
+Common overrides: `-Pjmh.iterations`, `-Pjmh.warmupIterations`, `-Pjmh.fork`, `-Pjmh.profilers='gc'`,
+`-Pjmh.resultFormat=JSON`, and `-Pjmh.workMicros='0,100,1000'` to run only a subset of the `workMicros` cells (CI uses
+this to skip the multi-ms regime that blows past the job cap). The full matrix of recommended publishing / CI / smoke
+runs is in [`METHODOLOGY.md`](METHODOLOGY.md#jmh-configuration).
 
-JMH parameters can be configured in `benchmarks/build.gradle.kts` or passed via the command line:
+Per-record tail latency uses its own task (not `jmh`), and reuses the suite's Testcontainers broker (Docker required):
 
 ```bash
-# Example: 1 iteration, 1 warmup, 1 fork
-./gradlew :benchmarks:jmh -Pjmh.iterations=1 -Pjmh.warmupIterations=1 -Pjmh.fork=1
+./gradlew :benchmarks:perRecordLatency \
+  -Platency.workMicros=100 \
+  -Platency.ratePerSecond=2000 \
+  -Platency.warmupRecords=5000 \
+  -Platency.measuredRecords=20000 \
+  -Platency.arms=kpipeParallel,kpipeKeyOrdered,confluentUnordered,rawVirtualThreads
 ```
 
-## Latest Results (Snapshot)
+All properties are optional (values above are the defaults). Results print as a table and land in
+`benchmarks/build/results/per-record-latency/results.json`.
 
-Run date: `2026-05-09` · Apple Silicon · JDK 25.0.2 · single fork · 3×2s warmup + 5×3s measurement (`Cnt = 5`).
+## Results
 
-### 1. Avro Pipeline: The "Zero-Copy" Advantage
+Captured runs live in [`results/`](results/), one dated markdown snapshot (plus raw JSON) per capture — read the most
+recent one, and read the **ordering**, not the absolutes, for any CI-runner capture. Every snapshot records the box, JDK,
+fork count, and `workMicros` cells per the [publishing checklist](METHODOLOGY.md#what-to-write-down-with-every-published-number).
 
-This benchmark compares KPipe's zero-copy offset-based deserialization against the traditional approach of using
-`Arrays.copyOfRange`.
-
-> **Bench fix in this snapshot.** The previous snapshot's headline numbers (~740M ops/s / ~351M ops/s) were not real —
-> `@Setup` wrote to a `BinaryEncoder` without calling `flush()`, so `out.toByteArray()` returned an empty array. Earlier
-> versions of `AvroFormat.deserialize` silently returned `null` on empty input; the manual path's `serialize(null)` then
-> NPE'd, but the older `AvroFormat.serialize(null)` happened to no-op. Both crashes were timed as "fast work," producing
-> numbers that looked impressive but measured nothing. Adding `encoder.flush()` in `@Setup` produces the realistic
-> numbers below.
-
-| Benchmark                                       |    Mode | Cnt |        Score |          Error |   Units |
-| ----------------------------------------------- | ------: | --: | -----------: | -------------: | ------: |
-| `AvroPipelineBenchmark.kpipeAvroMagicPipeline`  | `thrpt` | `5` | `926,454.03` | `± 255,156.10` | `ops/s` |
-| `AvroPipelineBenchmark.kpipeAvroPipeline`       | `thrpt` | `5` | `806,103.53` | `± 308,309.30` | `ops/s` |
-| `AvroPipelineBenchmark.manualAvroMagicHandling` | `thrpt` | `5` | `676,133.95` | `± 662,309.38` | `ops/s` |
-
-**Observation**: KPipe's zero-copy magic-byte handling is **~1.37× faster** than the manual `Arrays.copyOfRange`
-strip-and-reparse approach. The error band on the manual path is wide because allocation pressure interacts with GC
-pauses unpredictably; the gap is real but smaller than the previous (broken) snapshot's `~2.1×` claim.
-
-### 2. JSON Pipeline: Defeating the "SerDe Tax"
-
-This benchmark measures the cost of chaining multiple transformations.
-
-| Benchmark                                      |    Mode | Cnt |        Score |          Error |   Units |
-| ---------------------------------------------- | ------: | --: | -----------: | -------------: | ------: |
-| `JsonPipelineBenchmark.kpipeJsonPipeline`      | `thrpt` | `5` | `241,973.45` | `± 112,445.20` | `ops/s` |
-| `JsonPipelineBenchmark.manualJsonSerDeChained` | `thrpt` | `5` |  `78,396.78` |  `± 38,829.91` | `ops/s` |
-| `JsonPipelineBenchmark.manualJsonSingleSerDe`  | `thrpt` | `5` | `200,700.24` | `± 202,444.52` | `ops/s` |
-
-**Observation**: KPipe is **~3.1× faster** than a naive chained approach (`manualJsonSerDeChained`) and roughly on par
-with the manual single-SerDe implementation (`manualJsonSingleSerDe`) — the latter overlaps within error in this
-single-fork run. Both confirm KPipe's operator chaining adds no measurable SerDe tax on top of a bespoke single-pass
-implementation.
-
-### 3. Parallel Processing: Virtual Threads (Loom) vs. Confluent
-
-This benchmark compares KPipe's "thread-per-record" model using Java Virtual Threads against the industry-standard
-Confluent Parallel Consumer.
-
-| Benchmark                                                 |    Mode | Cnt |       Score |       Error |   Units |
-| --------------------------------------------------------- | ------: | --: | ----------: | ----------: | ------: |
-| `ParallelProcessingBenchmark.confluentParallelProcessing` | `thrpt` | `5` | `3,110.974` | `± 400.967` | `ops/s` |
-| `ParallelProcessingBenchmark.kpipeParallelProcessing`     | `thrpt` | `5` | `3,268.037` |  `± 83.313` | `ops/s` |
-
-**Observation**: With `10,000` messages per invocation and `8` partitions, this run shows a measurable throughput edge
-for KPipe (**~5.0%** over Confluent) with notably tighter variance (`±83` vs `±401`). KPipe's score is also more stable
-across iterations — Confluent's wider error band reflects iteration-to-iteration spread on the embedded Kafka broker.
-
-### 4. Batch Sink Throughput
-
-See § 4 above (`BatchSinkLatencyBenchmark`) for the size × latency parameter sweep. Headline: at
-`sinkLatencyMicros=1000` (≈ JDBC commit), `batchSize=100` yields **~84× the throughput** of `batchSize=1`.
-
-## Reading the numbers
-
-Throughput mode (`ops/s`). Bigger is better.
-
-### Projected messages per second
-
-- **Avro (In-Memory)**: Up to **~926,000 records/s** with zero-copy magic-byte handling. JSON beats this in absolute
-  ops/s here because the JSON bench applies two operators per record while the Avro bench applies two operators on a
-  larger payload — comparing benches with different shapes is unfair, but the within-benchmark KPipe-vs-manual ratio is
-  the headline number.
-- **JSON (In-Memory)**: Up to **~242,000 records/s** with the KPipe single-SerDe pipeline (3.1× the chained-SerDe
-  baseline).
-- **End-to-End Parallel Processing**: **~3,111 to ~3,268 records/s**. `ParallelProcessingBenchmark` uses
-  `@OperationsPerInvocation(TARGET_MESSAGES)`, so JMH already reports processed records per second.
-- **Batch Sink (Slow Destination)**: At a 1ms-per-call simulated sink, batching at size 100 reaches **~66,000 batches/s
-  ≈ 6.6M records/s**, vs **~788 records/s** for size 1. Batching wins big when destination cost dominates.
-
-> **Note**: The `ParallelProcessingBenchmark` uses `@OperationsPerInvocation(TARGET_MESSAGES)` where
-> `TARGET_MESSAGES = 25_000`. JMH already normalises for that, so the reported `ops/s` is the message rate.
-
-A few things worth keeping in mind when comparing runs:
-
-- **SerDe tax** shows up as throughput drop-off when you chain more transformations on the manual pipeline vs. KPipe's
-  single-deserialize approach.
-- **GC pressure** isn't on the throughput chart but matters for the Avro zero-copy bench — fewer copies means fewer
-  allocations means less GC noise.
-- **Concurrency scaling** between parallel and sequential modes only tells you something useful when the workload fits
-  more than one core's worth of work.
-- **Embedded Kafka** keeps runs repeatable and fast, at the cost of not exercising real network/SSL paths.
-- **Timing fairness for parallel benches**: both `kpipeParallelProcessing` and `confluentParallelProcessing` run their
-  processing loops inside the benchmark method (not `@Setup`), so startup-to-completion is measured the same way for
-  both.
-- **Throughput normalization**: `ParallelProcessingBenchmark` uses `@OperationsPerInvocation(TARGET_MESSAGES)`, so the
-  reported `ops/s` is already per processed message, not per full invocation.
-- **Logging noise**: the KPipe parallel bench uses a no-op sink so console I/O doesn't bend the numbers.
-- **CPU counters (Linux only)**: `perfnorm` gives normalized CPI / cycles / instructions. macOS can't supply those via
-  JMH, so don't quote CPI on a macOS run.
-
-## Requirements
-
-- **Java 24+**
-- **Gradle**: Used to compile and execute the benchmark harness.
-
-### CPU/CPI Profiling For Parallel Benchmark
-
-For KPipe vs Confluent parallel processing, keep the benchmark target fixed and enable a profiler:
-
-```bash
-# Linux: collect normalized hardware counters (includes CPI)
-./gradlew :benchmarks:jmh \
-  -Pjmh.includes='ParallelProcessingBenchmark' \
-  -Pjmh.profilers='perfnorm' \
-  -Pjmh.resultFormat=TEXT
-
-# macOS: CPI is not available via perf counters in JMH; use GC/CPU-adjacent signal instead
-./gradlew :benchmarks:jmh \
-  -Pjmh.includes='ParallelProcessingBenchmark' \
-  -Pjmh.profilers='gc' \
-  -Pjmh.resultFormat=TEXT
-```
-
-You can also use the helper script:
-
-```bash
-# Linux (CPI mode)
-PROFILE_MODE=cpi INCLUDES='ParallelProcessingBenchmark' ./scripts/run-benchmarks.sh
-
-# macOS (falls back from cpi -> gc with a warning)
-PROFILE_MODE=cpi INCLUDES='ParallelProcessingBenchmark' ./scripts/run-benchmarks.sh
-
-# Heap/allocation view (portable)
-PROFILE_MODE=heap INCLUDES='ParallelProcessingBenchmark' ./scripts/run-benchmarks.sh
-
-# Thread/runtime view (HotSpot)
-PROFILE_MODE=threads INCLUDES='ParallelProcessingBenchmark' ./scripts/run-benchmarks.sh
-```
-
-Supported `PROFILE_MODE` values in `scripts/run-benchmarks.sh`:
-
-- `none`: no JMH profiler
-- `gc`: allocation and GC counters (`gc`)
-- `heap`: allocation/GC plus HotSpot GC internals (`gc,hs_gc`)
-- `threads`: HotSpot thread/runtime signal (`hs_thr,hs_rt`)
-- `cpi`: Linux `perfnorm` (falls back to `gc` on macOS)
-
-Interpretation guidance for KPipe vs Confluent:
-
-- Throughput (`ops/s`) remains the primary metric.
-- On Linux, `perfnorm` adds normalized counters; compare CPI (`cycles`/`instructions`) between both benchmarks.
-- Lower CPI at similar throughput usually indicates better instruction-path efficiency.
-- On macOS, use throughput plus GC metrics; do not claim CPI without Linux perf counters.
-
-### Parallel Comparison Graph
-
-The latest visual comparison for KPipe vs Confluent parallel processing is at:
-
-- `benchmarks/graphs/parallel_processing_gc_comparison.svg`
+The latest KPipe-vs-alternatives visual is regenerated from a `gc`-profiled `ParallelProcessingBenchmark` run:
 
 ![KPipe vs Confluent Parallel Benchmark](graphs/parallel_processing_gc_comparison.svg)
 
-To regenerate source benchmark results before producing/refreshing the graph:
+## Profiling (parallel suite)
+
+Keep the target fixed and attach a profiler. CPI/hardware counters are Linux-only (`perfnorm`); macOS can't supply them
+through JMH, so don't quote CPI from a macOS run — use `gc` there instead.
 
 ```bash
-./gradlew :benchmarks:jmh \
-  -Pjmh.includes='ParallelProcessingBenchmark' \
-  -Pjmh.profilers='gc' \
-  -Pjmh.resultFormat=TEXT
+# Linux: normalized hardware counters (includes CPI = cycles/instructions)
+./gradlew :benchmarks:jmh -Pjmh.includes='ParallelProcessingBenchmark' -Pjmh.profilers='perfnorm' -Pjmh.resultFormat=TEXT
+
+# macOS: allocation / GC signal instead
+./gradlew :benchmarks:jmh -Pjmh.includes='ParallelProcessingBenchmark' -Pjmh.profilers='gc' -Pjmh.resultFormat=TEXT
 ```
 
-> Note: JMH output is written to `benchmarks/build/results/jmh/results.<resultFormat lowercase>`. For `TEXT`, the file
-> is typically `benchmarks/build/results/jmh/results.text`.
+The `scripts/run-benchmarks.sh` helper wraps these via `PROFILE_MODE` (`none` / `gc` / `heap` / `threads` / `cpi`, the
+last falling back to `gc` on macOS):
+
+```bash
+PROFILE_MODE=cpi   INCLUDES='ParallelProcessingBenchmark' ./scripts/run-benchmarks.sh
+PROFILE_MODE=heap  INCLUDES='ParallelProcessingBenchmark' ./scripts/run-benchmarks.sh
+```
+
+> JMH output is written to `benchmarks/build/results/jmh/results.<resultFormat lowercase>` (e.g. `results.json`).
+
+## Requirements
+
+- **Java 25** (the project toolchain; benchmarks compile at `--release 25`).
+- **Gradle** — compiles and runs the harness (use the wrapper, `./gradlew`).
+- **Docker** — required for the competitive suite (`ParallelProcessingBenchmark`, `ParallelProcessingLatencyBenchmark`)
+  and `perRecordLatency`; Testcontainers pulls `apache/kafka:4.3.0`. The design-validation and micro-benches run
+  in-memory and need no broker.

--- a/lib/kpipe-api/src/main/java/io/github/eschizoid/kpipe/DefaultBatchSink.java
+++ b/lib/kpipe-api/src/main/java/io/github/eschizoid/kpipe/DefaultBatchSink.java
@@ -13,7 +13,8 @@ import java.util.Objects;
 /// [KPipeConsumer.Builder#withBatchPipeline] together with the configured [BatchSink] and
 /// [BatchPolicy]. Honors whatever processing mode the underlying [DefaultStream] carries
 /// (default: parallel); consumer-level config (metrics, errorHandler, DLQ, pollTimeout, retry,
-/// backpressure) carries over too.
+/// backpressure, tracer, circuit breaker) carries over too via
+/// [DefaultStream#applyCommonConsumerConfig].
 ///
 /// `Stream.toBatch(...)` produces a single-topic instance. [MultiBuilder] also constructs single-
 /// topic instances per route and collects them at `start()` time into one consumer subscribing

--- a/lib/kpipe-api/src/main/java/io/github/eschizoid/kpipe/DefaultSink.java
+++ b/lib/kpipe-api/src/main/java/io/github/eschizoid/kpipe/DefaultSink.java
@@ -33,8 +33,6 @@ record DefaultSink<T>(DefaultStream<T> stream, MessageSink<T> terminalSink) impl
       .withKeyOrderedMaxKeys(stream.keyOrderedMaxKeys());
 
     stream.applyCommonConsumerConfig(consumerBuilder);
-    if (stream.tracer() != null) consumerBuilder.withTracer(stream.tracer());
-    if (stream.circuitBreaker() != null) consumerBuilder.withCircuitBreaker(stream.circuitBreaker());
 
     return DefaultHandle.startAndWrap(consumerBuilder.build());
   }

--- a/lib/kpipe-api/src/main/java/io/github/eschizoid/kpipe/DefaultStream.java
+++ b/lib/kpipe-api/src/main/java/io/github/eschizoid/kpipe/DefaultStream.java
@@ -306,10 +306,11 @@ record DefaultStream<T>(
     });
   }
 
-  /// Applies the consumer-level config that both [DefaultSink] and [DefaultBatchSink] share onto
-  /// `builder`: retry, backpressure, metrics, error handler, dead-letter topic, poll timeout.
-  /// Tracer and circuit-breaker are NOT applied here — they're only wired by [DefaultSink];
-  /// `DefaultBatchSink` historically does not expose them (would change behavior to add).
+  /// Applies every consumer-level setting that both [DefaultSink] and [DefaultBatchSink] share onto
+  /// `builder`: retry, backpressure, metrics, error handler, dead-letter topic, poll timeout,
+  /// tracer, and circuit breaker. All are consumer-wide, so wiring them from one place keeps the
+  /// two sink types from drifting — the batch path previously skipped tracer and circuit breaker,
+  /// silently dropping both when set on a `toBatch(...)` stream.
   void applyCommonConsumerConfig(final KPipeConsumer.Builder builder) {
     if (maxRetries > 0) builder.withRetry(maxRetries, retryBackoff);
     if (backpressureHigh != null) builder.withBackpressure(backpressureHigh, backpressureLow);
@@ -317,6 +318,8 @@ record DefaultStream<T>(
     if (errorHandler != null) builder.withErrorHandler(errorHandler::accept);
     if (deadLetterTopic != null) builder.withDeadLetterTopic(deadLetterTopic);
     if (pollTimeout != null) builder.withPollTimeout(pollTimeout);
+    if (tracer != null) builder.withTracer(tracer);
+    if (circuitBreaker != null) builder.withCircuitBreaker(circuitBreaker);
   }
 
   /// Single funnel for every wither: snapshot this record into a [Mut], let the caller change

--- a/lib/kpipe-api/src/main/java/io/github/eschizoid/kpipe/MultiBuilder.java
+++ b/lib/kpipe-api/src/main/java/io/github/eschizoid/kpipe/MultiBuilder.java
@@ -1,6 +1,7 @@
 package io.github.eschizoid.kpipe;
 
 import com.google.protobuf.Message;
+import io.github.eschizoid.kpipe.consumer.BackpressureController;
 import io.github.eschizoid.kpipe.consumer.CircuitBreakerController;
 import io.github.eschizoid.kpipe.consumer.KPipeConsumer;
 import io.github.eschizoid.kpipe.consumer.ProcessingMode;
@@ -15,11 +16,13 @@ import io.github.eschizoid.kpipe.registry.SchemaResolver;
 import io.github.eschizoid.kpipe.sink.MessageSink;
 import java.lang.System.Logger;
 import java.lang.System.Logger.Level;
+import java.time.Duration;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Properties;
 import java.util.Set;
+import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Supplier;
 import org.apache.avro.generic.GenericRecord;
@@ -51,6 +54,13 @@ public final class MultiBuilder {
   private CircuitBreakerController circuitBreaker;
   private ProcessingMode processingMode = ProcessingMode.PARALLEL;
   private Integer keyOrderedMaxKeys;
+  private Integer maxRetries;
+  private Duration retryBackoff;
+  private Long backpressureHigh;
+  private Long backpressureLow;
+  private Consumer<KPipeConsumer.ProcessingError> errorHandler;
+  private String deadLetterTopic;
+  private Duration pollTimeout;
 
   MultiBuilder(final Properties kafkaProps) {
     this.kafkaProps = (Properties) Objects.requireNonNull(kafkaProps, "kafkaProps cannot be null").clone();
@@ -111,6 +121,79 @@ public final class MultiBuilder {
   public MultiBuilder withKeyOrderedMaxKeys(final int maxKeys) {
     if (maxKeys <= 0) throw new IllegalArgumentException("maxKeys must be positive, got " + maxKeys);
     this.keyOrderedMaxKeys = maxKeys;
+    return this;
+  }
+
+  /// Retries a failing record up to `maxRetries` times with a fixed `backoff` before routing it to
+  /// the DLQ (or logging, if none). Consumer-wide — the same policy applies to every route, mirror
+  /// of `Stream.withRetry(int, Duration)`.
+  ///
+  /// @param maxRetries retry attempts after the first failure (must be non-negative)
+  /// @param backoff delay between attempts (must be non-null)
+  /// @return this builder
+  public MultiBuilder withRetry(final int maxRetries, final Duration backoff) {
+    if (maxRetries < 0) throw new IllegalArgumentException("maxRetries cannot be negative");
+    this.maxRetries = maxRetries;
+    this.retryBackoff = Objects.requireNonNull(backoff, "backoff cannot be null");
+    return this;
+  }
+
+  /// Enables in-flight backpressure with the default watermarks (pause at
+  /// `BackpressureController.DEFAULT_HIGH_WATERMARK`, resume at `DEFAULT_LOW_WATERMARK`). Mirror of
+  /// `Stream.withBackpressure()`.
+  ///
+  /// @return this builder
+  public MultiBuilder withBackpressure() {
+    return withBackpressure(
+      BackpressureController.DEFAULT_HIGH_WATERMARK,
+      BackpressureController.DEFAULT_LOW_WATERMARK
+    );
+  }
+
+  /// Enables backpressure with custom high/low watermarks (hysteresis). The strategy is derived
+  /// from the consumer's processing mode. Consumer-wide, mirror of
+  /// `Stream.withBackpressure(long, long)`.
+  ///
+  /// @param high pause watermark (must be > low)
+  /// @param low resume watermark (must be >= 0 and < high)
+  /// @return this builder
+  public MultiBuilder withBackpressure(final long high, final long low) {
+    if (low < 0 || low >= high) throw new IllegalArgumentException(
+      "withBackpressure requires high > low > 0 (got high=%d, low=%d)".formatted(high, low)
+    );
+    this.backpressureHigh = high;
+    this.backpressureLow = low;
+    return this;
+  }
+
+  /// Sets a custom error handler invoked (after offset marking) for every record that fails on any
+  /// route. Consumer-wide, mirror of `Stream.withErrorHandler(...)`; default logs at WARNING.
+  ///
+  /// @param handler the error callback (must be non-null)
+  /// @return this builder
+  public MultiBuilder withErrorHandler(final Consumer<KPipeConsumer.ProcessingError> handler) {
+    this.errorHandler = Objects.requireNonNull(handler, "handler cannot be null");
+    return this;
+  }
+
+  /// Routes records that exhaust their retries to `dlqTopic`. One DLQ for the whole consumer (there
+  /// is no per-route DLQ), mirror of `Stream.withDeadLetterTopic(String)`.
+  ///
+  /// @param dlqTopic the dead-letter topic (must be non-null and non-blank)
+  /// @return this builder
+  public MultiBuilder withDeadLetterTopic(final String dlqTopic) {
+    if (dlqTopic == null || dlqTopic.isBlank()) throw new IllegalArgumentException("dlqTopic cannot be null or blank");
+    this.deadLetterTopic = dlqTopic;
+    return this;
+  }
+
+  /// Sets the Kafka poll timeout for the underlying consumer. Consumer-wide (one poll loop), mirror
+  /// of `Stream.withPollTimeout(Duration)`; default 100ms.
+  ///
+  /// @param timeout the poll timeout (must be non-null)
+  /// @return this builder
+  public MultiBuilder withPollTimeout(final Duration timeout) {
+    this.pollTimeout = Objects.requireNonNull(timeout, "timeout cannot be null");
     return this;
   }
 
@@ -282,6 +365,11 @@ public final class MultiBuilder {
     if (consumerMetrics != null) consumerBuilder.withMetrics(consumerMetrics);
     if (tracer != null) consumerBuilder.withTracer(tracer);
     if (circuitBreaker != null) consumerBuilder.withCircuitBreaker(circuitBreaker);
+    if (maxRetries != null && maxRetries > 0) consumerBuilder.withRetry(maxRetries, retryBackoff);
+    if (backpressureHigh != null) consumerBuilder.withBackpressure(backpressureHigh, backpressureLow);
+    if (errorHandler != null) consumerBuilder.withErrorHandler(errorHandler::accept);
+    if (deadLetterTopic != null) consumerBuilder.withDeadLetterTopic(deadLetterTopic);
+    if (pollTimeout != null) consumerBuilder.withPollTimeout(pollTimeout);
     return DefaultHandle.startAndWrap(consumerBuilder.build());
   }
 
@@ -321,18 +409,20 @@ public final class MultiBuilder {
     if (stream.circuitBreaker() != null) throw new IllegalArgumentException(
       perRouteRejection(topic, "withCircuitBreaker", "MultiBuilder.withCircuitBreaker(...)")
     );
-    if (stream.maxRetries() > 0) throw new IllegalArgumentException(perRouteRejectionDeferred(topic, "withRetry"));
+    if (stream.maxRetries() > 0) throw new IllegalArgumentException(
+      perRouteRejection(topic, "withRetry", "MultiBuilder.withRetry(...)")
+    );
     if (stream.backpressureHigh() != null) throw new IllegalArgumentException(
-      perRouteRejectionDeferred(topic, "withBackpressure")
+      perRouteRejection(topic, "withBackpressure", "MultiBuilder.withBackpressure(...)")
     );
     if (stream.deadLetterTopic() != null) throw new IllegalArgumentException(
-      perRouteRejectionDeferred(topic, "withDeadLetterTopic")
+      perRouteRejection(topic, "withDeadLetterTopic", "MultiBuilder.withDeadLetterTopic(...)")
     );
     if (stream.errorHandler() != null) throw new IllegalArgumentException(
-      perRouteRejectionDeferred(topic, "withErrorHandler")
+      perRouteRejection(topic, "withErrorHandler", "MultiBuilder.withErrorHandler(...)")
     );
     if (stream.pollTimeout() != null) throw new IllegalArgumentException(
-      perRouteRejectionDeferred(topic, "withPollTimeout")
+      perRouteRejection(topic, "withPollTimeout", "MultiBuilder.withPollTimeout(...)")
     );
   }
 
@@ -342,17 +432,6 @@ public final class MultiBuilder {
     return (
       "Route '%s' sets %s on its Stream, but %s is a consumer-wide setting; ".formatted(topic, setting, setting) +
       "set it on %s instead.".formatted(mirror)
-    );
-  }
-
-  /// Builds the rejection message for a per-route setting that does NOT yet have a symmetric
-  /// `MultiBuilder.with*` mirror. Point the user at the explicit `KPipeConsumer.Builder` escape
-  /// hatch and note the open follow-up.
-  private static String perRouteRejectionDeferred(final String topic, final String setting) {
-    return (
-      "Route '%s' sets %s on its Stream, but %s is a consumer-wide setting; ".formatted(topic, setting, setting) +
-      "configure via the explicit KPipeConsumer.Builder for the homogeneous case, " +
-      "or wait for the multi-builder mirror (open issue)."
     );
   }
 

--- a/lib/kpipe-api/src/test/java/io/github/eschizoid/kpipe/KPipeFacadeBuildTest.java
+++ b/lib/kpipe-api/src/test/java/io/github/eschizoid/kpipe/KPipeFacadeBuildTest.java
@@ -168,9 +168,10 @@ class KPipeFacadeBuildTest {
 
   // --- per-route consumer-wide-setting rejection ---
   // Every public consumer-wide setting reachable from the per-route Stream is silently dropped
-  // by the original MultiBuilder.start() — it only invokes ds.buildPipeline() / addBatchRoute()
-  // and never replays the route's consumer-level config onto the underlying single
-  // KPipeConsumer.Builder. The tests below pin each setting to fail loud rather than disappear.
+  // by MultiBuilder.start() — it only invokes ds.buildPipeline() / addBatchRoute() and never
+  // replays a route's consumer-level config onto the underlying single KPipeConsumer.Builder.
+  // The tests below pin each setting to fail loud rather than disappear, and to point the user at
+  // the symmetric MultiBuilder.with* setter (all of these now have one).
 
   @Test
   void multiBuilderRejectsPerRouteWithRetry() {
@@ -184,8 +185,8 @@ class KPipeFacadeBuildTest {
       () -> "message should name the offending route: " + ex.getMessage()
     );
     assertTrue(
-      ex.getMessage().contains("KPipeConsumer.Builder"),
-      () -> "message should point users at the explicit-builder escape hatch: " + ex.getMessage()
+      ex.getMessage().contains("MultiBuilder.withRetry"),
+      () -> "message should point users at the consumer-level setter: " + ex.getMessage()
     );
   }
 
@@ -198,6 +199,10 @@ class KPipeFacadeBuildTest {
       () -> "message should name withBackpressure: " + ex.getMessage()
     );
     assertTrue(ex.getMessage().contains("'topic-a'"), () -> "message should name the route: " + ex.getMessage());
+    assertTrue(
+      ex.getMessage().contains("MultiBuilder.withBackpressure"),
+      () -> "message should point users at the consumer-level setter: " + ex.getMessage()
+    );
   }
 
   @Test
@@ -209,6 +214,10 @@ class KPipeFacadeBuildTest {
       () -> "message should name withDeadLetterTopic: " + ex.getMessage()
     );
     assertTrue(ex.getMessage().contains("'topic-a'"), () -> "message should name the route: " + ex.getMessage());
+    assertTrue(
+      ex.getMessage().contains("MultiBuilder.withDeadLetterTopic"),
+      () -> "message should point users at the consumer-level setter: " + ex.getMessage()
+    );
   }
 
   @Test
@@ -220,6 +229,10 @@ class KPipeFacadeBuildTest {
       () -> "message should name withErrorHandler: " + ex.getMessage()
     );
     assertTrue(ex.getMessage().contains("'topic-a'"), () -> "message should name the route: " + ex.getMessage());
+    assertTrue(
+      ex.getMessage().contains("MultiBuilder.withErrorHandler"),
+      () -> "message should point users at the consumer-level setter: " + ex.getMessage()
+    );
   }
 
   @Test
@@ -233,6 +246,27 @@ class KPipeFacadeBuildTest {
       () -> "message should name withPollTimeout: " + ex.getMessage()
     );
     assertTrue(ex.getMessage().contains("'topic-a'"), () -> "message should name the route: " + ex.getMessage());
+    assertTrue(
+      ex.getMessage().contains("MultiBuilder.withPollTimeout"),
+      () -> "message should point users at the consumer-level setter: " + ex.getMessage()
+    );
+  }
+
+  @Test
+  void multiBuilderAcceptsConsumerWideRetryDlqBackpressureErrorHandlerPollTimeout() {
+    // The legitimate path for the settings the per-route tests reject: set them on the MultiBuilder
+    // itself. Not calling .start() (would open a real Kafka connection) — chaining is enough to
+    // prove the mirror setters exist, validate, and configure without tripping the reject.
+    assertDoesNotThrow(() ->
+      KPipe.multi(props())
+        .withRetry(3, Duration.ofSeconds(1))
+        .withBackpressure(5_000, 1_000)
+        .withDeadLetterTopic("dlq")
+        .withErrorHandler(_ -> {})
+        .withPollTimeout(Duration.ofMillis(250))
+        .json("topic-a", s -> s.toCustom(_ -> {}))
+        .json("topic-b", s -> s.toCustom(_ -> {}))
+    );
   }
 
   @Test

--- a/lib/kpipe-api/src/test/java/io/github/eschizoid/kpipe/StreamBatchIntegrationTest.java
+++ b/lib/kpipe-api/src/test/java/io/github/eschizoid/kpipe/StreamBatchIntegrationTest.java
@@ -3,7 +3,9 @@ package io.github.eschizoid.kpipe;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import io.github.eschizoid.kpipe.consumer.CircuitBreakerController;
 import io.github.eschizoid.kpipe.consumer.ProcessingMode;
+import io.github.eschizoid.kpipe.producer.tracing.Tracer;
 import io.github.eschizoid.kpipe.sink.BatchPolicy;
 import io.github.eschizoid.kpipe.sink.BatchSink;
 import java.nio.charset.StandardCharsets;
@@ -15,7 +17,9 @@ import java.util.Properties;
 import java.util.UUID;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.producer.KafkaProducer;
 import org.apache.kafka.clients.producer.ProducerConfig;
 import org.apache.kafka.clients.producer.ProducerRecord;
@@ -112,6 +116,57 @@ class StreamBatchIntegrationTest {
       for (int i = 1; i <= 25; i++) assertEquals(i, observedIds.get(i - 1), "missing id " + i);
     } finally {
       handle.shutdownGracefully(Duration.ofSeconds(2));
+    }
+  }
+
+  @Test
+  void batchPathWiresTracerAndCircuitBreaker() throws Exception {
+    // Regression: DefaultBatchSink.start() used to skip tracer + circuit breaker (it called only
+    // applyCommonConsumerConfig, which excluded both), so a tracer set on a toBatch(...) stream was
+    // silently dropped. Assert the tracer is now invoked once per record on the batch path.
+    final var topic = "kpipe-batch-tracer-" + UUID.randomUUID().toString().substring(0, 8);
+    final var spans = new AtomicInteger();
+    final Tracer countingTracer = new Tracer() {
+      @Override
+      public Tracer.SpanScope startConsumerSpan(final ConsumerRecord<?, byte[]> record) {
+        spans.incrementAndGet();
+        return Tracer.SpanScope.noop();
+      }
+
+      @Override
+      public void injectContextInto(final org.apache.kafka.common.header.Headers headers) {}
+    };
+    // High threshold + large window so the breaker never trips during the test — we only need it
+    // wired, not tripping.
+    final var breaker = new CircuitBreakerController(0.99, 10_000, Duration.ofSeconds(30));
+
+    final BatchSink<Map<String, Object>> batchSink = BatchSink.ofVoid(batch -> {});
+
+    final var handle = KPipe.json(topic, consumerProps("kpipe-batch-tracer-group-" + UUID.randomUUID()))
+      .withProcessingMode(ProcessingMode.SEQUENTIAL)
+      .withTracer(countingTracer)
+      .withCircuitBreaker(breaker)
+      .toBatch(batchSink, new BatchPolicy(5, Duration.ofSeconds(2)))
+      .start();
+
+    try {
+      try (final var producer = new KafkaProducer<byte[], byte[]>(producerProps())) {
+        for (int i = 1; i <= 10; i++) {
+          producer
+            .send(new ProducerRecord<>(topic, "{\"id\":%d}".formatted(i).getBytes(StandardCharsets.UTF_8)))
+            .get();
+        }
+        producer.flush();
+      }
+
+      waitFor(
+        () -> spans.get() >= 10,
+        Duration.ofSeconds(20),
+        "batch path must invoke the tracer once per record; the circuit breaker must also be wired"
+      );
+      assertTrue(handle.isHealthy(), "breaker is far below threshold — consumer stays healthy");
+    } finally {
+      handle.shutdownGracefully(Duration.ofSeconds(5));
     }
   }
 

--- a/lib/kpipe-bom/build.gradle.kts
+++ b/lib/kpipe-bom/build.gradle.kts
@@ -4,17 +4,40 @@ plugins {
 
 description = "KPipe BOM — Maven Bill-of-Materials that pins all kpipe-* modules to matching versions"
 
+// Derive the constrained set from the :lib project graph instead of hand-listing modules. Every
+// sibling :lib module except this BOM is a published artifact that must be pinned; sourcing from
+// `parent.subprojects` keeps the BOM in lockstep with `publishAllLibModules` and the JReleaser
+// deploy list (both already graph-sourced), so a newly added lib module can't silently drop out of
+// the BOM — the drift that left tracing-otel, schema-registry-confluent, and format-protobuf-confluent
+// unpinned through 1.17.0.
 dependencies {
   constraints {
-    api(project(":lib:kpipe-core"))
-    api(project(":lib:kpipe-metrics"))
-    api(project(":lib:kpipe-metrics-otel"))
-    api(project(":lib:kpipe-consumer"))
-    api(project(":lib:kpipe-producer"))
-    api(project(":lib:kpipe-format-json"))
-    api(project(":lib:kpipe-format-avro"))
-    api(project(":lib:kpipe-format-protobuf"))
-    api(project(":lib:kpipe-api"))
-    api(project(":lib:kpipe-test"))
+    publishedLibModules().forEach { api(project(it.path)) }
   }
 }
+
+// CI guard: fail the build if the BOM's constrained set ever diverges from the publishable :lib set.
+// Redundant with the graph-sourced derivation above by construction, but it pins the invariant so a
+// future refactor back to a hand-maintained list can't silently reintroduce the drift. Runs as part
+// of `check` (hence `build`), which CI already invokes.
+val verifyBomCoverage by tasks.registering {
+  group = "verification"
+  description = "Asserts the BOM constrains exactly the set of published :lib modules."
+  doLast {
+    val expected = publishedLibModules().map { it.name }.toSortedSet()
+    val actual = configurations["api"].dependencyConstraints.map { it.name }.toSortedSet()
+    check(actual == expected) {
+      "BOM constraint set drifted from the publishable :lib modules.\n" +
+        "  missing from BOM: ${expected - actual}\n" +
+        "  extra in BOM:     ${actual - expected}"
+    }
+  }
+}
+
+tasks.named("check") { dependsOn(verifyBomCoverage) }
+
+// The publishable :lib modules: every sibling under :lib except the BOM itself (a BOM never
+// constrains itself). Same graph source as `publishAllLibModules` / the JReleaser deploy list.
+fun publishedLibModules(): List<Project> = parent!!.subprojects
+  .filter { it.name != "kpipe-bom" }
+  .sortedBy { it.name }

--- a/lib/kpipe-metrics-otel/src/main/java/io/github/eschizoid/kpipe/metrics/otel/PipelineMetricsObserver.java
+++ b/lib/kpipe-metrics-otel/src/main/java/io/github/eschizoid/kpipe/metrics/otel/PipelineMetricsObserver.java
@@ -5,6 +5,8 @@ import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.api.metrics.LongCounter;
+import io.opentelemetry.api.metrics.Meter;
+import io.opentelemetry.api.metrics.ObservableLongCounter;
 import io.opentelemetry.api.metrics.ObservableLongGauge;
 import java.util.Objects;
 import java.util.function.Consumer;
@@ -37,7 +39,13 @@ import java.util.function.LongSupplier;
 /// [#bindSchemaRegistryCache(LongSupplier, LongSupplier, LongSupplier)]. The observer uses
 /// `LongSupplier` rather than a concrete `CachedSchemaResolver` type so this module stays
 /// independent of `kpipe-schema-registry-confluent`.
-public final class PipelineMetricsObserver implements Consumer<Result<?>> {
+///
+/// Lifecycle. The pipeline-outcome counters are synchronous and need no teardown. The optional
+/// Schema-Registry cache instruments are **asynchronous** — the OTel SDK strongly retains their
+/// callbacks until the instrument is closed. The observer is [AutoCloseable]: call [#close()]
+/// when discarding it so those callbacks stop firing. Re-binding closes the previous cache
+/// registration first, so binding twice never leaks the earlier callbacks.
+public final class PipelineMetricsObserver implements Consumer<Result<?>>, AutoCloseable {
 
   private static final AttributeKey<String> PIPELINE_KEY = AttributeKey.stringKey("pipeline");
 
@@ -45,16 +53,15 @@ public final class PipelineMetricsObserver implements Consumer<Result<?>> {
   private final LongCounter filtered;
   private final LongCounter failed;
   private final Attributes baseAttributes;
-  private final io.opentelemetry.api.metrics.Meter meter;
+  private final Meter meter;
 
-  @SuppressWarnings("unused")
-  private ObservableLongGauge srCacheSizeGauge;
-
-  @SuppressWarnings("unused")
-  private ObservableLongGauge srCacheHitsGauge;
-
-  @SuppressWarnings("unused")
-  private ObservableLongGauge srCacheMissesGauge;
+  // Async Schema-Registry cache instruments, registered lazily by bindSchemaRegistryCache and held
+  // so close() (and a re-bind) can unregister them. buildWithCallback hands the SDK a callback it
+  // strongly retains until the instrument is closed; overwriting these fields without closing would
+  // leak the old callbacks (they keep firing against stale suppliers → duplicate/stale series).
+  private ObservableLongCounter srCacheHits;
+  private ObservableLongCounter srCacheMisses;
+  private ObservableLongGauge srCacheSize;
 
   /// Creates an observer that reports pipeline-outcome counters under the given OTel meter.
   ///
@@ -95,17 +102,24 @@ public final class PipelineMetricsObserver implements Consumer<Result<?>> {
     }
   }
 
-  /// Registers three observable gauges that report the current state of a Confluent Schema
-  /// Registry cache (`CachedSchemaResolver` in `kpipe-schema-registry-confluent`). Wire the
-  /// suppliers to the resolver's `hitCount`, `missCount`, and `size` methods.
+  /// Registers instruments that report the current state of a Confluent Schema Registry cache
+  /// (`CachedSchemaResolver` in `kpipe-schema-registry-confluent`). Wire the suppliers to the
+  /// resolver's `hitCount`, `missCount`, and `size` methods.
   ///
   /// Metrics emitted:
   ///
-  ///   * `kpipe.schema_registry.cache.hits`   — cumulative hits since process start.
-  ///   * `kpipe.schema_registry.cache.misses` — cumulative misses (each one is one HTTP call).
-  ///   * `kpipe.schema_registry.cache.size`   — current distinct-id cardinality.
+  ///   * `kpipe.schema_registry.cache.hits`   — async **counter**: cumulative hits since start.
+  ///   * `kpipe.schema_registry.cache.misses` — async **counter**: cumulative misses (each is an
+  ///     HTTP call).
+  ///   * `kpipe.schema_registry.cache.size`   — gauge: current distinct-id cardinality.
   ///
-  /// Returns `this` for fluent chaining.
+  /// Hits and misses are monotonic cumulative totals, so they are modeled as (observable) counters,
+  /// not gauges — a downstream backend can then compute rates over them. Size is a level, so it
+  /// stays a gauge.
+  ///
+  /// Binding is one-shot per registration: calling this again closes the previous three instruments
+  /// before registering the new ones, so a re-bind swaps suppliers cleanly instead of leaking the
+  /// earlier callbacks. Returns `this` for fluent chaining.
   ///
   /// @param hits   supplier of cumulative cache hits (must be non-null)
   /// @param misses supplier of cumulative cache misses (must be non-null)
@@ -119,24 +133,46 @@ public final class PipelineMetricsObserver implements Consumer<Result<?>> {
     Objects.requireNonNull(hits, "hits supplier cannot be null");
     Objects.requireNonNull(misses, "misses supplier cannot be null");
     Objects.requireNonNull(size, "size supplier cannot be null");
-    this.srCacheHitsGauge = meter
-      .gaugeBuilder("kpipe.schema_registry.cache.hits")
-      .ofLongs()
+    closeSchemaRegistryInstruments();
+    this.srCacheHits = meter
+      .counterBuilder("kpipe.schema_registry.cache.hits")
       .setDescription("Cumulative cache hits for the Confluent Schema Registry resolver")
       .setUnit("{lookup}")
       .buildWithCallback(m -> m.record(hits.getAsLong(), baseAttributes));
-    this.srCacheMissesGauge = meter
-      .gaugeBuilder("kpipe.schema_registry.cache.misses")
-      .ofLongs()
+    this.srCacheMisses = meter
+      .counterBuilder("kpipe.schema_registry.cache.misses")
       .setDescription("Cumulative cache misses (each one resulted in a registry HTTP call)")
       .setUnit("{lookup}")
       .buildWithCallback(m -> m.record(misses.getAsLong(), baseAttributes));
-    this.srCacheSizeGauge = meter
+    this.srCacheSize = meter
       .gaugeBuilder("kpipe.schema_registry.cache.size")
       .ofLongs()
       .setDescription("Current number of distinct schema ids cached")
       .setUnit("{schema}")
       .buildWithCallback(m -> m.record(size.getAsLong(), baseAttributes));
     return this;
+  }
+
+  /// Unregisters the Schema-Registry cache instruments if bound. Idempotent — safe to call when
+  /// nothing was bound, and safe to call more than once. The pipeline-outcome counters are
+  /// synchronous and require no teardown, so this only tears down the async cache callbacks.
+  @Override
+  public void close() {
+    closeSchemaRegistryInstruments();
+  }
+
+  private void closeSchemaRegistryInstruments() {
+    if (srCacheHits != null) {
+      srCacheHits.close();
+      srCacheHits = null;
+    }
+    if (srCacheMisses != null) {
+      srCacheMisses.close();
+      srCacheMisses = null;
+    }
+    if (srCacheSize != null) {
+      srCacheSize.close();
+      srCacheSize = null;
+    }
   }
 }

--- a/lib/kpipe-metrics-otel/src/main/java/io/github/eschizoid/kpipe/metrics/otel/PipelineMetricsObserver.java
+++ b/lib/kpipe-metrics-otel/src/main/java/io/github/eschizoid/kpipe/metrics/otel/PipelineMetricsObserver.java
@@ -8,6 +8,8 @@ import io.opentelemetry.api.metrics.LongCounter;
 import io.opentelemetry.api.metrics.Meter;
 import io.opentelemetry.api.metrics.ObservableLongCounter;
 import io.opentelemetry.api.metrics.ObservableLongGauge;
+import java.lang.System.Logger;
+import java.lang.System.Logger.Level;
 import java.util.Objects;
 import java.util.function.Consumer;
 import java.util.function.LongSupplier;
@@ -45,8 +47,13 @@ import java.util.function.LongSupplier;
 /// callbacks until the instrument is closed. The observer is [AutoCloseable]: call [#close()]
 /// when discarding it so those callbacks stop firing. Re-binding closes the previous cache
 /// registration first, so binding twice never leaks the earlier callbacks.
+///
+/// Thread-safety. [#accept] is safe to call concurrently — it only reads the three `final`
+/// counters. The lifecycle methods ([#bindSchemaRegistryCache] and [#close()]) are NOT thread-safe
+/// with respect to each other; call them from a single owning thread (setup / teardown).
 public final class PipelineMetricsObserver implements Consumer<Result<?>>, AutoCloseable {
 
+  private static final Logger LOGGER = System.getLogger(PipelineMetricsObserver.class.getName());
   private static final AttributeKey<String> PIPELINE_KEY = AttributeKey.stringKey("pipeline");
 
   private final LongCounter passed;
@@ -162,17 +169,24 @@ public final class PipelineMetricsObserver implements Consumer<Result<?>>, AutoC
   }
 
   private void closeSchemaRegistryInstruments() {
-    if (srCacheHits != null) {
-      srCacheHits.close();
-      srCacheHits = null;
+    // Close each instrument independently and clear its field regardless of a throw. A sequential
+    // close where the first .close() throws would leave the others registered and non-null — still
+    // firing against stale suppliers, the exact leak this method exists to prevent.
+    srCacheHits = closeQuietly(srCacheHits);
+    srCacheMisses = closeQuietly(srCacheMisses);
+    srCacheSize = closeQuietly(srCacheSize);
+  }
+
+  /// Closes `instrument` if non-null, logging (never rethrowing) any failure so teardown of the
+  /// remaining instruments always continues. Returns null so the caller can clear the field.
+  private static <T extends AutoCloseable> T closeQuietly(final T instrument) {
+    if (instrument != null) {
+      try {
+        instrument.close();
+      } catch (final Exception e) {
+        LOGGER.log(Level.WARNING, "Failed to close a Schema-Registry cache instrument; continuing teardown", e);
+      }
     }
-    if (srCacheMisses != null) {
-      srCacheMisses.close();
-      srCacheMisses = null;
-    }
-    if (srCacheSize != null) {
-      srCacheSize.close();
-      srCacheSize = null;
-    }
+    return null;
   }
 }

--- a/lib/kpipe-metrics-otel/src/test/java/io/github/eschizoid/kpipe/metrics/otel/PipelineMetricsObserverTest.java
+++ b/lib/kpipe-metrics-otel/src/test/java/io/github/eschizoid/kpipe/metrics/otel/PipelineMetricsObserverTest.java
@@ -142,7 +142,7 @@ class PipelineMetricsObserverTest {
   }
 
   @Test
-  void bindSchemaRegistryCacheRegistersThreeGaugesAndReadsFromSuppliers() {
+  void bindSchemaRegistryCacheRegistersCountersAndGaugeAndReadsFromSuppliers() {
     final var f = fixture("sr-test");
     final var hits = new AtomicLong(7);
     final var misses = new AtomicLong(3);
@@ -150,9 +150,10 @@ class PipelineMetricsObserverTest {
     final var returned = f.observer().bindSchemaRegistryCache(hits::get, misses::get, size::get);
     assertSame(f.observer(), returned, "bindSchemaRegistryCache must return `this` for fluent chaining");
 
+    // hits/misses are cumulative → async counters (sum data); size is a level → gauge.
     final var metrics = f.collect();
-    assertEquals(7L, gaugeValue(metrics, "kpipe.schema_registry.cache.hits"));
-    assertEquals(3L, gaugeValue(metrics, "kpipe.schema_registry.cache.misses"));
+    assertEquals(7L, valueOf(metrics, "kpipe.schema_registry.cache.hits"));
+    assertEquals(3L, valueOf(metrics, "kpipe.schema_registry.cache.misses"));
     assertEquals(10L, gaugeValue(metrics, "kpipe.schema_registry.cache.size"));
 
     // Suppliers are read on each collection — bumping the values must surface on the next read.
@@ -160,9 +161,44 @@ class PipelineMetricsObserverTest {
     misses.set(4);
     size.set(11);
     final var second = f.collect();
-    assertEquals(15L, gaugeValue(second, "kpipe.schema_registry.cache.hits"));
-    assertEquals(4L, gaugeValue(second, "kpipe.schema_registry.cache.misses"));
+    assertEquals(15L, valueOf(second, "kpipe.schema_registry.cache.hits"));
+    assertEquals(4L, valueOf(second, "kpipe.schema_registry.cache.misses"));
     assertEquals(11L, gaugeValue(second, "kpipe.schema_registry.cache.size"));
+  }
+
+  @Test
+  void rebindClosesPreviousCallbacksAndSwapsSuppliers() {
+    // Binding twice must not leak the first registration's callbacks (which would emit a second,
+    // stale series against the old suppliers). After a re-bind, each metric has exactly one point,
+    // reading from the new suppliers only.
+    final var f = fixture("sr-test");
+    f.observer().bindSchemaRegistryCache(() -> 1L, () -> 1L, () -> 1L);
+    f.observer().bindSchemaRegistryCache(() -> 42L, () -> 9L, () -> 5L);
+
+    final var metrics = f.collect();
+    assertEquals(1, pointCount(metrics, "kpipe.schema_registry.cache.hits"), "leaked stale hits callback");
+    assertEquals(1, pointCount(metrics, "kpipe.schema_registry.cache.size"), "leaked stale size callback");
+    assertEquals(42L, valueOf(metrics, "kpipe.schema_registry.cache.hits"));
+    assertEquals(9L, valueOf(metrics, "kpipe.schema_registry.cache.misses"));
+    assertEquals(5L, gaugeValue(metrics, "kpipe.schema_registry.cache.size"));
+  }
+
+  @Test
+  void closeUnregistersSchemaRegistryInstruments() {
+    final var f = fixture("sr-test");
+    f.observer().bindSchemaRegistryCache(() -> 7L, () -> 3L, () -> 10L);
+    assertEquals(7L, valueOf(f.collect(), "kpipe.schema_registry.cache.hits"));
+
+    f.observer().close();
+
+    // After close the async cache instruments no longer emit; the pipeline counters are unaffected.
+    final var afterClose = f.collect();
+    assertEquals(
+      0,
+      pointCount(afterClose, "kpipe.schema_registry.cache.hits"),
+      "cache instruments must stop emitting after close()"
+    );
+    assertDoesNotThrow(f.observer()::close, "close() must be idempotent");
   }
 
   @Test
@@ -171,6 +207,15 @@ class PipelineMetricsObserverTest {
     assertThrows(NullPointerException.class, () -> f.observer().bindSchemaRegistryCache(null, () -> 0L, () -> 0L));
     assertThrows(NullPointerException.class, () -> f.observer().bindSchemaRegistryCache(() -> 0L, null, () -> 0L));
     assertThrows(NullPointerException.class, () -> f.observer().bindSchemaRegistryCache(() -> 0L, () -> 0L, null));
+  }
+
+  private static long pointCount(final Collection<MetricData> metrics, final String name) {
+    return metrics
+      .stream()
+      .filter(m -> m.getName().equals(name))
+      .findFirst()
+      .map(m -> (long) m.getData().getPoints().size())
+      .orElse(0L);
   }
 
   private static long gaugeValue(final Collection<MetricData> metrics, final String name) {


### PR DESCRIPTION
Executes the five validated top targets from the per-module architecture critique. Independent DEBT items, one commit each.

## 1. BOM derives from the `:lib` graph + coverage guard (`b65f3ba`)
`kpipe-bom` hand-listed 10 of 13 published modules, silently omitting `kpipe-tracing-otel`, `kpipe-schema-registry-confluent`, and `kpipe-format-protobuf-confluent` — importers of the BOM got no version pin for those three. Now sourced from `parent.subprojects` (the same graph `publishAllLibModules` / the JReleaser deploy list already use), so a new lib module can't drift out again. A `verifyBomCoverage` task wired into `check` asserts BOM == publishable set. **Proven:** injected drift fails with `missing from BOM: [kpipe-test]`; generated POM now lists all 13.

## 2. PipelineMetricsObserver callback leak (`8e702f2`)
The three SR-cache gauges were non-final reassignable fields with no unregister path. `buildWithCallback` hands the OTel SDK a callback it strongly retains until the instrument is closed, so a second `bindSchemaRegistryCache` leaked the first three callbacks (they kept firing against stale suppliers). Made the observer `AutoCloseable` with an idempotent `close()`; re-binding closes the previous registration first. Also corrected `hits`/`misses` from gauges to monotonic async **counters** (matching their "cumulative" Javadoc). New tests cover rebind-no-leak and close-unregisters against a real `InMemoryMetricReader`.

## 3. MultiBuilder consumer-wide mirrors (`ded36b5`)
`retry` / `DLQ` / `backpressure` / `error-handler` / `poll-timeout` were rejected per-route with a "wait for the multi-builder mirror (open issue)" message. Added the symmetric `MultiBuilder.with*` setters (delegating 1:1 onto the single consumer builder in `start()`, like `withMetrics`/`withTracer`), so the 80% multi-topic path no longer forces a drop to the explicit API. The per-route rejection now points at the matching setter; the dead `perRouteRejectionDeferred` helper is deleted.

## 4. Batch-sink tracer + circuit breaker (`1e86e3d`)
`DefaultBatchSink.start()` called only `applyCommonConsumerConfig`, which excluded tracer + circuit breaker (wired separately by `DefaultSink`) — so both were silently dropped on a `toBatch(...)` stream. Folded both into the shared helper so the two sink types can't drift again; dropped the redundant lines from `DefaultSink`. **Proven** by a broker-backed test: a counting tracer on a `toBatch(...)` stream now fires once per record (was 0), circuit breaker wired without tripping.

## 5. benchmarks/README.md rewrite (`04c4c8e`)
The README named `@Benchmark` arms that don't exist, described the parallel suite as 4 arms (it's 9) with `workMicros {0,100,1000}` (it's `{0,100,1000,10000,35000,50000,100000}`), self-contradicted on 25k-vs-10k records, omitted four benches, and required "Java 24+" (toolchain is 25). Rewritten from `METHODOLOGY.md` — all eight benches with their real arms/params, deferring numbers to the dated `results/` captures. Every claim checked against the sources.

## Verification
`./gradlew :lib:kpipe-bom:check :lib:kpipe-metrics-otel:test :lib:kpipe-api:test` — BUILD SUCCESSFUL (full Testcontainers api suite included).

No `@Deprecated` cycles (§16 delete-and-migrate); §17 capability table updated locally.