### PR TITLE
refactor(formats): standardize read-path failures on IllegalStateException

### DIFF
--- a/lib/kpipe-format-avro/src/main/java/io/github/eschizoid/kpipe/format/avro/AvroFormat.java
+++ b/lib/kpipe-format-avro/src/main/java/io/github/eschizoid/kpipe/format/avro/AvroFormat.java
@@ -159,8 +159,8 @@ public final class AvroFormat implements MessageFormat<GenericRecord> {
       // RuntimeException is caught alongside IOException because malformed bytes surface as Avro's
       // own AvroRuntimeException (e.g. "Malformed data. Length is negative"), not IOException — so
       // the common bad-payload case would otherwise escape with a bare, context-free message. The
-      // original cause is always attached, so a genuine programming error (NPE, IllegalState) is
-      // still visible in the cause chain rather than swallowed.
+      // original cause is always attached, so a genuine programming error (e.g. an NPE) is still
+      // visible in the cause chain rather than swallowed.
       throw new IllegalStateException(
         "AvroFormat.deserialize failed in static mode on " + data.length + " bytes against schema " +
           staticSchema.getFullName(),

--- a/lib/kpipe-format-avro/src/main/java/io/github/eschizoid/kpipe/format/avro/AvroFormat.java
+++ b/lib/kpipe-format-avro/src/main/java/io/github/eschizoid/kpipe/format/avro/AvroFormat.java
@@ -161,7 +161,7 @@ public final class AvroFormat implements MessageFormat<GenericRecord> {
       // the common bad-payload case would otherwise escape with a bare, context-free message. The
       // original cause is always attached, so a genuine programming error (NPE, IllegalState) is
       // still visible in the cause chain rather than swallowed.
-      throw new RuntimeException(
+      throw new IllegalStateException(
         "AvroFormat.deserialize failed in static mode on " + data.length + " bytes against schema " +
           staticSchema.getFullName(),
         e
@@ -170,10 +170,10 @@ public final class AvroFormat implements MessageFormat<GenericRecord> {
   }
 
   private GenericRecord deserializeFromEnvelope(final byte[] data) {
-    if (data.length < ENVELOPE_LENGTH) throw new RuntimeException(
+    if (data.length < ENVELOPE_LENGTH) throw new IllegalStateException(
       "Record too short for Confluent wire envelope: " + data.length + " bytes; expected at least " + ENVELOPE_LENGTH
     );
-    if (data[0] != CONFLUENT_MAGIC) throw new RuntimeException(
+    if (data[0] != CONFLUENT_MAGIC) throw new IllegalStateException(
       "Unexpected magic byte 0x%02x; expected 0x00 (Confluent Schema Registry envelope)".formatted(data[0] & 0xff)
     );
     final int schemaId =
@@ -181,7 +181,7 @@ public final class AvroFormat implements MessageFormat<GenericRecord> {
 
     final var schema = resolvedSchemas.computeIfAbsent(schemaId, id -> {
       final var json = resolver.lookupById(id);
-      if (json == null || json.isBlank()) throw new RuntimeException(
+      if (json == null || json.isBlank()) throw new IllegalStateException(
         "Schema resolver returned empty schema for id " + id
       );
       return new Schema.Parser().parse(json);
@@ -192,7 +192,7 @@ public final class AvroFormat implements MessageFormat<GenericRecord> {
     try {
       return reader.read(null, decoder);
     } catch (final IOException e) {
-      throw new RuntimeException(
+      throw new IllegalStateException(
         "Failed to decode Avro record under Confluent wire envelope (schema id " + schemaId + ")",
         e
       );

--- a/lib/kpipe-format-avro/src/test/java/io/github/eschizoid/kpipe/format/avro/AvroFormatBehaviorTest.java
+++ b/lib/kpipe-format-avro/src/test/java/io/github/eschizoid/kpipe/format/avro/AvroFormatBehaviorTest.java
@@ -93,14 +93,14 @@ class AvroFormatBehaviorTest {
   @Test
   void deserializeThrowsForGarbageBytes() {
     final var format = AvroFormat.of(USER_SCHEMA_JSON);
-    assertThrows(RuntimeException.class, () -> format.deserialize(new byte[] { 0x7f, 0x7f, 0x7f }));
+    assertThrows(IllegalStateException.class, () -> format.deserialize(new byte[] { 0x7f, 0x7f, 0x7f }));
   }
 
   @Test
   void deserializeErrorMessageCarriesFormatNameAndByteLength() {
     final var format = AvroFormat.of(USER_SCHEMA_JSON);
     final var garbage = new byte[] { 0x7f, 0x7f, 0x7f };
-    final var thrown = assertThrows(RuntimeException.class, () -> format.deserialize(garbage));
+    final var thrown = assertThrows(IllegalStateException.class, () -> format.deserialize(garbage));
     final var message = thrown.getMessage();
     assertTrue(message.contains("AvroFormat"), () -> "message should name the format: " + message);
     assertTrue(message.contains(garbage.length + " bytes"), () -> "message should report the byte length: " + message);

--- a/lib/kpipe-format-avro/src/test/java/io/github/eschizoid/kpipe/format/avro/AvroFormatRegistryTest.java
+++ b/lib/kpipe-format-avro/src/test/java/io/github/eschizoid/kpipe/format/avro/AvroFormatRegistryTest.java
@@ -135,7 +135,7 @@ class AvroFormatRegistryTest {
     final var format = AvroFormat.withRegistry(resolver);
 
     final var bad = new byte[] { 0x01, 0x00, 0x00, 0x00, 0x01, 0x42 };
-    final var ex = assertThrows(RuntimeException.class, () -> format.deserialize(bad));
+    final var ex = assertThrows(IllegalStateException.class, () -> format.deserialize(bad));
     assertTrue(ex.getMessage().contains("magic byte"), "must mention magic byte; got: " + ex.getMessage());
   }
 
@@ -145,7 +145,7 @@ class AvroFormatRegistryTest {
     final var format = AvroFormat.withRegistry(resolver);
 
     final var tooShort = new byte[] { 0x00, 0x00, 0x00 };
-    final var ex = assertThrows(RuntimeException.class, () -> format.deserialize(tooShort));
+    final var ex = assertThrows(IllegalStateException.class, () -> format.deserialize(tooShort));
     assertTrue(ex.getMessage().contains("envelope"));
   }
 
@@ -193,7 +193,7 @@ class AvroFormatRegistryTest {
     };
     final var format = AvroFormat.withRegistry(resolver);
     final var anyEnvelope = new byte[] { 0x00, 0x00, 0x00, 0x00, 0x01, 0x42, 0x00 };
-    final var ex = assertThrows(RuntimeException.class, () -> format.deserialize(anyEnvelope));
+    final var ex = assertThrows(IllegalStateException.class, () -> format.deserialize(anyEnvelope));
     assertTrue(ex.getMessage().contains("empty schema"));
   }
 }

--- a/lib/kpipe-format-avro/src/test/java/io/github/eschizoid/kpipe/format/avro/AvroFormatSchemaEvolutionTest.java
+++ b/lib/kpipe-format-avro/src/test/java/io/github/eschizoid/kpipe/format/avro/AvroFormatSchemaEvolutionTest.java
@@ -283,7 +283,7 @@ class AvroFormatSchemaEvolutionTest {
     final var resolver = new FakeResolver().put(2, USER_V2);
     final var format = AvroFormat.withRegistry(resolver);
 
-    final var ex = assertThrows(RuntimeException.class, () -> format.deserialize(stripped));
+    final var ex = assertThrows(IllegalStateException.class, () -> format.deserialize(stripped));
     // The Avro payload for this record does not begin with the 0x00 magic byte, so the envelope
     // check fires before any schema lookup happens.
     assertTrue(
@@ -315,7 +315,7 @@ class AvroFormatSchemaEvolutionTest {
     if (stripped.length == 0) {
       assertNull(format.deserialize(stripped));
     } else {
-      final var ex = assertThrows(RuntimeException.class, () -> format.deserialize(stripped));
+      final var ex = assertThrows(IllegalStateException.class, () -> format.deserialize(stripped));
       assertTrue(
         ex.getMessage().contains("envelope") || ex.getMessage().contains("magic byte"),
         "short double-stripped record must be rejected; got: " + ex.getMessage()

--- a/lib/kpipe-format-json/src/main/java/io/github/eschizoid/kpipe/format/json/JsonFormat.java
+++ b/lib/kpipe-format-json/src/main/java/io/github/eschizoid/kpipe/format/json/JsonFormat.java
@@ -67,7 +67,7 @@ public final class JsonFormat implements MessageFormat<Map<String, Object>> {
     try {
       return JSON.parseObject(data);
     } catch (final JSONException e) {
-      throw new RuntimeException(
+      throw new IllegalStateException(
         "JsonFormat.deserialize failed on " + data.length + " bytes (first bytes " + hexPreview(data) + ")",
         e
       );

--- a/lib/kpipe-format-json/src/test/java/io/github/eschizoid/kpipe/format/json/JsonFormatEdgeCasesTest.java
+++ b/lib/kpipe-format-json/src/test/java/io/github/eschizoid/kpipe/format/json/JsonFormatEdgeCasesTest.java
@@ -64,7 +64,7 @@ class JsonFormatEdgeCasesTest {
   /// green this test on an unrelated bug. `JsonFormat.deserialize` wraps parse failures with this
   /// prefix; anything else (NPE, coercion) propagates without it and fails the check loudly.
   private static void assertDecodeFailure(final byte[] data) {
-    final var ex = assertThrows(RuntimeException.class, () -> JsonFormat.INSTANCE.deserialize(data));
+    final var ex = assertThrows(IllegalStateException.class, () -> JsonFormat.INSTANCE.deserialize(data));
     assertTrue(
       ex.getMessage() != null && ex.getMessage().contains("JsonFormat.deserialize failed"),
       () -> "expected a JsonFormat decode failure, got: " + ex

--- a/lib/kpipe-format-json/src/test/java/io/github/eschizoid/kpipe/format/json/JsonFormatTest.java
+++ b/lib/kpipe-format-json/src/test/java/io/github/eschizoid/kpipe/format/json/JsonFormatTest.java
@@ -18,7 +18,7 @@ class JsonFormatTest {
   @Test
   void deserializeErrorMessageCarriesFormatNameAndByteLength() {
     final var malformed = "{\"a\":".getBytes(StandardCharsets.UTF_8);
-    final var thrown = assertThrows(RuntimeException.class, () -> JsonFormat.INSTANCE.deserialize(malformed));
+    final var thrown = assertThrows(IllegalStateException.class, () -> JsonFormat.INSTANCE.deserialize(malformed));
     final var message = thrown.getMessage();
     assertTrue(message.contains("JsonFormat"), () -> "message should name the format: " + message);
     assertTrue(
@@ -30,7 +30,7 @@ class JsonFormatTest {
   @Test
   void deserializeErrorMessageHandlesShortPayloadWithoutThrowing() {
     final var shortMalformed = new byte[] { (byte) 0xff, (byte) 0xfe };
-    final var thrown = assertThrows(RuntimeException.class, () -> JsonFormat.INSTANCE.deserialize(shortMalformed));
+    final var thrown = assertThrows(IllegalStateException.class, () -> JsonFormat.INSTANCE.deserialize(shortMalformed));
     assertTrue(thrown.getMessage().contains("2 bytes"), () -> "message: " + thrown.getMessage());
   }
 }

--- a/lib/kpipe-format-protobuf-confluent/src/main/java/io/github/eschizoid/kpipe/format/protobuf/confluent/ConfluentProtobufDescriptorCompiler.java
+++ b/lib/kpipe-format-protobuf-confluent/src/main/java/io/github/eschizoid/kpipe/format/protobuf/confluent/ConfluentProtobufDescriptorCompiler.java
@@ -26,20 +26,20 @@ public final class ConfluentProtobufDescriptorCompiler implements ProtobufDescri
   public Descriptor compile(final String protoText, final int[] messageIndex) {
     Objects.requireNonNull(protoText, "protoText cannot be null");
     Objects.requireNonNull(messageIndex, "messageIndex cannot be null");
-    if (messageIndex.length == 0) throw new IllegalArgumentException("messageIndex must not be empty");
+    if (messageIndex.length == 0) throw new IllegalStateException("messageIndex must not be empty");
 
     final var schema = new ProtobufSchema(protoText);
     final var file = schema.toDescriptor().getFile();
 
     final var topLevel = file.getMessageTypes();
-    if (messageIndex[0] < 0 || messageIndex[0] >= topLevel.size()) throw new IllegalArgumentException(
+    if (messageIndex[0] < 0 || messageIndex[0] >= topLevel.size()) throw new IllegalStateException(
       "message-index[0]=" + messageIndex[0] + " out of range for " + topLevel.size() + " top-level messages"
     );
     var descriptor = topLevel.get(messageIndex[0]);
     for (var depth = 1; depth < messageIndex.length; depth++) {
       final var nested = descriptor.getNestedTypes();
       final var idx = messageIndex[depth];
-      if (idx < 0 || idx >= nested.size()) throw new IllegalArgumentException(
+      if (idx < 0 || idx >= nested.size()) throw new IllegalStateException(
         "message-index[" +
           depth +
           "]=" +

--- a/lib/kpipe-format-protobuf-confluent/src/test/java/io/github/eschizoid/kpipe/format/protobuf/confluent/ConfluentProtobufDescriptorCompilerTest.java
+++ b/lib/kpipe-format-protobuf-confluent/src/test/java/io/github/eschizoid/kpipe/format/protobuf/confluent/ConfluentProtobufDescriptorCompilerTest.java
@@ -63,8 +63,8 @@ class ConfluentProtobufDescriptorCompilerTest {
   @Test
   void outOfRangeIndexIsRejected() {
     final var proto = "syntax = \"proto3\"; message A { int64 id = 1; }";
-    assertThrows(IllegalArgumentException.class, () -> compiler.compile(proto, new int[] { 5 }));
-    assertThrows(IllegalArgumentException.class, () -> compiler.compile(proto, new int[] {}));
+    assertThrows(IllegalStateException.class, () -> compiler.compile(proto, new int[] { 5 }));
+    assertThrows(IllegalStateException.class, () -> compiler.compile(proto, new int[] {}));
   }
 
   @Test

--- a/lib/kpipe-format-protobuf/src/main/java/io/github/eschizoid/kpipe/format/protobuf/ProtobufFormat.java
+++ b/lib/kpipe-format-protobuf/src/main/java/io/github/eschizoid/kpipe/format/protobuf/ProtobufFormat.java
@@ -152,7 +152,7 @@ public final class ProtobufFormat implements MessageFormat<Message> {
     try {
       return DynamicMessage.parseFrom(descriptor, data);
     } catch (final InvalidProtocolBufferException e) {
-      throw new RuntimeException(
+      throw new IllegalStateException(
         "ProtobufFormat.deserialize failed on " +
           data.length +
           " bytes for descriptor " +
@@ -218,7 +218,7 @@ public final class ProtobufFormat implements MessageFormat<Message> {
       final var payload = CodedInputStream.newInstance(data, payloadOffset, data.length - payloadOffset);
       return DynamicMessage.parseFrom(messageDescriptor, payload);
     } catch (final IOException e) {
-      throw new RuntimeException(
+      throw new IllegalStateException(
         "Failed to decode Protobuf record under Confluent wire envelope (schema id " + schemaId + ")",
         e
       );

--- a/lib/kpipe-format-protobuf/src/test/java/io/github/eschizoid/kpipe/format/protobuf/ProtobufFormatEdgeCasesTest.java
+++ b/lib/kpipe-format-protobuf/src/test/java/io/github/eschizoid/kpipe/format/protobuf/ProtobufFormatEdgeCasesTest.java
@@ -85,7 +85,7 @@ class ProtobufFormatEdgeCasesTest {
     // Tag byte for field 2 (name, wire type 2 = length-delimited) says "10 bytes follow" but
     // the buffer ends early. A partial decode must throw, not return a half-built message.
     final var truncated = new byte[] { 0x12, 0x0a, 'A', 'l', 'i' };
-    assertThrows(RuntimeException.class, () -> format.deserialize(truncated));
+    assertThrows(IllegalStateException.class, () -> format.deserialize(truncated));
   }
 
   @Test

--- a/lib/kpipe-format-protobuf/src/test/java/io/github/eschizoid/kpipe/format/protobuf/ProtobufFormatRegistryTest.java
+++ b/lib/kpipe-format-protobuf/src/test/java/io/github/eschizoid/kpipe/format/protobuf/ProtobufFormatRegistryTest.java
@@ -244,14 +244,14 @@ class ProtobufFormatRegistryTest {
     final var format = ProtobufFormat.withRegistry(new FakeResolver().put(1, "x"), new FakeCompiler());
     // magic + id=1 + zig-zag size 0x04 (=2) but truncated before the two index elements.
     final var truncated = new byte[] { 0x00, 0x00, 0x00, 0x00, 0x01, 0x04 };
-    assertThrows(RuntimeException.class, () -> format.deserialize(truncated));
+    assertThrows(IllegalStateException.class, () -> format.deserialize(truncated));
   }
 
   @Test
   void wrongMagicByteThrows() {
     final var format = ProtobufFormat.withRegistry(new FakeResolver().put(1, "x"), new FakeCompiler());
     final var bad = new byte[] { 0x01, 0x00, 0x00, 0x00, 0x01, 0x00, 0x42 };
-    final var ex = assertThrows(RuntimeException.class, () -> format.deserialize(bad));
+    final var ex = assertThrows(IllegalStateException.class, () -> format.deserialize(bad));
     assertTrue(ex.getMessage().contains("magic byte"), "must mention magic byte; got: " + ex.getMessage());
   }
 
@@ -259,7 +259,7 @@ class ProtobufFormatRegistryTest {
   void payloadShorterThanEnvelopeThrows() {
     final var format = ProtobufFormat.withRegistry(new FakeResolver(), new FakeCompiler());
     final var tooShort = new byte[] { 0x00, 0x00, 0x00 };
-    final var ex = assertThrows(RuntimeException.class, () -> format.deserialize(tooShort));
+    final var ex = assertThrows(IllegalStateException.class, () -> format.deserialize(tooShort));
     assertTrue(ex.getMessage().contains("envelope"));
   }
 
@@ -267,7 +267,7 @@ class ProtobufFormatRegistryTest {
   void resolverReturningEmptyThrows() {
     final SchemaResolver resolver = schemaId -> "";
     final var format = ProtobufFormat.withRegistry(resolver, new FakeCompiler());
-    final var ex = assertThrows(RuntimeException.class, () ->
+    final var ex = assertThrows(IllegalStateException.class, () ->
       format.deserialize(envelope(1, new int[] { 0 }, customer(1, "a")))
     );
     assertTrue(ex.getMessage().contains("empty schema"));
@@ -304,6 +304,8 @@ class ProtobufFormatRegistryTest {
     final var format = ProtobufFormat.withRegistry(flaky, new FakeCompiler());
     final var env = envelope(101, new int[] { 0 }, customer(1, "a"));
 
+    // The resolver throws its own RuntimeException; the format propagates it as-is (a resolver/IO
+    // failure is not a malformed-envelope condition to reclassify), so this stays RuntimeException.
     assertThrows(RuntimeException.class, () -> format.deserialize(env));
     final var decoded = format.deserialize(env);
 

--- a/lib/kpipe-format-protobuf/src/test/java/io/github/eschizoid/kpipe/format/protobuf/ProtobufFormatTest.java
+++ b/lib/kpipe-format-protobuf/src/test/java/io/github/eschizoid/kpipe/format/protobuf/ProtobufFormatTest.java
@@ -75,13 +75,13 @@ class ProtobufFormatTest {
 
   @Test
   void shouldThrowOnInvalidProtobufBytes() {
-    assertThrows(RuntimeException.class, () -> format.deserialize(new byte[] { (byte) 0xFF, (byte) 0xFF }));
+    assertThrows(IllegalStateException.class, () -> format.deserialize(new byte[] { (byte) 0xFF, (byte) 0xFF }));
   }
 
   @Test
   void deserializeErrorMessageCarriesFormatNameAndByteLength() {
     final var garbage = new byte[] { (byte) 0xFF, (byte) 0xFF };
-    final var thrown = assertThrows(RuntimeException.class, () -> format.deserialize(garbage));
+    final var thrown = assertThrows(IllegalStateException.class, () -> format.deserialize(garbage));
     final var message = thrown.getMessage();
     assertTrue(message.contains("ProtobufFormat"), () -> "message should name the format: " + message);
     assertTrue(message.contains(garbage.length + " bytes"), () -> "message should report the byte length: " + message);


### PR DESCRIPTION
Delivers the demoted architecture-critique item: unify the "malformed wire envelope / decode failed" exception type across the format modules.

## The divergence
The same class of failure — bad input bytes at the read boundary — threw three different types:
- **JSON / Avro** deserialize + wire-envelope → `RuntimeException`
- **Protobuf** envelope → `IllegalStateException`, but static/registry **decode** → `RuntimeException`
- **Confluent descriptor compiler** wire-derived message-index errors → `IllegalArgumentException`

A reader grepping logs or catching by type got no consistent signal.

## The standard
Every read-path failure (deserialize, wire-envelope parse, descriptor-index resolution) now throws **`IllegalStateException`** — the type `MessagePipeline.deserializeOrFail` already uses ("null deserialization → IllegalStateException, retryable") and the one Protobuf's envelope path already followed.

- `JsonFormat.deserialize`, `AvroFormat` static-decode + all four envelope conditions, `ProtobufFormat` static/envelope decode → ISE.
- `ConfluentProtobufDescriptorCompiler`'s three message-index errors → ISE.

## Deliberate boundaries (preserved)
- **Resolver-thrown exceptions propagate unchanged** — a transiently-down `SchemaResolver` is not a malformed-envelope condition to reclassify (pinned by `aThrowingResolveIsNotCachedSoTheNextRecordRetries`, which the test-tightening below actually surfaced).
- **Write-path `serialize` failures stay `RuntimeException`** — a can't-encode-this-object failure is a distinct mode from bad-input-bytes.

## Not a correctness change
No consumer path switches on exception type (retry catches `Exception` uniformly), so runtime behavior is unchanged. This is log/reader consistency. `RuntimeException` is a supertype of `IllegalStateException`, so pipeline-level roundtrip assertions still pass unchanged.

## Tests
- The Confluent index test moves `IllegalArgumentException` → `IllegalStateException`.
- The format-unit deserialize-failure assertions are tightened from the loose `RuntimeException` supertype to `IllegalStateException` to **pin** the standard — this tightening is what caught the resolver-propagation boundary above.

## Verification
`./gradlew :lib:kpipe-format-json:test :lib:kpipe-format-avro:test :lib:kpipe-format-protobuf:test :lib:kpipe-format-protobuf-confluent:test` — BUILD SUCCESSFUL.