### PR TITLE
fix(consumer): add a safety-net catch to ParallelDispatcher, matching KeyOrderedDispatcher

### DIFF
--- a/lib/kpipe-consumer/src/main/java/io/github/eschizoid/kpipe/consumer/ParallelDispatcher.java
+++ b/lib/kpipe-consumer/src/main/java/io/github/eschizoid/kpipe/consumer/ParallelDispatcher.java
@@ -43,11 +43,12 @@ final class ParallelDispatcher implements Dispatcher {
     this.terminationTimeout = terminationTimeout;
   }
 
-  /// `processTask` must handle its own exceptions — `executor.submit(Runnable)` returns a `Future`
-  /// that the dispatcher discards, so any throwable escaping `processTask.run()` is silently
-  /// swallowed by the VT executor. The finally block still decrements `inFlight` and fires
-  /// `onComplete` so accounting and backpressure remain honest, but the failure itself only
-  /// surfaces if `processTask` routed it (e.g. through the consumer's error handler / DLQ).
+  /// `processTask` is expected to handle its own exceptions (the consumer's per-record error
+  /// handling / DLQ runs inside it). As a safety net for a contract violation, an outer
+  /// `catch (Throwable)` logs anything that still escapes `processTask.run()` at ERROR rather than
+  /// letting the discarded `Future` from `executor.submit(...)` swallow it silently — mirroring
+  /// [KeyOrderedDispatcher]'s drain loop. The finally block always decrements `inFlight` and fires
+  /// `onComplete` (itself guarded) so accounting and backpressure stay honest.
   @Override
   public void dispatch(
     final ConsumerRecord<byte[], byte[]> record,
@@ -58,10 +59,22 @@ final class ParallelDispatcher implements Dispatcher {
     try {
       executor.submit(() -> {
         try {
-          processTask.run();
-        } finally {
-          inFlight.decrementAndGet();
-          onComplete.run();
+          try {
+            processTask.run();
+          } finally {
+            inFlight.decrementAndGet();
+            try {
+              onComplete.run();
+            } catch (final RuntimeException e) {
+              LOGGER.log(Level.WARNING, "onComplete callback threw", e);
+            }
+          }
+        } catch (final Throwable t) {
+          LOGGER.log(
+            Level.ERROR,
+            "Dispatched record task threw; the record's own error handling should have caught it",
+            t
+          );
         }
       });
     } catch (final RejectedExecutionException e) {

--- a/lib/kpipe-consumer/src/test/java/io/github/eschizoid/kpipe/consumer/ParallelDispatcherTest.java
+++ b/lib/kpipe-consumer/src/test/java/io/github/eschizoid/kpipe/consumer/ParallelDispatcherTest.java
@@ -5,9 +5,16 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.time.Duration;
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.BooleanSupplier;
+import java.util.logging.Handler;
+import java.util.logging.Level;
+import java.util.logging.LogRecord;
+import java.util.logging.Logger;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.junit.jupiter.api.Test;
 
@@ -27,6 +34,97 @@ class ParallelDispatcherTest {
 
   private static ParallelDispatcher newDispatcher(final AtomicInteger rejectCount, final Duration terminationTimeout) {
     return new ParallelDispatcher((_, _) -> rejectCount.incrementAndGet(), terminationTimeout);
+  }
+
+  /// Captures [ParallelDispatcher]'s log records at or above `threshold` via a JUL handler
+  /// (`System.Logger` delegates to JUL). Returns the live list plus a detach hook to restore state.
+  private record LogCapture(List<LogRecord> records, Runnable detach) {}
+
+  private static LogCapture captureLogs(final Level threshold) {
+    final var jul = Logger.getLogger(ParallelDispatcher.class.getName());
+    final var captured = new CopyOnWriteArrayList<LogRecord>();
+    final var handler = new Handler() {
+      @Override
+      public void publish(final LogRecord r) {
+        if (r.getLevel().intValue() >= threshold.intValue()) captured.add(r);
+      }
+
+      @Override
+      public void flush() {}
+
+      @Override
+      public void close() {}
+    };
+    final var origLevel = jul.getLevel();
+    final var origUseParent = jul.getUseParentHandlers();
+    jul.addHandler(handler);
+    jul.setLevel(Level.ALL);
+    jul.setUseParentHandlers(false);
+    return new LogCapture(captured, () -> {
+      jul.removeHandler(handler);
+      jul.setLevel(origLevel);
+      jul.setUseParentHandlers(origUseParent);
+    });
+  }
+
+  private static void awaitTrue(final BooleanSupplier cond) throws InterruptedException {
+    final var deadline = System.nanoTime() + Duration.ofSeconds(2).toNanos();
+    while (!cond.getAsBoolean() && System.nanoTime() < deadline) Thread.sleep(5);
+  }
+
+  @Test
+  void throwingTaskIsLoggedBySafetyNetNotSwallowed() throws InterruptedException {
+    // The discarded Future from executor.submit(...) would otherwise swallow a throwable escaping
+    // processTask (a contract violation — processTask owns its error handling). The outer
+    // catch(Throwable) logs it at ERROR (JUL SEVERE), mirroring KeyOrderedDispatcher, so the bug
+    // is visible instead of lost.
+    final var capture = captureLogs(Level.SEVERE);
+    final var dispatcher = newDispatcher(new AtomicInteger(0));
+    final var completed = new CountDownLatch(1);
+    try {
+      dispatcher.dispatch(
+        record(0),
+        () -> {
+          throw new RuntimeException("boom");
+        },
+        completed::countDown
+      );
+      assertTrue(completed.await(2, TimeUnit.SECONDS), "onComplete must fire even when the task throws");
+      awaitTrue(() -> !capture.records().isEmpty());
+      assertEquals(1, capture.records().size(), "the escaping throwable must be logged once at ERROR");
+      assertTrue(
+        capture.records().getFirst().getThrown() instanceof RuntimeException,
+        "the original throwable must be attached to the log record"
+      );
+    } finally {
+      capture.detach().run();
+      dispatcher.close();
+    }
+  }
+
+  @Test
+  void throwingOnCompleteIsGuardedAndInFlightStillDrains() throws InterruptedException {
+    // onComplete is the consumer's afterRecordComplete hook. A bug making it throw must be caught
+    // (logged at WARNING), never escape into the discarded Future, and never strand the in-flight
+    // counter — the decrement runs before onComplete in the finally.
+    final var capture = captureLogs(Level.WARNING);
+    final var dispatcher = newDispatcher(new AtomicInteger(0));
+    final var ran = new CountDownLatch(1);
+    try {
+      dispatcher.dispatch(record(0), ran::countDown, () -> {
+        throw new IllegalStateException("onComplete boom");
+      });
+      assertTrue(ran.await(2, TimeUnit.SECONDS), "processTask must run");
+      awaitTrue(() -> dispatcher.pendingCount() == 0 && !capture.records().isEmpty());
+      assertEquals(0, dispatcher.pendingCount(), "a throwing onComplete must not strand in-flight");
+      assertTrue(
+        capture.records().stream().anyMatch(r -> r.getMessage().contains("onComplete callback threw")),
+        "the throwing onComplete must be logged at WARNING"
+      );
+    } finally {
+      capture.detach().run();
+      dispatcher.close();
+    }
   }
 
   @Test


### PR DESCRIPTION
Closes a §12 silent-failure asymmetry between the two async dispatchers.

## Problem
`ParallelDispatcher.dispatch` submitted each record to the VT executor and **discarded the `Future`**. A throwable escaping `processTask.run()` — a contract violation, since `processTask` runs the consumer's per-record error handling / DLQ — was captured by the `FutureTask` and silently lost. `KeyOrderedDispatcher.drain` already wraps its task in a `catch(Throwable)` that logs at ERROR, so the two dispatchers had an **inconsistent silent-failure surface** (the kind that's "one refactor away" from hiding a real bug).

## Fix
Mirror `KeyOrderedDispatcher`'s structure exactly:
- inner `try(processTask)` / `finally(decrement inFlight + guarded onComplete)`,
- wrapped in an outer `catch(Throwable)` that logs the escaping throwable at **ERROR** instead of letting the discarded `Future` eat it.
- `onComplete` is now guarded too (WARNING on throw), so a bug in the `afterRecordComplete` hook can't escape into the `Future` either.

Accounting/backpressure are unchanged — the `finally` still decrements exactly once (the existing `pendingCount*` tests still pass).

## Tests
A JUL-handler log capture (mirroring `KeyOrderedDispatcherTest`) proves the escaping throwable is **logged once at ERROR with the cause attached**, and that a throwing `onComplete` is logged at WARNING **without stranding in-flight**.

## Verification
`./gradlew :lib:kpipe-consumer:test --tests "*ParallelDispatcherTest"` — BUILD SUCCESSFUL (10 tests).