### PR TITLE
refactor(consumer): replace stringly-typed offset observability with typed records

### DIFF
--- a/lib/kpipe-consumer/src/jcstress/java/io/github/eschizoid/kpipe/consumer/OffsetManagerGapHoldJCStressTest.java
+++ b/lib/kpipe-consumer/src/jcstress/java/io/github/eschizoid/kpipe/consumer/OffsetManagerGapHoldJCStressTest.java
@@ -67,7 +67,7 @@ public class OffsetManagerGapHoldJCStressTest {
 
   @Arbiter
   public void observe(final J_Result r) {
-    r.r1 = (long) manager.getPartitionState(PARTITION).get("nextOffsetToCommit");
+    r.r1 = (long) manager.getPartitionState(PARTITION).nextOffsetToCommit();
   }
 
   private static ConsumerRecord<byte[], byte[]> record(final long offset) {

--- a/lib/kpipe-consumer/src/jcstress/java/io/github/eschizoid/kpipe/consumer/OffsetManagerLowestPendingJCStressTest.java
+++ b/lib/kpipe-consumer/src/jcstress/java/io/github/eschizoid/kpipe/consumer/OffsetManagerLowestPendingJCStressTest.java
@@ -65,7 +65,7 @@ public class OffsetManagerLowestPendingJCStressTest {
 
   @Arbiter
   public void observe(final J_Result r) {
-    r.r1 = (long) manager.getPartitionState(PARTITION).get("nextOffsetToCommit");
+    r.r1 = (long) manager.getPartitionState(PARTITION).nextOffsetToCommit();
   }
 
   private static ConsumerRecord<byte[], byte[]> record(final long offset) {

--- a/lib/kpipe-consumer/src/jcstress/java/io/github/eschizoid/kpipe/consumer/OffsetManagerRevokeRaceJCStressTest.java
+++ b/lib/kpipe-consumer/src/jcstress/java/io/github/eschizoid/kpipe/consumer/OffsetManagerRevokeRaceJCStressTest.java
@@ -81,8 +81,8 @@ public class OffsetManagerRevokeRaceJCStressTest {
   @Arbiter
   public void observe(final JZ_Result r) {
     final var partitionState = manager.getPartitionState(PARTITION);
-    r.r1 = (long) partitionState.get("nextOffsetToCommit");
-    r.r2 = ((int) partitionState.get("pendingCount")) > 0;
+    r.r1 = (long) partitionState.nextOffsetToCommit();
+    r.r2 = ((int) partitionState.pendingCount()) > 0;
   }
 
   private static ConsumerRecord<byte[], byte[]> record(final long offset) {

--- a/lib/kpipe-consumer/src/jcstress/java/io/github/eschizoid/kpipe/consumer/RemoveIfEmptyJCStressTest.java
+++ b/lib/kpipe-consumer/src/jcstress/java/io/github/eschizoid/kpipe/consumer/RemoveIfEmptyJCStressTest.java
@@ -64,8 +64,8 @@ public class RemoveIfEmptyJCStressTest {
   @Arbiter
   public void observe(final JJ_Result r) {
     final var state = manager.getPartitionState(PARTITION);
-    r.r1 = (long) state.get("nextOffsetToCommit");
-    r.r2 = ((Number) state.get("pendingCount")).longValue();
+    r.r1 = (long) state.nextOffsetToCommit();
+    r.r2 = state.pendingCount();
   }
 
   private static ConsumerRecord<byte[], byte[]> record(final long offset) {

--- a/lib/kpipe-consumer/src/jcstress/java/io/github/eschizoid/kpipe/consumer/SafeFirstJCStressTest.java
+++ b/lib/kpipe-consumer/src/jcstress/java/io/github/eschizoid/kpipe/consumer/SafeFirstJCStressTest.java
@@ -31,7 +31,7 @@ import org.openjdk.jcstress.infra.results.J_Result;
 /// set starts holding exactly that one element — the set most likely to be observed mid-drain.
 /// The remover actor marks offset 100 processed, which removes it from the set and clears the
 /// partition entry once empty. The reader actor reads the commit point via
-/// `getPartitionState(...).get("nextOffsetToCommit")`, which routes through `firstOrNull`. The two
+/// `getPartitionState(...).nextOffsetToCommit()`, which routes through `firstOrNull`. The two
 /// run concurrently under every interleaving the scheduler can produce.
 ///
 /// The property under test is narrow and exact: the commit-point read must never throw, no matter
@@ -82,7 +82,7 @@ public class SafeFirstJCStressTest {
 
   @Actor
   public void reader(final J_Result r) {
-    r.r1 = (long) manager.getPartitionState(PARTITION).get("nextOffsetToCommit");
+    r.r1 = (long) manager.getPartitionState(PARTITION).nextOffsetToCommit();
   }
 
   private static ConsumerRecord<byte[], byte[]> record(final long offset) {

--- a/lib/kpipe-consumer/src/main/java/io/github/eschizoid/kpipe/consumer/KafkaOffsetManager.java
+++ b/lib/kpipe-consumer/src/main/java/io/github/eschizoid/kpipe/consumer/KafkaOffsetManager.java
@@ -386,68 +386,72 @@ public class KafkaOffsetManager implements OffsetManager {
     }
   }
 
-  /// Returns a snapshot of the current processing state for a partition.
+  /// Returns a typed snapshot of the current processing state for a partition.
   ///
   /// @param partition The partition to get state for
-  /// @return Map containing state information
-  public Map<String, Object> getPartitionState(final TopicPartition partition) {
-    final var state = new HashMap<String, Object>();
+  /// @return the partition's offset-tracking state
+  public PartitionState getPartitionState(final TopicPartition partition) {
     final var pending = pendingOffsets.get(partition);
     final var highestProcessed = highestProcessedOffsets.get(partition);
     final var lowestPending = pending != null ? pending.firstOrNull() : null;
 
+    final long nextOffsetToCommit;
     if (lowestPending != null) {
-      state.put("nextOffsetToCommit", lowestPending);
+      nextOffsetToCommit = lowestPending;
     } else if (highestProcessed != null) {
-      state.put("nextOffsetToCommit", highestProcessed + 1);
+      nextOffsetToCommit = highestProcessed + 1;
     } else {
-      state.put("nextOffsetToCommit", -1L);
+      nextOffsetToCommit = -1L;
     }
 
-    state.put("highestProcessedOffset", highestProcessed != null ? highestProcessed : -1L);
-    state.put("managerState", this.state.get().name());
-
-    if (pending != null) {
-      state.put("pendingCount", pending.size());
-      if (lowestPending != null) {
-        state.put("lowestPendingOffset", lowestPending);
-        final var highestPending = pending.lastOrNull();
-        if (highestPending != null) state.put("highestPendingOffset", highestPending);
-      }
-    } else {
-      state.put("pendingCount", 0);
+    var lowestPendingOffset = OptionalLong.empty();
+    var highestPendingOffset = OptionalLong.empty();
+    if (pending != null && lowestPending != null) {
+      lowestPendingOffset = OptionalLong.of(lowestPending);
+      final var highestPending = pending.lastOrNull();
+      if (highestPending != null) highestPendingOffset = OptionalLong.of(highestPending);
     }
 
-    return state;
+    return new PartitionState(
+      nextOffsetToCommit,
+      highestProcessed != null ? highestProcessed : -1L,
+      this.state.get(),
+      pending != null ? pending.size() : 0,
+      lowestPendingOffset,
+      highestPendingOffset
+    );
   }
 
-  /// Returns overall statistics about all partitions being managed.
+  /// Returns typed overall statistics about all partitions being managed.
   ///
-  /// @return Map containing statistics for all partitions
+  /// @return statistics across all partitions
   @Override
-  public Map<String, Object> getStatistics() {
-    final var stats = new HashMap<String, Object>();
-    final var allPartitions = new HashSet<>();
-
+  public OffsetStatistics getStatistics() {
+    final var allPartitions = new HashSet<TopicPartition>();
     allPartitions.addAll(pendingOffsets.keySet());
     allPartitions.addAll(highestProcessedOffsets.keySet());
-    stats.put("partitionCount", allPartitions.size());
 
-    stats.put("totalPendingOffsets", pendingOffsets.values().stream().mapToInt(PendingOffsetSet::size).sum());
-    stats.put("totalProcessedPartitions", highestProcessedOffsets.size());
-    stats.put("managerState", state.get().name());
+    final var totalPending = pendingOffsets.values().stream().mapToInt(PendingOffsetSet::size).sum();
 
+    final Map<TopicPartition, Long> byPartition;
+    final double average;
     if (!highestProcessedOffsets.isEmpty()) {
-      stats.put("highestProcessedOffsetsByPartition", new HashMap<>(highestProcessedOffsets));
-      stats.put(
-        "averageHighestProcessedOffset",
-        highestProcessedOffsets.values().stream().mapToLong(Long::longValue).average().orElse(0)
-      );
+      byPartition = new HashMap<>(highestProcessedOffsets);
+      average = highestProcessedOffsets.values().stream().mapToLong(Long::longValue).average().orElse(0);
+    } else {
+      byPartition = Map.of();
+      average = 0.0;
     }
 
-    stats.put("pendingCommits", commitFutures.size());
-
-    return stats;
+    return new OffsetStatistics(
+      allPartitions.size(),
+      totalPending,
+      highestProcessedOffsets.size(),
+      state.get(),
+      byPartition,
+      average,
+      commitFutures.size()
+    );
   }
 
   /// Gets the current state of the KafkaOffsetManager.

--- a/lib/kpipe-consumer/src/main/java/io/github/eschizoid/kpipe/consumer/OffsetManager.java
+++ b/lib/kpipe-consumer/src/main/java/io/github/eschizoid/kpipe/consumer/OffsetManager.java
@@ -62,8 +62,8 @@ public interface OffsetManager extends AutoCloseable {
   boolean isRunning();
 
   /// Gets statistics about the offset manager's performance and state.
-  /// @return A map containing statistics
-  Map<String, Object> getStatistics();
+  /// @return a typed statistics snapshot
+  OffsetStatistics getStatistics();
 
   @Override
   void close();

--- a/lib/kpipe-consumer/src/main/java/io/github/eschizoid/kpipe/consumer/OffsetStatistics.java
+++ b/lib/kpipe-consumer/src/main/java/io/github/eschizoid/kpipe/consumer/OffsetStatistics.java
@@ -1,0 +1,33 @@
+package io.github.eschizoid.kpipe.consumer;
+
+import java.util.Map;
+import org.apache.kafka.common.TopicPartition;
+
+/// Typed snapshot of an offset manager's overall state, returned by [OffsetManager#getStatistics].
+/// Replaces the former stringly-typed `Map<String, Object>` so callers read fields directly instead
+/// of casting magic-string keys. Test/observability use only — not on the user-facing `Handle`.
+///
+/// @param partitionCount                      distinct partitions being tracked
+/// @param totalPendingOffsets                 in-flight offsets summed across all partitions
+/// @param totalProcessedPartitions            partitions with at least one processed offset
+/// @param managerState                        the offset manager's lifecycle state
+/// @param highestProcessedOffsetsByPartition  per-partition highest processed offset (empty if none)
+/// @param averageHighestProcessedOffset       mean of the per-partition highest offsets, `0` if none
+/// @param pendingCommits                      commits issued but not yet acknowledged
+public record OffsetStatistics(
+  int partitionCount,
+  int totalPendingOffsets,
+  int totalProcessedPartitions,
+  OffsetState managerState,
+  Map<TopicPartition, Long> highestProcessedOffsetsByPartition,
+  double averageHighestProcessedOffset,
+  int pendingCommits
+) {
+  /// An empty statistics snapshot for offset managers that don't track per-partition detail
+  /// (e.g. test fakes and external-store managers).
+  ///
+  /// @return a zeroed snapshot in the `CREATED` state
+  public static OffsetStatistics empty() {
+    return new OffsetStatistics(0, 0, 0, OffsetState.CREATED, Map.of(), 0.0, 0);
+  }
+}

--- a/lib/kpipe-consumer/src/main/java/io/github/eschizoid/kpipe/consumer/PartitionState.java
+++ b/lib/kpipe-consumer/src/main/java/io/github/eschizoid/kpipe/consumer/PartitionState.java
@@ -1,0 +1,23 @@
+package io.github.eschizoid.kpipe.consumer;
+
+import java.util.OptionalLong;
+
+/// Typed snapshot of one partition's offset-tracking state, returned by
+/// [KafkaOffsetManager#getPartitionState]. Replaces the former stringly-typed `Map<String, Object>`
+/// so callers read fields directly instead of casting magic-string keys.
+///
+/// @param nextOffsetToCommit    the offset the manager would next commit, or `-1` if the partition
+///                              has neither pending nor processed offsets
+/// @param highestProcessedOffset the highest offset marked processed, or `-1` if none
+/// @param managerState          the offset manager's lifecycle state
+/// @param pendingCount          number of offsets currently in flight (not yet committed)
+/// @param lowestPendingOffset   the lowest in-flight offset, empty if none pending
+/// @param highestPendingOffset  the highest in-flight offset, empty if none pending
+public record PartitionState(
+  long nextOffsetToCommit,
+  long highestProcessedOffset,
+  OffsetState managerState,
+  int pendingCount,
+  OptionalLong lowestPendingOffset,
+  OptionalLong highestPendingOffset
+) {}

--- a/lib/kpipe-consumer/src/test/java/io/github/eschizoid/kpipe/consumer/DispatcherIntegrationTest.java
+++ b/lib/kpipe-consumer/src/test/java/io/github/eschizoid/kpipe/consumer/DispatcherIntegrationTest.java
@@ -385,8 +385,8 @@ class DispatcherIntegrationTest {
             .allMatch(tp -> {
               final var st = manager.getPartitionState(tp);
               return (
-                ((Number) st.get("pendingCount")).intValue() == 0 &&
-                ((Number) st.get("highestProcessedOffset")).longValue() == recordsPerPartition - 1
+                st.pendingCount() == 0 &&
+                st.highestProcessedOffset() == recordsPerPartition - 1
               );
             }),
         5_000
@@ -396,17 +396,17 @@ class DispatcherIntegrationTest {
         final var state = manager.getPartitionState(tp);
         assertEquals(
           0,
-          ((Number) state.get("pendingCount")).intValue(),
+          state.pendingCount(),
           () -> "mode " + mode + " left pending offsets on " + tp + ": " + state
         );
         assertEquals(
           (recordsPerPartition - 1),
-          ((Number) state.get("highestProcessedOffset")).longValue(),
+          state.highestProcessedOffset(),
           () -> "mode " + mode + " did not mark all offsets processed on " + tp + ": " + state
         );
         assertEquals(
           recordsPerPartition,
-          ((Number) state.get("nextOffsetToCommit")).longValue(),
+          state.nextOffsetToCommit(),
           () -> "mode " + mode + " did not advance commit offset on " + tp + ": " + state
         );
       }

--- a/lib/kpipe-consumer/src/test/java/io/github/eschizoid/kpipe/consumer/DlqSendFailureTest.java
+++ b/lib/kpipe-consumer/src/test/java/io/github/eschizoid/kpipe/consumer/DlqSendFailureTest.java
@@ -326,8 +326,8 @@ class DlqSendFailureTest {
     }
 
     @Override
-    public Map<String, Object> getStatistics() {
-      return Map.of();
+    public OffsetStatistics getStatistics() {
+      return OffsetStatistics.empty();
     }
 
     @Override

--- a/lib/kpipe-consumer/src/test/java/io/github/eschizoid/kpipe/consumer/ExternalOffsetIntegrationTest.java
+++ b/lib/kpipe-consumer/src/test/java/io/github/eschizoid/kpipe/consumer/ExternalOffsetIntegrationTest.java
@@ -152,8 +152,8 @@ class ExternalOffsetIntegrationTest {
     }
 
     @Override
-    public Map<String, Object> getStatistics() {
-      return Map.of();
+    public OffsetStatistics getStatistics() {
+      return OffsetStatistics.empty();
     }
 
     @Override

--- a/lib/kpipe-consumer/src/test/java/io/github/eschizoid/kpipe/consumer/KPipeConsumerTest.java
+++ b/lib/kpipe-consumer/src/test/java/io/github/eschizoid/kpipe/consumer/KPipeConsumerTest.java
@@ -114,8 +114,8 @@ class KPipeConsumerTest {
     }
 
     @Override
-    public Map<String, Object> getStatistics() {
-      return Map.of();
+    public OffsetStatistics getStatistics() {
+      return OffsetStatistics.empty();
     }
 
     @Override

--- a/lib/kpipe-consumer/src/test/java/io/github/eschizoid/kpipe/consumer/KafkaOffsetManagerTest.java
+++ b/lib/kpipe-consumer/src/test/java/io/github/eschizoid/kpipe/consumer/KafkaOffsetManagerTest.java
@@ -99,7 +99,7 @@ class KafkaOffsetManagerTest {
       // Verify partition state after first commit
       assertEventually(
         () ->
-          expectedOffsetAfterFirstCommit == (long) offsetManager.getPartitionState(PARTITION).get("nextOffsetToCommit"),
+          expectedOffsetAfterFirstCommit == (long) offsetManager.getPartitionState(PARTITION).nextOffsetToCommit(),
         Duration.ofSeconds(2),
         "Offset after first commit should be %d".formatted(expectedOffsetAfterFirstCommit)
       );
@@ -119,7 +119,7 @@ class KafkaOffsetManagerTest {
       assertEventually(
         () ->
           expectedOffsetAfterSecondCommit ==
-          (long) offsetManager.getPartitionState(PARTITION).get("nextOffsetToCommit"),
+          (long) offsetManager.getPartitionState(PARTITION).nextOffsetToCommit(),
         Duration.ofSeconds(10),
         "Offset after second commit should be " + expectedOffsetAfterSecondCommit
       );
@@ -147,7 +147,7 @@ class KafkaOffsetManagerTest {
 
       // Verify the partition state after commit
       assertEventually(
-        () -> expectedOffsetAfterCommit == (long) offsetManager.getPartitionState(PARTITION).get("nextOffsetToCommit"),
+        () -> expectedOffsetAfterCommit == (long) offsetManager.getPartitionState(PARTITION).nextOffsetToCommit(),
         Duration.ofSeconds(2),
         "Offset after commit should be %d".formatted(expectedOffsetAfterCommit)
       );
@@ -175,7 +175,7 @@ class KafkaOffsetManagerTest {
 
       // Verify the partition state after commit
       assertEventually(
-        () -> expectedOffsetAfterCommit == (long) offsetManager.getPartitionState(PARTITION).get("nextOffsetToCommit"),
+        () -> expectedOffsetAfterCommit == (long) offsetManager.getPartitionState(PARTITION).nextOffsetToCommit(),
         Duration.ofSeconds(2),
         "Offset after commit should be %d".formatted(expectedOffsetAfterCommit)
       );
@@ -201,7 +201,7 @@ class KafkaOffsetManagerTest {
       final var stateAfterRevoke = offsetManager.getPartitionState(PARTITION);
       assertEquals(
         -1L,
-        stateAfterRevoke.get("nextOffsetToCommit"),
+        stateAfterRevoke.nextOffsetToCommit(),
         "Next offset to commit should be reset after revoke"
       );
 
@@ -215,7 +215,7 @@ class KafkaOffsetManagerTest {
       final var stateAfterAssign = offsetManager.getPartitionState(PARTITION);
       assertEquals(
         200L,
-        stateAfterAssign.get("nextOffsetToCommit"),
+        stateAfterAssign.nextOffsetToCommit(),
         "Next offset to commit should initialize from first record after assignment"
       );
     }
@@ -274,9 +274,9 @@ class KafkaOffsetManagerTest {
       listener.onPartitionsRevoked(List.of(PARTITION));
 
       // Revoked partition's state is gone
-      assertEquals(-1L, offsetManager.getPartitionState(PARTITION).get("nextOffsetToCommit"));
+      assertEquals(-1L, offsetManager.getPartitionState(PARTITION).nextOffsetToCommit());
       // Non-revoked partition is preserved
-      assertEquals(310L, offsetManager.getPartitionState(partition2).get("nextOffsetToCommit"));
+      assertEquals(310L, offsetManager.getPartitionState(partition2).nextOffsetToCommit());
     }
 
     /// Pre-existing commit commands targeting a revoked partition would commit against the
@@ -339,7 +339,7 @@ class KafkaOffsetManagerTest {
       assertEquals(1, commandQueue.size(), "command queue must be left alone after stop");
       assertEquals(
         100L,
-        offsetManager.getPartitionState(PARTITION).get("nextOffsetToCommit"),
+        offsetManager.getPartitionState(PARTITION).nextOffsetToCommit(),
         "partition state must survive a post-stop revoke (regression: would be -1 if revoke ran the clear loop)"
       );
     }
@@ -540,7 +540,7 @@ class KafkaOffsetManagerTest {
 
       // Verify internal state remained consistent
       final var state = offsetManager.getPartitionState(PARTITION);
-      assertEquals(101L, state.get("highestProcessedOffset"), "Should maintain highest processed offset");
+      assertEquals(101L, state.highestProcessedOffset(), "Should maintain highest processed offset");
     }
 
     @Test
@@ -1056,11 +1056,11 @@ class KafkaOffsetManagerTest {
       assertTrue(errors.isEmpty(), "no thread should fail: " + errors);
 
       final var stats = manager.getStatistics();
-      assertEquals(0, (int) stats.get("totalPendingOffsets"), "all tracked offsets should be marked");
+      assertEquals(0, (int) stats.totalPendingOffsets(), "all tracked offsets should be marked");
 
       // The "highest processed" offset must equal the last offset across all threads.
       final var partitionState = manager.getPartitionState(PARTITION);
-      assertEquals(totalOffsets - 1L, partitionState.get("highestProcessedOffset"));
+      assertEquals(totalOffsets - 1L, partitionState.highestProcessedOffset());
       manager.close();
     }
 
@@ -1244,7 +1244,7 @@ class KafkaOffsetManagerTest {
       // Assert: future was cleaned up via the finally block in performCommit().
       assertEquals(
         0,
-        ((Number) offsetManager.getStatistics().get("pendingCommits")).intValue(),
+        offsetManager.getStatistics().pendingCommits(),
         "pendingCommits should be 0 after timeout cleanup"
       );
     }

--- a/lib/kpipe-consumer/src/test/java/io/github/eschizoid/kpipe/consumer/LifecycleLeakCycleTest.java
+++ b/lib/kpipe-consumer/src/test/java/io/github/eschizoid/kpipe/consumer/LifecycleLeakCycleTest.java
@@ -102,8 +102,8 @@ class LifecycleLeakCycleTest {
     }
 
     @Override
-    public Map<String, Object> getStatistics() {
-      return Map.of();
+    public OffsetStatistics getStatistics() {
+      return OffsetStatistics.empty();
     }
 
     @Override

--- a/lib/kpipe-consumer/src/test/java/io/github/eschizoid/kpipe/consumer/MultiTopicUnroutedPolicyTest.java
+++ b/lib/kpipe-consumer/src/test/java/io/github/eschizoid/kpipe/consumer/MultiTopicUnroutedPolicyTest.java
@@ -134,7 +134,7 @@ class MultiTopicUnroutedPolicyTest {
     }
 
     @Override
-    public Map<String, Object> getStatistics() {
+    public OffsetStatistics getStatistics() {
       return delegate.getStatistics();
     }
 

--- a/lib/kpipe-consumer/src/test/java/io/github/eschizoid/kpipe/consumer/OffsetConcurrencyStressTest.java
+++ b/lib/kpipe-consumer/src/test/java/io/github/eschizoid/kpipe/consumer/OffsetConcurrencyStressTest.java
@@ -56,7 +56,7 @@ class OffsetConcurrencyStressTest {
   }
 
   private static long commitPoint(final KafkaOffsetManager manager, final TopicPartition partition) {
-    return (long) manager.getPartitionState(partition).get("nextOffsetToCommit");
+    return (long) manager.getPartitionState(partition).nextOffsetToCommit();
   }
 
   /// No commit past a gap under parallel marking: N virtual threads each own a disjoint contiguous
@@ -93,14 +93,16 @@ class OffsetConcurrencyStressTest {
       while (!stopProbe.get()) {
         try {
           final var s = manager.getPartitionState(partition);
-          final var next = (long) s.get("nextOffsetToCommit");
-          final var lowestPending = s.get("lowestPendingOffset");
-          if (lowestPending != null) {
+          final var next = (long) s.nextOffsetToCommit();
+          final var lowestPending = s.lowestPendingOffset();
+          if (lowestPending.isPresent()) {
             // Commit point can never exceed the lowest pending offset — it cannot jump
             // the gap.
-            if (next > (long) lowestPending) {
+            if (next > lowestPending.getAsLong()) {
               errors.add(
-                new AssertionError("commit point %d passed pending gap at %d".formatted(next, (long) lowestPending))
+                new AssertionError(
+                  "commit point %d passed pending gap at %d".formatted(next, lowestPending.getAsLong())
+                )
               );
             }
           }
@@ -145,9 +147,9 @@ class OffsetConcurrencyStressTest {
 
     // After drain: everything marked, no pending → commit point is exactly total.
     final var finalState = manager.getPartitionState(partition);
-    assertEquals(0, (int) finalState.get("pendingCount"), "no offset left pending");
+    assertEquals(0, (int) finalState.pendingCount(), "no offset left pending");
     assertEquals((long) total, commitPoint(manager, partition), "commit point is exactly highestProcessed+1");
-    assertEquals(total - 1L, (long) finalState.get("highestProcessedOffset"));
+    assertEquals(total - 1L, (long) finalState.highestProcessedOffset());
 
     manager.close();
   }
@@ -267,11 +269,13 @@ class OffsetConcurrencyStressTest {
           // Immediately probe: any pending offset must still pin the commit point at or
           // below it.
           final var s = manager.getPartitionState(partition);
-          final var next = (long) s.get("nextOffsetToCommit");
-          final var lowestPending = s.get("lowestPendingOffset");
-          if (lowestPending != null && next > (long) lowestPending) {
+          final var next = (long) s.nextOffsetToCommit();
+          final var lowestPending = s.lowestPendingOffset();
+          if (lowestPending.isPresent() && next > lowestPending.getAsLong()) {
             errors.add(
-              new AssertionError("post-revoke commit point %d skipped pending %d".formatted(next, (long) lowestPending))
+              new AssertionError(
+                "post-revoke commit point %d skipped pending %d".formatted(next, lowestPending.getAsLong())
+              )
             );
           }
           Thread.yield();
@@ -320,8 +324,8 @@ class OffsetConcurrencyStressTest {
 
     // After the dedicated thread's final quiescent revoke: state fully cleared, commit point -1.
     final var cleared = manager.getPartitionState(partition);
-    assertEquals(-1L, (long) cleared.get("nextOffsetToCommit"), "revoked partition reports cleared commit point");
-    assertEquals(0, (int) cleared.get("pendingCount"), "revoked partition has no pending offsets");
+    assertEquals(-1L, (long) cleared.nextOffsetToCommit(), "revoked partition reports cleared commit point");
+    assertEquals(0, (int) cleared.pendingCount(), "revoked partition has no pending offsets");
 
     // Rebalance-safe: a mark for the already-revoked/cleared partition is a clean no-op (no throw),
     // and the lazily re-created entry still obeys lowest-pending. trackOffset / markOffsetProcessed
@@ -366,12 +370,12 @@ class OffsetConcurrencyStressTest {
         for (final var partition : partitions) {
           try {
             final var s = manager.getPartitionState(partition);
-            final var next = (long) s.get("nextOffsetToCommit");
-            final var lowestPending = s.get("lowestPendingOffset");
-            if (lowestPending != null && next > (long) lowestPending) {
+            final var next = (long) s.nextOffsetToCommit();
+            final var lowestPending = s.lowestPendingOffset();
+            if (lowestPending.isPresent() && next > lowestPending.getAsLong()) {
               errors.add(
                 new AssertionError(
-                  "partition %s commit point %d passed gap %d".formatted(partition, next, (long) lowestPending)
+                  "partition %s commit point %d passed gap %d".formatted(partition, next, lowestPending.getAsLong())
                 )
               );
             }
@@ -415,13 +419,13 @@ class OffsetConcurrencyStressTest {
     // Each partition independently reaches the exact contiguous commit point.
     for (final var partition : partitions) {
       final var s = manager.getPartitionState(partition);
-      assertEquals(0, (int) s.get("pendingCount"), "partition " + partition + " fully drained");
+      assertEquals(0, (int) s.pendingCount(), "partition " + partition + " fully drained");
       assertEquals(
         (long) perPartitionTotal,
-        (long) s.get("nextOffsetToCommit"),
+        (long) s.nextOffsetToCommit(),
         "partition " + partition + " commits exactly highestProcessed+1"
       );
-      assertEquals(perPartitionTotal - 1L, (long) s.get("highestProcessedOffset"), "partition " + partition);
+      assertEquals(perPartitionTotal - 1L, (long) s.highestProcessedOffset(), "partition " + partition);
     }
 
     manager.close();

--- a/lib/kpipe-consumer/src/test/java/io/github/eschizoid/kpipe/consumer/OffsetInvariantPropertyTest.java
+++ b/lib/kpipe-consumer/src/test/java/io/github/eschizoid/kpipe/consumer/OffsetInvariantPropertyTest.java
@@ -67,7 +67,7 @@ class OffsetInvariantPropertyTest {
           highestMarked = Math.max(highestMarked, op.offset());
         }
 
-        final var commitPoint = (long) manager.getPartitionState(PARTITION).get("nextOffsetToCommit");
+        final var commitPoint = (long) manager.getPartitionState(PARTITION).nextOffsetToCommit();
 
         if (!pending.isEmpty()) {
           final var lowestPending = pending.stream().mapToLong(Long::longValue).min().orElseThrow();

--- a/lib/kpipe-consumer/src/test/java/io/github/eschizoid/kpipe/consumer/OffsetOrderingPropertyTest.java
+++ b/lib/kpipe-consumer/src/test/java/io/github/eschizoid/kpipe/consumer/OffsetOrderingPropertyTest.java
@@ -57,11 +57,11 @@ class OffsetOrderingPropertyTest {
   }
 
   private static long commitPoint(final KafkaOffsetManager manager, final TopicPartition tp) {
-    return (long) manager.getPartitionState(tp).get("nextOffsetToCommit");
+    return (long) manager.getPartitionState(tp).nextOffsetToCommit();
   }
 
   private static long highestProcessed(final KafkaOffsetManager manager, final TopicPartition tp) {
-    return (long) manager.getPartitionState(tp).get("highestProcessedOffset");
+    return (long) manager.getPartitionState(tp).highestProcessedOffset();
   }
 
   /// The commit point the spec mandates for a partition given its pending set and highest marked

--- a/lib/kpipe-consumer/src/test/java/io/github/eschizoid/kpipe/consumer/ProcessingModeSinkDlqMatrixTest.java
+++ b/lib/kpipe-consumer/src/test/java/io/github/eschizoid/kpipe/consumer/ProcessingModeSinkDlqMatrixTest.java
@@ -119,8 +119,8 @@ class ProcessingModeSinkDlqMatrixTest {
     }
 
     @Override
-    public Map<String, Object> getStatistics() {
-      return Map.of();
+    public OffsetStatistics getStatistics() {
+      return OffsetStatistics.empty();
     }
 
     @Override

--- a/lib/kpipe-consumer/src/test/java/io/github/eschizoid/kpipe/consumer/RebalanceAtScaleIntegrationTest.java
+++ b/lib/kpipe-consumer/src/test/java/io/github/eschizoid/kpipe/consumer/RebalanceAtScaleIntegrationTest.java
@@ -453,7 +453,7 @@ class RebalanceAtScaleIntegrationTest {
     }
 
     @Override
-    public Map<String, Object> getStatistics() {
+    public OffsetStatistics getStatistics() {
       return delegate.getStatistics();
     }
 

--- a/lib/kpipe-consumer/src/test/java/io/github/eschizoid/kpipe/consumer/RetryInterruptTest.java
+++ b/lib/kpipe-consumer/src/test/java/io/github/eschizoid/kpipe/consumer/RetryInterruptTest.java
@@ -107,16 +107,21 @@ class RetryInterruptTest {
     // Core no-loss assertion: the offset is still pending and the commit point points AT it, so on
     // the next poll the record is re-fetched and reprocessed rather than silently acknowledged.
     final var state = offsetManager.getPartitionState(TOPIC_PARTITION);
-    assertEquals(1, state.get("pendingCount"), "interrupted record must remain pending");
-    assertEquals(OFFSET, state.get("lowestPendingOffset"), "lowest pending offset must be the interrupted record");
+    assertEquals(1, state.pendingCount(), "interrupted record must remain pending");
+    assertTrue(state.lowestPendingOffset().isPresent(), "there must be a lowest pending offset");
     assertEquals(
       OFFSET,
-      state.get("nextOffsetToCommit"),
+      state.lowestPendingOffset().getAsLong(),
+      "lowest pending offset must be the interrupted record"
+    );
+    assertEquals(
+      OFFSET,
+      state.nextOffsetToCommit(),
       "commit point must not advance past the interrupted, never-acknowledged offset"
     );
     assertEquals(
       -1L,
-      state.get("highestProcessedOffset"),
+      state.highestProcessedOffset(),
       "no offset was successfully processed, so highestProcessed must stay unset"
     );
 

--- a/lib/kpipe-consumer/src/test/java/io/github/eschizoid/kpipe/consumer/ShutdownOrderingTest.java
+++ b/lib/kpipe-consumer/src/test/java/io/github/eschizoid/kpipe/consumer/ShutdownOrderingTest.java
@@ -118,8 +118,8 @@ class ShutdownOrderingTest {
     }
 
     @Override
-    public Map<String, Object> getStatistics() {
-      return Map.of();
+    public OffsetStatistics getStatistics() {
+      return OffsetStatistics.empty();
     }
 
     @Override

--- a/lib/kpipe-test/src/main/java/io/github/eschizoid/kpipe/test/CrashRestartHarness.java
+++ b/lib/kpipe-test/src/main/java/io/github/eschizoid/kpipe/test/CrashRestartHarness.java
@@ -3,6 +3,7 @@ package io.github.eschizoid.kpipe.test;
 import io.github.eschizoid.kpipe.consumer.KPipeConsumer;
 import io.github.eschizoid.kpipe.consumer.OffsetManager;
 import io.github.eschizoid.kpipe.consumer.OffsetState;
+import io.github.eschizoid.kpipe.consumer.OffsetStatistics;
 import io.github.eschizoid.kpipe.consumer.ProcessingMode;
 import io.github.eschizoid.kpipe.registry.MessageFormat;
 import io.github.eschizoid.kpipe.registry.MessageProcessorRegistry;
@@ -337,8 +338,8 @@ public final class CrashRestartHarness<T> {
     }
 
     @Override
-    public Map<String, Object> getStatistics() {
-      return Map.of();
+    public OffsetStatistics getStatistics() {
+      return OffsetStatistics.empty();
     }
 
     @Override


### PR DESCRIPTION
Tier-1 item 2 (part 1): kill the stringly-typed `Map<String,Object>` observability on `KafkaOffsetManager`.

## Problem
`getStatistics()` (on the `OffsetManager` SPI) and `getPartitionState()` (impl-only) returned `Map<String,Object>` with magic-string keys; **27+ call sites** across tests/jcstress/property/stress did unchecked casts like `(long) state.get("nextOffsetToCommit")`. Both are **internal/test-only** observability (not on `Handle`/`KPipeConsumer`), so retyping the SPI is safe — no user-facing break.

## Change
- New public records **`PartitionState`** and **`OffsetStatistics`** (+ a static `OffsetStatistics.empty()`).
- `managerState` is the **`OffsetState` enum**, not `.name()` — kills the stringly-typing at the source. Nullable longs are **`OptionalLong`** (no boxing, explicit present/absent).
- `OffsetManager.getStatistics()` SPI retyped; **all 10 implementors** updated (7 test fakes → `empty()`; 2 delegating wrappers → signature only; `KafkaOffsetManager` rewritten to build the records from the same values).
- **47 call sites across 11 files** migrated to typed field access — every assertion's semantics preserved, only the *read* changed.

## Bug surfaced by the typing
`RetryInterruptTest` asserted `assertEquals(OFFSET, state.lowestPendingOffset())` — after typing, that's `assertEquals(long, OptionalLong)` (Object-vs-Object, **always false**). It was a latent no-op assertion the stringly `Object` return hid; fixed to `isPresent()` + `getAsLong()`.

## Deferred (separate PR)
Extract the `commitFutures` UUID-correlation into a `CommitCoordinator` to shrink the god-class further — independent of this typing change.

## Verification
All source sets compile (main / test / **jcstress** / kpipe-test / api); `:lib:kpipe-consumer:test` green (3m8s, incl. property/stress); zero stringly `.get()` access remains.