### PR TITLE
feat(producer): count sends through KafkaMessageSink + de-OTel the metrics field name

### DIFF
--- a/lib/kpipe-consumer/src/test/java/io/github/eschizoid/kpipe/consumer/KPipeProducerIntegrationTest.java
+++ b/lib/kpipe-consumer/src/test/java/io/github/eschizoid/kpipe/consumer/KPipeProducerIntegrationTest.java
@@ -123,6 +123,7 @@ class KPipeProducerIntegrationTest {
       new KafkaProducer<>(props, new ByteArraySerializer(), new ByteArraySerializer()),
       outputTopic,
       v -> v,
+      null,
       null
     );
     final var consumer = KPipeConsumer.builder()

--- a/lib/kpipe-producer/src/main/java/io/github/eschizoid/kpipe/producer/KPipeProducer.java
+++ b/lib/kpipe-producer/src/main/java/io/github/eschizoid/kpipe/producer/KPipeProducer.java
@@ -25,24 +25,25 @@ public class KPipeProducer<K, V> implements AutoCloseable {
 
   private final Producer<K, V> producer;
   private final boolean ownProducer;
-  private final ProducerMetrics otelMetrics;
+  private final ProducerMetrics metrics;
   private final Tracer tracer;
 
   /// Creates a new KPipeProducer that wraps an existing Kafka producer.
   ///
   /// @param producer    the Kafka producer to wrap
   /// @param ownProducer whether this wrapper owns the producer and should close it
-  /// @param otelMetrics OpenTelemetry metrics instruments; uses noop if null
+  /// @param metrics the producer metrics — any [ProducerMetrics] impl (e.g. `OtelProducerMetrics`
+  ///                from `kpipe-metrics-otel`); uses noop if null
   /// @param tracer      the tracer for outbound header injection; uses noop if null
   KPipeProducer(
     final Producer<K, V> producer,
     final boolean ownProducer,
-    final ProducerMetrics otelMetrics,
+    final ProducerMetrics metrics,
     final Tracer tracer
   ) {
     this.producer = Objects.requireNonNull(producer, "Producer cannot be null");
     this.ownProducer = ownProducer;
-    this.otelMetrics = otelMetrics != null ? otelMetrics : ProducerMetrics.noop();
+    this.metrics = metrics != null ? metrics : ProducerMetrics.noop();
     this.tracer = tracer != null ? tracer : Tracer.noop();
   }
 
@@ -187,11 +188,11 @@ public class KPipeProducer<K, V> implements AutoCloseable {
 
     try {
       send(producerRecord);
-      otelMetrics.recordDlqSent();
+      metrics.recordDlqSent();
       LOGGER.log(Level.DEBUG, "Sent record to DLQ topic {0}", dlqTopic);
       return true;
     } catch (final Exception ex) {
-      otelMetrics.recordDlqFailed();
+      metrics.recordDlqFailed();
       LOGGER.log(Level.ERROR, () -> "Failed to send record to DLQ topic " + dlqTopic, ex);
       return false;
     }
@@ -208,14 +209,14 @@ public class KPipeProducer<K, V> implements AutoCloseable {
   public RecordMetadata send(final ProducerRecord<K, V> record) {
     try {
       final var metadata = producer.send(record).get();
-      otelMetrics.recordMessageSent();
+      metrics.recordMessageSent();
       return metadata;
     } catch (final InterruptedException e) {
       Thread.currentThread().interrupt();
-      otelMetrics.recordMessageFailed();
+      metrics.recordMessageFailed();
       throw new RuntimeException("Send interrupted", e);
     } catch (final ExecutionException e) {
-      otelMetrics.recordMessageFailed();
+      metrics.recordMessageFailed();
       throw new RuntimeException("Send failed", e.getCause());
     }
   }
@@ -229,8 +230,8 @@ public class KPipeProducer<K, V> implements AutoCloseable {
   /// @return a future that will contain the record metadata
   public Future<RecordMetadata> sendAsync(final ProducerRecord<K, V> record) {
     return producer.send(record, (_, exception) -> {
-      if (exception == null) otelMetrics.recordMessageSent();
-      else otelMetrics.recordMessageFailed();
+      if (exception == null) metrics.recordMessageSent();
+      else metrics.recordMessageFailed();
     });
   }
 

--- a/lib/kpipe-producer/src/main/java/io/github/eschizoid/kpipe/producer/KPipeProducer.java
+++ b/lib/kpipe-producer/src/main/java/io/github/eschizoid/kpipe/producer/KPipeProducer.java
@@ -96,13 +96,12 @@ public class KPipeProducer<K, V> implements AutoCloseable {
       return this;
     }
 
-    /// Sets the OpenTelemetry metrics instruments for this producer.
+    /// Sets the [ProducerMetrics] for this producer. The SPI is vendor-neutral (§10 "bring your own
+    /// SDK"): use `io.github.eschizoid.kpipe.metrics.otel.OtelProducerMetrics` from
+    /// `kpipe-metrics-otel` for an OpenTelemetry-backed instance, or [ProducerMetrics#noop()] for a
+    /// no-op default.
     ///
-    /// Use `io.github.eschizoid.kpipe.metrics.otel.OtelProducerMetrics` to create an instrumented
-    /// instance, or
-    /// [ProducerMetrics#noop()] for a no-op default.
-    ///
-    /// @param metrics the producer metrics instruments
+    /// @param metrics the producer metrics
     /// @return this builder instance for method chaining
     public Builder<K, V> withMetrics(final ProducerMetrics metrics) {
       this.metrics = metrics;

--- a/lib/kpipe-producer/src/main/java/io/github/eschizoid/kpipe/producer/sink/KafkaMessageSink.java
+++ b/lib/kpipe-producer/src/main/java/io/github/eschizoid/kpipe/producer/sink/KafkaMessageSink.java
@@ -72,10 +72,16 @@ public class KafkaMessageSink<T> implements MessageSink<T> {
     }
     producer.send(record, (_, exception) -> {
       if (exception != null) {
-        metrics.recordMessageFailed();
         LOGGER.log(Level.WARNING, () -> "Failed to send record to topic " + topic, exception);
-      } else {
-        metrics.recordMessageSent();
+      }
+      // Count after logging, and guard the user-supplied metrics impl the same way tracer is
+      // guarded above: a throwing ProducerMetrics must never crash the producer callback thread or
+      // swallow the failure log (§11 error-handler safety).
+      try {
+        if (exception == null) metrics.recordMessageSent();
+        else metrics.recordMessageFailed();
+      } catch (final Exception metricsEx) {
+        LOGGER.log(Level.WARNING, "ProducerMetrics callback threw", metricsEx);
       }
     });
   }

--- a/lib/kpipe-producer/src/main/java/io/github/eschizoid/kpipe/producer/sink/KafkaMessageSink.java
+++ b/lib/kpipe-producer/src/main/java/io/github/eschizoid/kpipe/producer/sink/KafkaMessageSink.java
@@ -1,5 +1,6 @@
 package io.github.eschizoid.kpipe.producer.sink;
 
+import io.github.eschizoid.kpipe.metrics.ProducerMetrics;
 import io.github.eschizoid.kpipe.producer.tracing.Tracer;
 import io.github.eschizoid.kpipe.sink.MessageSink;
 import java.lang.System.Logger;
@@ -12,7 +13,9 @@ import org.apache.kafka.clients.producer.ProducerRecord;
 /// A [MessageSink] that sends processed messages to a Kafka topic.
 ///
 /// Send failures are reported via the producer's async callback at WARNING level so they don't
-/// disappear silently. The Kafka `Future<RecordMetadata>` is otherwise discarded — callers who
+/// disappear silently, and each outcome increments the configured [ProducerMetrics]
+/// (`recordMessageSent` / `recordMessageFailed`) so sends through this sink are counted the same way
+/// as `KPipeProducer`'s. The Kafka `Future<RecordMetadata>` is otherwise discarded — callers who
 /// need synchronous send semantics or precise failure handling per record should use
 /// `KPipeProducer.send` / `sendAsync` directly rather than wiring this sink.
 ///
@@ -29,6 +32,7 @@ public class KafkaMessageSink<T> implements MessageSink<T> {
   private final String topic;
   private final Function<T, byte[]> keyMapper;
   private final Function<T, byte[]> valueMapper;
+  private final ProducerMetrics metrics;
   private final Tracer tracer;
 
   /// Creates a new KafkaMessageSink.
@@ -37,18 +41,21 @@ public class KafkaMessageSink<T> implements MessageSink<T> {
   /// @param topic       the destination topic
   /// @param keyMapper   function to serialize the key (may be null for null keys)
   /// @param valueMapper function to serialize the value
+  /// @param metrics     counts sent / failed records; pass `null` for a no-op
   /// @param tracer      injects span context into outbound headers; pass `null` to disable
   public KafkaMessageSink(
     final Producer<byte[], byte[]> producer,
     final String topic,
     final Function<T, byte[]> keyMapper,
     final Function<T, byte[]> valueMapper,
+    final ProducerMetrics metrics,
     final Tracer tracer
   ) {
     this.producer = Objects.requireNonNull(producer, "producer cannot be null");
     this.topic = Objects.requireNonNull(topic, "topic cannot be null");
     this.keyMapper = keyMapper;
     this.valueMapper = Objects.requireNonNull(valueMapper, "valueMapper cannot be null");
+    this.metrics = metrics != null ? metrics : ProducerMetrics.noop();
     this.tracer = tracer != null ? tracer : Tracer.noop();
   }
 
@@ -65,7 +72,10 @@ public class KafkaMessageSink<T> implements MessageSink<T> {
     }
     producer.send(record, (_, exception) -> {
       if (exception != null) {
+        metrics.recordMessageFailed();
         LOGGER.log(Level.WARNING, () -> "Failed to send record to topic " + topic, exception);
+      } else {
+        metrics.recordMessageSent();
       }
     });
   }
@@ -75,6 +85,7 @@ public class KafkaMessageSink<T> implements MessageSink<T> {
   /// @param producer    the Kafka producer to use
   /// @param topic       the destination topic
   /// @param valueMapper function to serialize the value
+  /// @param metrics     counts sent / failed records; pass `null` for a no-op
   /// @param tracer      injects span context into outbound headers; pass `null` to disable
   /// @param <T>         the type of the processed object
   /// @return a new KafkaMessageSink
@@ -82,8 +93,9 @@ public class KafkaMessageSink<T> implements MessageSink<T> {
     final Producer<byte[], byte[]> producer,
     final String topic,
     final Function<T, byte[]> valueMapper,
+    final ProducerMetrics metrics,
     final Tracer tracer
   ) {
-    return new KafkaMessageSink<>(producer, topic, null, valueMapper, tracer);
+    return new KafkaMessageSink<>(producer, topic, null, valueMapper, metrics, tracer);
   }
 }

--- a/lib/kpipe-producer/src/test/java/io/github/eschizoid/kpipe/producer/sink/KafkaMessageSinkTest.java
+++ b/lib/kpipe-producer/src/test/java/io/github/eschizoid/kpipe/producer/sink/KafkaMessageSinkTest.java
@@ -4,11 +4,13 @@ import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 
+import io.github.eschizoid.kpipe.metrics.ProducerMetrics;
 import org.apache.kafka.clients.producer.Callback;
 import org.apache.kafka.clients.producer.Producer;
 import org.apache.kafka.common.KafkaException;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
@@ -22,7 +24,7 @@ class KafkaMessageSinkTest {
 
   @Test
   void shouldSendToKafka() {
-    final KafkaMessageSink<String> sink = KafkaMessageSink.of(mockProducer, TOPIC, String::getBytes, null);
+    final KafkaMessageSink<String> sink = KafkaMessageSink.of(mockProducer, TOPIC, String::getBytes, null, null);
 
     sink.accept("hello");
 
@@ -44,6 +46,7 @@ class KafkaMessageSinkTest {
       TOPIC,
       _ -> "key".getBytes(),
       String::getBytes,
+      null,
       null
     );
 
@@ -62,11 +65,41 @@ class KafkaMessageSinkTest {
 
   @Test
   void shouldNotSendWhenValueIsNull() {
-    final KafkaMessageSink<String> sink = KafkaMessageSink.of(mockProducer, TOPIC, String::getBytes, null);
+    final KafkaMessageSink<String> sink = KafkaMessageSink.of(mockProducer, TOPIC, String::getBytes, null, null);
 
     sink.accept(null);
 
     verifyNoInteractions(mockProducer);
+  }
+
+  @Test
+  void metricsCountSentOnSuccessfulCallback() {
+    final var metrics = mock(ProducerMetrics.class);
+    final var sink = new KafkaMessageSink<String>(mockProducer, TOPIC, null, String::getBytes, metrics, null);
+
+    sink.accept("hello");
+
+    final var callback = ArgumentCaptor.forClass(Callback.class);
+    verify(mockProducer).send(any(), callback.capture());
+    callback.getValue().onCompletion(null, null); // success — no exception
+
+    verify(metrics, times(1)).recordMessageSent();
+    verify(metrics, never()).recordMessageFailed();
+  }
+
+  @Test
+  void metricsCountFailedOnErrorCallback() {
+    final var metrics = mock(ProducerMetrics.class);
+    final var sink = new KafkaMessageSink<String>(mockProducer, TOPIC, null, String::getBytes, metrics, null);
+
+    sink.accept("hello");
+
+    final var callback = ArgumentCaptor.forClass(Callback.class);
+    verify(mockProducer).send(any(), callback.capture());
+    callback.getValue().onCompletion(null, new KafkaException("async send failed"));
+
+    verify(metrics, times(1)).recordMessageFailed();
+    verify(metrics, never()).recordMessageSent();
   }
 
   /// When the underlying Kafka `Producer.send` throws a `KafkaException` synchronously (e.g.
@@ -80,7 +113,7 @@ class KafkaMessageSinkTest {
     final var failure = new KafkaException("synchronous send failure");
     when(mockProducer.send(any(), any(Callback.class))).thenThrow(failure);
 
-    final KafkaMessageSink<String> sink = KafkaMessageSink.of(mockProducer, TOPIC, String::getBytes, null);
+    final KafkaMessageSink<String> sink = KafkaMessageSink.of(mockProducer, TOPIC, String::getBytes, null, null);
 
     final var thrown = assertThrows(KafkaException.class, () -> sink.accept("payload"));
     assertSame(failure, thrown, "the original KafkaException must propagate unwrapped");
@@ -97,7 +130,7 @@ class KafkaMessageSinkTest {
     final var closed = new IllegalStateException("Cannot perform operation after producer has been closed");
     when(mockProducer.send(any(), any(Callback.class))).thenThrow(closed);
 
-    final KafkaMessageSink<String> sink = KafkaMessageSink.of(mockProducer, TOPIC, String::getBytes, null);
+    final KafkaMessageSink<String> sink = KafkaMessageSink.of(mockProducer, TOPIC, String::getBytes, null, null);
 
     final var thrown = assertThrows(IllegalStateException.class, () -> sink.accept("payload"));
     assertSame(closed, thrown, "the closed-producer ISE must propagate unwrapped");
@@ -108,7 +141,7 @@ class KafkaMessageSinkTest {
   /// assignment falls back to the configured partitioner — round-robin / sticky for the default).
   @Test
   void ofStaticFactoryWithNullKeyAccepted() {
-    final KafkaMessageSink<String> sink = KafkaMessageSink.of(mockProducer, TOPIC, String::getBytes, null);
+    final KafkaMessageSink<String> sink = KafkaMessageSink.of(mockProducer, TOPIC, String::getBytes, null, null);
 
     sink.accept("payload");
 

--- a/lib/kpipe-tracing-otel/src/test/java/io/github/eschizoid/kpipe/tracing/otel/TracePropagationIntegrationTest.java
+++ b/lib/kpipe-tracing-otel/src/test/java/io/github/eschizoid/kpipe/tracing/otel/TracePropagationIntegrationTest.java
@@ -108,7 +108,7 @@ class TracePropagationIntegrationTest {
     // The KPipe consumer produces to the output topic via KafkaMessageSink (with the same tracer
     // so it injects the active context into outbound headers).
     final Producer<byte[], byte[]> sinkProducer = new KafkaProducer<>(producerProps());
-    final var sink = KafkaMessageSink.<byte[]>of(sinkProducer, outputTopic, v -> v, tracer);
+    final var sink = KafkaMessageSink.<byte[]>of(sinkProducer, outputTopic, v -> v, null, tracer);
 
     final var handle = KPipe.bytes(inputTopic, consumerProps("trace-prop-group-" + UUID.randomUUID()))
       .withTracer(tracer)


### PR DESCRIPTION
Two producer-module observability cleanups from the architecture backlog.

## 1. KafkaMessageSink counted no metrics
`KafkaMessageSink` (the facade custom terminal Kafka sink) sent via the raw producer and logged failures at WARNING, but incremented **no** `ProducerMetrics` — so sends through this sink were invisible to metrics, unlike the DLQ path in `KPipeProducer`. That's the §12 "sends invisible" triage trap: a rising processed count with a flat sent count and no signal why.

Fix: thread a `ProducerMetrics` through (nullable → noop, **mirroring the existing `tracer` handling**) and count `recordMessageSent` / `recordMessageFailed` in the async send callback. All call sites migrated in the same PR (§16, no deprecation).

## 2. `otelMetrics` field name re-coupled the §10 abstraction
`KPipeProducer`'s metrics field was named `otelMetrics` but typed as the vendor-neutral `ProducerMetrics` SPI (the Builder param was already `metrics`). The name implied OTel where the whole §10 point is "bring your own SDK." Renamed to `metrics`; the ctor Javadoc now names the SPI, not the impl.

## Tests
Two new `KafkaMessageSink` tests capture the send callback and assert `recordMessageSent` fires on success and `recordMessageFailed` on an async error. Existing send/tracer/propagation tests migrated to the new signature.

## Verification
`./gradlew :lib:kpipe-producer:test :lib:kpipe-consumer:compileTestJava :lib:kpipe-tracing-otel:compileTestJava` — BUILD SUCCESSFUL.

Note: `KPipeConsumer` carries the same `otelMetrics`-for-a-neutral-SPI misnaming; deferred to a follow-up rather than doing a blind rename in that 1974-line class (shadowing risk), and best folded into the planned `KPipeConsumerBuilder` extraction.