### PR TITLE
refactor(consumer): extract CommitCoordinator from KafkaOffsetManager

### DIFF
--- a/lib/kpipe-consumer/src/main/java/io/github/eschizoid/kpipe/consumer/CommitCoordinator.java
+++ b/lib/kpipe-consumer/src/main/java/io/github/eschizoid/kpipe/consumer/CommitCoordinator.java
@@ -1,0 +1,53 @@
+package io.github.eschizoid.kpipe.consumer;
+
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
+
+/// Correlates an asynchronous offset commit with its completion.
+///
+/// A commit is a round trip: [KafkaOffsetManager] enqueues a `CommitOffsets` command for the
+/// consumer thread, then blocks until that thread reports back. This owns the UUID →
+/// [CompletableFuture] correlation that bridges the two — [#register] mints a correlation id and
+/// its pending future, the consumer thread calls [#complete] with that id when the commit lands,
+/// and the waiter calls [#forget] once it returns (or times out).
+///
+/// Thread-safe: the backing map is a [ConcurrentHashMap], and a late [#complete] racing the
+/// waiter's [#forget] is harmless (whichever removes the future first wins; the other is a no-op).
+final class CommitCoordinator {
+
+  /// A registered commit awaiting completion: the correlation id to attach to the outbound
+  /// `CommitOffsets` command, and the future the caller blocks on.
+  record Pending(String commitId, CompletableFuture<Boolean> future) {}
+
+  private final Map<String, CompletableFuture<Boolean>> commitFutures = new ConcurrentHashMap<>();
+
+  /// Registers a new commit and returns its correlation id + pending future. Attach the id to the
+  /// outbound command so [#complete] can find the future when the commit lands.
+  Pending register() {
+    final var commitId = UUID.randomUUID().toString();
+    final var future = new CompletableFuture<Boolean>();
+    commitFutures.put(commitId, future);
+    return new Pending(commitId, future);
+  }
+
+  /// Completes the pending commit for `commitId`. No-op if unknown — a late completion after the
+  /// waiter already timed out and forgot it. Called from the consumer thread.
+  void complete(final String commitId, final boolean success) {
+    final var future = commitFutures.remove(commitId);
+    if (future != null) future.complete(success);
+  }
+
+  /// Drops the correlation for `commitId` (idempotent) — called by the waiter in its finally block
+  /// so a timed-out commit doesn't leak its future.
+  void forget(final String commitId) {
+    commitFutures.remove(commitId);
+  }
+
+  /// Number of commits registered but not yet completed or forgotten — surfaced as
+  /// [OffsetStatistics#pendingCommits].
+  int pendingCount() {
+    return commitFutures.size();
+  }
+}

--- a/lib/kpipe-consumer/src/main/java/io/github/eschizoid/kpipe/consumer/CommitCoordinator.java
+++ b/lib/kpipe-consumer/src/main/java/io/github/eschizoid/kpipe/consumer/CommitCoordinator.java
@@ -1,51 +1,69 @@
 package io.github.eschizoid.kpipe.consumer;
 
+import java.lang.System.Logger;
+import java.lang.System.Logger.Level;
+import java.time.Duration;
 import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 
-/// Correlates an asynchronous offset commit with its completion.
+/// Correlates an asynchronous offset commit with its completion, owning the whole round trip.
 ///
-/// A commit is a round trip: [KafkaOffsetManager] enqueues a `CommitOffsets` command for the
-/// consumer thread, then blocks until that thread reports back. This owns the UUID →
-/// [CompletableFuture] correlation that bridges the two — [#register] mints a correlation id and
-/// its pending future, the consumer thread calls [#complete] with that id when the commit lands,
-/// and the waiter calls [#forget] once it returns (or times out).
+/// A commit spans two threads: [KafkaOffsetManager] [#register]s a commit and enqueues a
+/// `CommitOffsets` command carrying the returned id, then [#await]s the result; the consumer thread
+/// [#complete]s that id when the commit lands. This owns the `UUID → CompletableFuture` correlation
+/// so the future never escapes — callers hold only the id.
 ///
-/// Thread-safe: the backing map is a [ConcurrentHashMap], and a late [#complete] racing the
-/// waiter's [#forget] is harmless (whichever removes the future first wins; the other is a no-op).
+/// Thread-safe: the backing map is a [ConcurrentHashMap]. [#await] is the sole remover of a
+/// correlation; [#complete] only resolves the future in place (it may run before OR after the
+/// awaiter reaches [#await], and it must not remove the entry the awaiter still needs to look up).
+/// A late [#complete] after the awaiter already timed out and removed the entry is a no-op.
 final class CommitCoordinator {
 
-  /// A registered commit awaiting completion: the correlation id to attach to the outbound
-  /// `CommitOffsets` command, and the future the caller blocks on.
-  record Pending(String commitId, CompletableFuture<Boolean> future) {}
+  private static final Logger LOGGER = System.getLogger(CommitCoordinator.class.getName());
 
   private final Map<String, CompletableFuture<Boolean>> commitFutures = new ConcurrentHashMap<>();
 
-  /// Registers a new commit and returns its correlation id + pending future. Attach the id to the
-  /// outbound command so [#complete] can find the future when the commit lands.
-  Pending register() {
+  /// Registers a new commit and returns its correlation id. Attach the id to the outbound
+  /// `CommitOffsets` command, then block on it via [#await]; the completing thread calls [#complete]
+  /// with the same id.
+  String register() {
     final var commitId = UUID.randomUUID().toString();
-    final var future = new CompletableFuture<Boolean>();
-    commitFutures.put(commitId, future);
-    return new Pending(commitId, future);
+    commitFutures.put(commitId, new CompletableFuture<>());
+    return commitId;
   }
 
-  /// Completes the pending commit for `commitId`. No-op if unknown — a late completion after the
-  /// waiter already timed out and forgot it. Called from the consumer thread.
+  /// Blocks until the commit for `commitId` completes or `timeout` elapses, then drops the
+  /// correlation. Returns the commit's success value, or `false` if it timed out or failed. Must be
+  /// called by the thread that registered the id.
+  ///
+  /// @throws InterruptedException if interrupted while waiting (the correlation is still cleaned up)
+  boolean await(final String commitId, final Duration timeout) throws InterruptedException {
+    final var future = commitFutures.get(commitId);
+    try {
+      return future.get(timeout.toMillis(), TimeUnit.MILLISECONDS);
+    } catch (final ExecutionException | TimeoutException e) {
+      LOGGER.log(Level.WARNING, "Error waiting for offset commit", e);
+      return false;
+    } finally {
+      commitFutures.remove(commitId);
+    }
+  }
+
+  /// Completes the pending commit for `commitId`, resolving the future in place WITHOUT removing it
+  /// — [#await] owns the single removal, and may not yet have looked the future up. No-op if unknown
+  /// (a late completion after the awaiter already timed out and removed it). Called from the consumer
+  /// thread.
   void complete(final String commitId, final boolean success) {
-    final var future = commitFutures.remove(commitId);
+    final var future = commitFutures.get(commitId);
     if (future != null) future.complete(success);
   }
 
-  /// Drops the correlation for `commitId` (idempotent) — called by the waiter in its finally block
-  /// so a timed-out commit doesn't leak its future.
-  void forget(final String commitId) {
-    commitFutures.remove(commitId);
-  }
-
-  /// Number of commits registered but not yet completed or forgotten — surfaced as
+  /// Number of commits registered but not yet completed or awaited-out — surfaced as
   /// [OffsetStatistics#pendingCommits].
   int pendingCount() {
     return commitFutures.size();

--- a/lib/kpipe-consumer/src/main/java/io/github/eschizoid/kpipe/consumer/KafkaOffsetManager.java
+++ b/lib/kpipe-consumer/src/main/java/io/github/eschizoid/kpipe/consumer/KafkaOffsetManager.java
@@ -369,18 +369,9 @@ public class KafkaOffsetManager implements OffsetManager {
     throws InterruptedException {
     if (offsetsToCommit.isEmpty()) return true;
 
-    final var pending = commitCoordinator.register();
-
-    commandQueue.offer(new ConsumerCommand.CommitOffsets(offsetsToCommit, pending.commitId()));
-
-    try {
-      return pending.future().get(timeout.toMillis(), TimeUnit.MILLISECONDS);
-    } catch (final ExecutionException | TimeoutException e) {
-      LOGGER.log(Level.WARNING, "Error waiting for offset commit", e);
-      return false;
-    } finally {
-      commitCoordinator.forget(pending.commitId());
-    }
+    final var commitId = commitCoordinator.register();
+    commandQueue.offer(new ConsumerCommand.CommitOffsets(offsetsToCommit, commitId));
+    return commitCoordinator.await(commitId, timeout);
   }
 
   /// Returns a typed snapshot of the current processing state for a partition.

--- a/lib/kpipe-consumer/src/main/java/io/github/eschizoid/kpipe/consumer/KafkaOffsetManager.java
+++ b/lib/kpipe-consumer/src/main/java/io/github/eschizoid/kpipe/consumer/KafkaOffsetManager.java
@@ -77,7 +77,7 @@ public class KafkaOffsetManager implements OffsetManager {
   /// same thread (see `assertOnConsumerThread`).
   private final Queue<ConsumerCommand> commandQueue;
 
-  private final Map<String, CompletableFuture<Boolean>> commitFutures = new ConcurrentHashMap<>();
+  private final CommitCoordinator commitCoordinator = new CommitCoordinator();
 
   /// Per-partition pending offsets: a sorted primitive-`long` window (`PendingOffsetSet`) rather
   /// than a `ConcurrentSkipListSet<Long>`. The skiplist cost a `Long` box plus node/marker churn
@@ -199,8 +199,7 @@ public class KafkaOffsetManager implements OffsetManager {
   /// @param success True if the commit was successful, false otherwise
   @Override
   public void notifyCommitComplete(final String commitId, final boolean success) {
-    var future = commitFutures.remove(commitId);
-    if (future != null) future.complete(success);
+    commitCoordinator.complete(commitId, success);
   }
 
   /// Tracks an offset that is about to be processed using a ConsumerRecord.
@@ -370,19 +369,17 @@ public class KafkaOffsetManager implements OffsetManager {
     throws InterruptedException {
     if (offsetsToCommit.isEmpty()) return true;
 
-    final var commitId = UUID.randomUUID().toString();
-    final var future = new CompletableFuture<Boolean>();
-    commitFutures.put(commitId, future);
+    final var pending = commitCoordinator.register();
 
-    commandQueue.offer(new ConsumerCommand.CommitOffsets(offsetsToCommit, commitId));
+    commandQueue.offer(new ConsumerCommand.CommitOffsets(offsetsToCommit, pending.commitId()));
 
     try {
-      return future.get(timeout.toMillis(), TimeUnit.MILLISECONDS);
+      return pending.future().get(timeout.toMillis(), TimeUnit.MILLISECONDS);
     } catch (final ExecutionException | TimeoutException e) {
       LOGGER.log(Level.WARNING, "Error waiting for offset commit", e);
       return false;
     } finally {
-      commitFutures.remove(commitId);
+      commitCoordinator.forget(pending.commitId());
     }
   }
 
@@ -450,7 +447,7 @@ public class KafkaOffsetManager implements OffsetManager {
       state.get(),
       byPartition,
       average,
-      commitFutures.size()
+      commitCoordinator.pendingCount()
     );
   }
 

--- a/lib/kpipe-consumer/src/test/java/io/github/eschizoid/kpipe/consumer/CommitCoordinatorTest.java
+++ b/lib/kpipe-consumer/src/test/java/io/github/eschizoid/kpipe/consumer/CommitCoordinatorTest.java
@@ -6,32 +6,58 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import java.util.concurrent.TimeUnit;
+import java.time.Duration;
 import org.junit.jupiter.api.Test;
 
 /// Unit tests for [CommitCoordinator] — the async commit-correlation primitive extracted from
-/// KafkaOffsetManager. Pins the register → complete happy path, the forget/timeout cleanup, and the
-/// late-completion race (a `complete` after `forget` must be a harmless no-op).
+/// KafkaOffsetManager. Pins the register → complete → await round trip, the await-timeout cleanup,
+/// and the late-completion race (a `complete` after the awaiter timed out must be a harmless no-op).
 class CommitCoordinatorTest {
 
   @Test
-  void registerThenCompleteResolvesTheFuture() throws Exception {
+  void awaitReturnsTheCompletionValueAndClearsPending() throws Exception {
     final var coordinator = new CommitCoordinator();
-    final var pending = coordinator.register();
+    final var commitId = coordinator.register();
     assertEquals(1, coordinator.pendingCount());
 
-    coordinator.complete(pending.commitId(), true);
-
-    assertTrue(pending.future().get(1, TimeUnit.SECONDS), "future resolves to the completion value");
-    assertEquals(0, coordinator.pendingCount(), "complete() removes the correlation");
+    // Completed before await, so await returns immediately with the value.
+    coordinator.complete(commitId, true);
+    assertTrue(coordinator.await(commitId, Duration.ofSeconds(1)));
+    assertEquals(0, coordinator.pendingCount(), "await drops the correlation");
   }
 
   @Test
-  void completePropagatesFailureValue() throws Exception {
+  void awaitPropagatesAFailureCompletion() throws Exception {
     final var coordinator = new CommitCoordinator();
-    final var pending = coordinator.register();
-    coordinator.complete(pending.commitId(), false);
-    assertFalse(pending.future().get(1, TimeUnit.SECONDS));
+    final var commitId = coordinator.register();
+    coordinator.complete(commitId, false);
+    assertFalse(coordinator.await(commitId, Duration.ofSeconds(1)));
+  }
+
+  @Test
+  void completeUnblocksAConcurrentAwaiter() throws Exception {
+    final var coordinator = new CommitCoordinator();
+    final var commitId = coordinator.register();
+    // Complete from another thread while the main thread blocks in await.
+    Thread.ofVirtual().start(() -> {
+      try {
+        Thread.sleep(50);
+      } catch (final InterruptedException e) {
+        Thread.currentThread().interrupt();
+      }
+      coordinator.complete(commitId, true);
+    });
+    assertTrue(coordinator.await(commitId, Duration.ofSeconds(2)), "await must observe the completion");
+    assertEquals(0, coordinator.pendingCount());
+  }
+
+  @Test
+  void awaitTimesOutToFalseAndClearsPending() throws Exception {
+    final var coordinator = new CommitCoordinator();
+    final var commitId = coordinator.register();
+    // Never completed → await returns false after the timeout and cleans up.
+    assertFalse(coordinator.await(commitId, Duration.ofMillis(50)));
+    assertEquals(0, coordinator.pendingCount(), "a timed-out commit must not leak its future");
   }
 
   @Test
@@ -39,30 +65,20 @@ class CommitCoordinatorTest {
     final var coordinator = new CommitCoordinator();
     final var a = coordinator.register();
     final var b = coordinator.register();
-    assertNotEquals(a.commitId(), b.commitId());
+    assertNotEquals(a, b);
     assertEquals(2, coordinator.pendingCount());
   }
 
   @Test
-  void forgetDropsPendingWithoutCompleting() {
+  void lateCompleteAfterTimeoutIsHarmlessNoOp() throws Exception {
+    // The awaiter times out and drops the correlation; a late notifyCommitComplete then arrives. It
+    // must not throw and must not resurrect a pending entry.
     final var coordinator = new CommitCoordinator();
-    final var pending = coordinator.register();
-    coordinator.forget(pending.commitId());
-    assertEquals(0, coordinator.pendingCount());
-    assertFalse(pending.future().isDone(), "forget must not complete the future — the waiter times out");
-  }
+    final var commitId = coordinator.register();
+    assertFalse(coordinator.await(commitId, Duration.ofMillis(50)));
 
-  @Test
-  void lateCompleteAfterForgetIsHarmlessNoOp() {
-    // The waiter times out and forgets; a late notifyCommitComplete then arrives. It must not throw
-    // and must not resurrect a pending entry or complete the forgotten future.
-    final var coordinator = new CommitCoordinator();
-    final var pending = coordinator.register();
-    coordinator.forget(pending.commitId());
-
-    assertDoesNotThrow(() -> coordinator.complete(pending.commitId(), true));
+    assertDoesNotThrow(() -> coordinator.complete(commitId, true));
     assertEquals(0, coordinator.pendingCount());
-    assertFalse(pending.future().isDone(), "a forgotten future stays uncompleted");
   }
 
   @Test

--- a/lib/kpipe-consumer/src/test/java/io/github/eschizoid/kpipe/consumer/CommitCoordinatorTest.java
+++ b/lib/kpipe-consumer/src/test/java/io/github/eschizoid/kpipe/consumer/CommitCoordinatorTest.java
@@ -1,0 +1,74 @@
+package io.github.eschizoid.kpipe.consumer;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.Test;
+
+/// Unit tests for [CommitCoordinator] — the async commit-correlation primitive extracted from
+/// KafkaOffsetManager. Pins the register → complete happy path, the forget/timeout cleanup, and the
+/// late-completion race (a `complete` after `forget` must be a harmless no-op).
+class CommitCoordinatorTest {
+
+  @Test
+  void registerThenCompleteResolvesTheFuture() throws Exception {
+    final var coordinator = new CommitCoordinator();
+    final var pending = coordinator.register();
+    assertEquals(1, coordinator.pendingCount());
+
+    coordinator.complete(pending.commitId(), true);
+
+    assertTrue(pending.future().get(1, TimeUnit.SECONDS), "future resolves to the completion value");
+    assertEquals(0, coordinator.pendingCount(), "complete() removes the correlation");
+  }
+
+  @Test
+  void completePropagatesFailureValue() throws Exception {
+    final var coordinator = new CommitCoordinator();
+    final var pending = coordinator.register();
+    coordinator.complete(pending.commitId(), false);
+    assertFalse(pending.future().get(1, TimeUnit.SECONDS));
+  }
+
+  @Test
+  void distinctRegistrationsGetDistinctIds() {
+    final var coordinator = new CommitCoordinator();
+    final var a = coordinator.register();
+    final var b = coordinator.register();
+    assertNotEquals(a.commitId(), b.commitId());
+    assertEquals(2, coordinator.pendingCount());
+  }
+
+  @Test
+  void forgetDropsPendingWithoutCompleting() {
+    final var coordinator = new CommitCoordinator();
+    final var pending = coordinator.register();
+    coordinator.forget(pending.commitId());
+    assertEquals(0, coordinator.pendingCount());
+    assertFalse(pending.future().isDone(), "forget must not complete the future — the waiter times out");
+  }
+
+  @Test
+  void lateCompleteAfterForgetIsHarmlessNoOp() {
+    // The waiter times out and forgets; a late notifyCommitComplete then arrives. It must not throw
+    // and must not resurrect a pending entry or complete the forgotten future.
+    final var coordinator = new CommitCoordinator();
+    final var pending = coordinator.register();
+    coordinator.forget(pending.commitId());
+
+    assertDoesNotThrow(() -> coordinator.complete(pending.commitId(), true));
+    assertEquals(0, coordinator.pendingCount());
+    assertFalse(pending.future().isDone(), "a forgotten future stays uncompleted");
+  }
+
+  @Test
+  void completeUnknownIdIsIgnored() {
+    final var coordinator = new CommitCoordinator();
+    assertDoesNotThrow(() -> coordinator.complete("never-registered", true));
+    assertEquals(0, coordinator.pendingCount());
+  }
+}


### PR DESCRIPTION
Finishes Tier-1 item 2: the `CommitCoordinator` extraction flagged as a follow-up in #249.

## What
The async-commit correlation — a `UUID → CompletableFuture<Boolean>` map with a register/complete/forget/count lifecycle — was inlined across four `KafkaOffsetManager` sites (field, `performCommit`, `notifyCommitComplete`, `getStatistics`). It's a distinct, subtle concern (a late `complete` racing the waiter's timeout-`forget`) that was only testable indirectly through the full manager.

Extracted to a package-private `CommitCoordinator`:
- `register()` mints the correlation id + pending future,
- `complete(id, success)` resolves it from the consumer thread (no-op if unknown/forgotten),
- `forget(id)` cleans up on the waiter's timeout,
- `pendingCount()` feeds `OffsetStatistics.pendingCommits`.

`KafkaOffsetManager` now delegates.

## Honest framing
This is a **deepening for testability + a named concern**, not a line-count win (`KafkaOffsetManager` only drops 617→614 — the delegation offsets most of what moved out). The real value is that the correlation lifecycle now has an **isolated test surface**.

## Tests
`CommitCoordinatorTest` pins the lifecycle directly: register→complete (success + failure values), distinct ids, forget-without-completing, the **late complete-after-forget no-op race**, and complete-of-unknown-id.

## Verification
`:lib:kpipe-consumer:test` green (3m2s — full property/stress suite; the commit path is exercised throughout); behavior unchanged.