### PR TITLE
refactor(consumer): extract OffsetLedger from KafkaOffsetManager

### DIFF
--- a/lib/kpipe-consumer/src/main/java/io/github/eschizoid/kpipe/consumer/KafkaOffsetManager.java
+++ b/lib/kpipe-consumer/src/main/java/io/github/eschizoid/kpipe/consumer/KafkaOffsetManager.java
@@ -7,7 +7,6 @@ import java.util.*;
 import java.util.concurrent.*;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
 import org.apache.kafka.clients.consumer.Consumer;
 import org.apache.kafka.clients.consumer.ConsumerRebalanceListener;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
@@ -79,26 +78,12 @@ public class KafkaOffsetManager implements OffsetManager {
 
   private final CommitCoordinator commitCoordinator = new CommitCoordinator();
 
-  /// Per-partition pending offsets: a sorted primitive-`long` window (`PendingOffsetSet`) rather
-  /// than a `ConcurrentSkipListSet<Long>`. The skiplist cost a `Long` box plus node/marker churn
-  /// on every track/mark; the primitive structure allocates nothing in steady state. All map
-  /// mutations keep the bucket-locked `compute` / `computeIfPresent` shapes below; the structure
-  /// itself is monitor-synchronized so commit-scheduler reads outside the bucket lock stay safe.
-  private final Map<TopicPartition, PendingOffsetSet> pendingOffsets = new ConcurrentHashMap<>();
-  private final Map<TopicPartition, Long> highestProcessedOffsets = new ConcurrentHashMap<>();
+  /// Per-partition offset bookkeeping — the pending windows, highest-processed marks, the interned
+  /// `TopicPartition` cache, and the single commit-frontier rule they feed. This manager owns
+  /// lifecycle, scheduling, commit I/O, and rebalance orchestration; the ledger owns everything
+  /// keyed by partition (see [OffsetLedger]).
+  private final OffsetLedger ledger = new OffsetLedger();
 
-  /// Per-partition `TopicPartition` cache used by `trackOffset` and `markOffsetProcessed`. Each
-  /// `ConsumerRecord` carries `topic()` (a `String`) + `partition()` (an `int`) — constructing a
-  /// fresh `TopicPartition` per call on every record allocates twice per record on the hot path
-  /// (track from the consumer thread, mark from the worker), which at 100k rec/s is ~200k
-  /// disposable instances/sec from this manager alone.
-  ///
-  /// The cache is keyed by topic name (outer map) then partition number (inner map) so the
-  /// outer-map miss path (one-time per topic) is small and the per-record fast path is two
-  /// `ConcurrentHashMap` lookups returning a stable, interned instance. Entries are evicted in
-  /// `onPartitionsRevoked` so a rebalance that hands a partition off doesn't leak the cached
-  /// instance — `onPartitionsAssigned` will repopulate on first record.
-  private final Map<String, Map<Integer, TopicPartition>> topicPartitionCache = new ConcurrentHashMap<>();
   private final Duration commitInterval;
   private volatile ScheduledExecutorService scheduler;
   private volatile ScheduledFuture<?> scheduledCommitTask;
@@ -216,18 +201,7 @@ public class KafkaOffsetManager implements OffsetManager {
   @Override
   public void trackOffset(final ConsumerRecord<byte[], byte[]> record) {
     if (state.get() == OffsetState.STOPPED) return;
-    final var partition = cachedTopicPartition(record.topic(), record.partition());
-    final var offset = record.offset();
-    // The add must happen INSIDE the bucket-locked compute, not as a trailing .add() on the value
-    // computeIfAbsent returns. Otherwise the add races markOffsetProcessed's remove-if-empty: that
-    // path can empty the set and atomically drop the key, leaving a trailing .add() to land on an
-    // orphaned set no longer in the map — silently losing a pending offset and letting the commit
-    // point advance past an in-flight record. compute() holds the bucket lock across the add.
-    pendingOffsets.compute(partition, (_, set) -> {
-      final var pending = set == null ? new PendingOffsetSet() : set;
-      pending.add(offset);
-      return pending;
-    });
+    ledger.track(record.topic(), record.partition(), record.offset());
   }
 
   /// Marks an offset as successfully processed using a ConsumerRecord.
@@ -242,44 +216,7 @@ public class KafkaOffsetManager implements OffsetManager {
   @Override
   public void markOffsetProcessed(final ConsumerRecord<byte[], byte[]> record) {
     if (state.get() == OffsetState.STOPPED) return;
-    final var partition = cachedTopicPartition(record.topic(), record.partition());
-    final var offset = record.offset();
-
-    highestProcessedOffsets.compute(partition, (_, v) -> v == null ? offset : Math.max(v, offset));
-
-    pendingOffsets.computeIfPresent(partition, (_, set) -> {
-      set.remove(offset);
-      return set.isEmpty() ? null : set;
-    });
-  }
-
-  /// Returns a cached `TopicPartition` for the given `(topic, partition)` pair, allocating one
-  /// on first observation and reusing the same instance for every subsequent call. The fast
-  /// path is two `ConcurrentHashMap` lookups returning a stable instance, replacing two `new
-  /// TopicPartition(...)` allocations per record on the hot path.
-  ///
-  /// `computeIfAbsent` on the outer map atomicizes the inner-map creation; the inner-map
-  /// lambda closes over `topic` from the local rather than the `BiFunction`'s `t` argument, so
-  /// the `TopicPartition(topic, partition)` constructor sees the exact `String` reference the
-  /// caller passed (`String#intern` is not assumed — `TopicPartition.equals/hashCode` use
-  /// value equality and pooled inner-map entries don't depend on string identity).
-  private TopicPartition cachedTopicPartition(final String topic, final int partition) {
-    return topicPartitionCache
-      .computeIfAbsent(topic, _ -> new ConcurrentHashMap<>())
-      .computeIfAbsent(partition, p -> new TopicPartition(topic, p));
-  }
-
-  /// Evicts the cached `TopicPartition` for a revoked partition. Uses `computeIfPresent` on the
-  /// inner map so the inner-map removal and the outer-map cleanup are bucket-locked together —
-  /// a concurrent `cachedTopicPartition` call for a different partition under the same topic
-  /// cannot see a transient empty inner map and double-allocate. If the inner map becomes empty
-  /// after removal (last partition for a topic), the outer entry is dropped so the cache doesn't
-  /// retain stale topic keys across rebalances.
-  private void evictCachedTopicPartition(final TopicPartition partition) {
-    topicPartitionCache.computeIfPresent(partition.topic(), (_, inner) -> {
-      inner.remove(partition.partition());
-      return inner.isEmpty() ? null : inner;
-    });
+    ledger.markProcessed(record.topic(), record.partition(), record.offset());
   }
 
   /// Commits offsets that are safe to commit based on the current processing state.
@@ -340,29 +277,10 @@ public class KafkaOffsetManager implements OffsetManager {
   public boolean commitSyncAndWait(final Duration timeout) throws InterruptedException {
     if (state.get() == OffsetState.STOPPED) return true;
 
-    final var offsetsToCommit = prepareOffsetsToCommit();
+    final var offsetsToCommit = ledger.committableOffsets();
     if (offsetsToCommit.isEmpty()) return true;
 
     return performCommit(offsetsToCommit, timeout);
-  }
-
-  /// Prepares offsets for commit based on the current processing state. This method calculates the
-  /// offsets to commit at the time of commit, rather than maintaining them continuously.
-  ///
-  /// @return Map of partition to offset metadata ready for committing
-  private Map<TopicPartition, OffsetAndMetadata> prepareOffsetsToCommit() {
-    return Stream.concat(pendingOffsets.keySet().stream(), highestProcessedOffsets.keySet().stream())
-      .distinct()
-      .flatMap(partition -> {
-        final var pending = pendingOffsets.get(partition);
-        final var lowestPending = pending != null ? pending.firstOrNull() : null;
-        if (lowestPending != null) return Stream.of(Map.entry(partition, new OffsetAndMetadata(lowestPending)));
-        final var highestProcessed = highestProcessedOffsets.get(partition);
-        return highestProcessed != null
-          ? Stream.of(Map.entry(partition, new OffsetAndMetadata(highestProcessed + 1)))
-          : Stream.empty();
-      })
-      .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
   }
 
   private boolean performCommit(final Map<TopicPartition, OffsetAndMetadata> offsetsToCommit, final Duration timeout)
@@ -379,35 +297,7 @@ public class KafkaOffsetManager implements OffsetManager {
   /// @param partition The partition to get state for
   /// @return the partition's offset-tracking state
   public PartitionState getPartitionState(final TopicPartition partition) {
-    final var pending = pendingOffsets.get(partition);
-    final var highestProcessed = highestProcessedOffsets.get(partition);
-    final var lowestPending = pending != null ? pending.firstOrNull() : null;
-
-    final long nextOffsetToCommit;
-    if (lowestPending != null) {
-      nextOffsetToCommit = lowestPending;
-    } else if (highestProcessed != null) {
-      nextOffsetToCommit = highestProcessed + 1;
-    } else {
-      nextOffsetToCommit = -1L;
-    }
-
-    var lowestPendingOffset = OptionalLong.empty();
-    var highestPendingOffset = OptionalLong.empty();
-    if (pending != null && lowestPending != null) {
-      lowestPendingOffset = OptionalLong.of(lowestPending);
-      final var highestPending = pending.lastOrNull();
-      if (highestPending != null) highestPendingOffset = OptionalLong.of(highestPending);
-    }
-
-    return new PartitionState(
-      nextOffsetToCommit,
-      highestProcessed != null ? highestProcessed : -1L,
-      this.state.get(),
-      pending != null ? pending.size() : 0,
-      lowestPendingOffset,
-      highestPendingOffset
-    );
+    return ledger.partitionState(partition, state.get());
   }
 
   /// Returns typed overall statistics about all partitions being managed.
@@ -415,31 +305,7 @@ public class KafkaOffsetManager implements OffsetManager {
   /// @return statistics across all partitions
   @Override
   public OffsetStatistics getStatistics() {
-    final var allPartitions = new HashSet<TopicPartition>();
-    allPartitions.addAll(pendingOffsets.keySet());
-    allPartitions.addAll(highestProcessedOffsets.keySet());
-
-    final var totalPending = pendingOffsets.values().stream().mapToInt(PendingOffsetSet::size).sum();
-
-    final Map<TopicPartition, Long> byPartition;
-    final double average;
-    if (!highestProcessedOffsets.isEmpty()) {
-      byPartition = new HashMap<>(highestProcessedOffsets);
-      average = highestProcessedOffsets.values().stream().mapToLong(Long::longValue).average().orElse(0);
-    } else {
-      byPartition = Map.of();
-      average = 0.0;
-    }
-
-    return new OffsetStatistics(
-      allPartitions.size(),
-      totalPending,
-      highestProcessedOffsets.size(),
-      state.get(),
-      byPartition,
-      average,
-      commitCoordinator.pendingCount()
-    );
+    return ledger.statistics(state.get(), commitCoordinator.pendingCount());
   }
 
   /// Gets the current state of the KafkaOffsetManager.
@@ -468,7 +334,7 @@ public class KafkaOffsetManager implements OffsetManager {
     try {
       stopScheduler();
       try {
-        final var offsetsToCommit = prepareOffsetsToCommit();
+        final var offsetsToCommit = ledger.committableOffsets();
         if (!offsetsToCommit.isEmpty()) kafkaConsumer.commitSync(offsetsToCommit, Duration.ofSeconds(5));
       } catch (final Exception e) {
         LOGGER.log(Level.WARNING, "Error during final offset commit", e);
@@ -495,19 +361,10 @@ public class KafkaOffsetManager implements OffsetManager {
         drainCommandQueueForRevokedPartitions(partitions);
 
         final var offsetsToCommit = new HashMap<TopicPartition, OffsetAndMetadata>();
-        partitions.forEach(partition -> {
-          final var pending = pendingOffsets.get(partition);
-          final var lowestPending = pending != null ? pending.firstOrNull() : null;
-          if (lowestPending != null) {
-            offsetsToCommit.put(partition, new OffsetAndMetadata(lowestPending));
-          } else {
-            final var highestProcessed = highestProcessedOffsets.get(partition);
-            if (highestProcessed != null) offsetsToCommit.put(partition, new OffsetAndMetadata(highestProcessed + 1));
-          }
-          pendingOffsets.remove(partition);
-          highestProcessedOffsets.remove(partition);
-          evictCachedTopicPartition(partition);
-        });
+        partitions.forEach(partition ->
+          ledger.frontier(partition).ifPresent(offset -> offsetsToCommit.put(partition, new OffsetAndMetadata(offset)))
+        );
+        ledger.removePartitions(partitions);
 
         if (!offsetsToCommit.isEmpty()) {
           try {
@@ -524,10 +381,7 @@ public class KafkaOffsetManager implements OffsetManager {
         assertOnConsumerThread();
         if (state.get() == OffsetState.STOPPED) return;
         LOGGER.log(Level.INFO, "Partitions assigned: %s".formatted(partitions));
-        partitions.forEach(partition -> {
-          pendingOffsets.remove(partition);
-          highestProcessedOffsets.remove(partition);
-        });
+        ledger.removePartitions(partitions);
       }
 
       @Override
@@ -598,8 +452,6 @@ public class KafkaOffsetManager implements OffsetManager {
 
   /// Cleans up resources.
   private void cleanup() {
-    pendingOffsets.clear();
-    highestProcessedOffsets.clear();
-    topicPartitionCache.clear();
+    ledger.clear();
   }
 }

--- a/lib/kpipe-consumer/src/main/java/io/github/eschizoid/kpipe/consumer/OffsetLedger.java
+++ b/lib/kpipe-consumer/src/main/java/io/github/eschizoid/kpipe/consumer/OffsetLedger.java
@@ -1,0 +1,240 @@
+package io.github.eschizoid.kpipe.consumer;
+
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.OptionalLong;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import org.apache.kafka.clients.consumer.OffsetAndMetadata;
+import org.apache.kafka.common.TopicPartition;
+
+/// Per-partition offset bookkeeping behind [KafkaOffsetManager]: the pending-offset windows, the
+/// highest-processed marks, the interned [TopicPartition] cache, and the single **commit-frontier
+/// rule** they all feed.
+///
+/// The frontier rule is the honest core of at-least-once-with-parallelism: commit the lowest
+/// still-pending offset if any (you must not advance past an in-flight record), otherwise
+/// highest-processed + 1 (Kafka's next-offset semantics), otherwise nothing. It lived inline in
+/// three places (commit prep, per-partition reporting, rebalance revoke) before this type pulled it
+/// into one function ([#frontierOf]).
+///
+/// **Ownership boundary.** The ledger owns everything keyed by partition. It knows nothing about the
+/// consumer lifecycle (start/stop/close), the commit I/O (command queue, [CommitCoordinator]), or
+/// rebalance orchestration — those stay on [KafkaOffsetManager], which injects the two fields it
+/// owns ([OffsetState], pending-commit count) into the reporting projections. The `commandQueue`
+/// single-writer invariant never crosses this seam: the ledger touches no queue.
+///
+/// **Concurrency.** The maps are [ConcurrentHashMap]; every read-modify-write on a per-partition
+/// value stays inside a bucket-locked `compute` / `computeIfPresent` so it is atomic against the
+/// remove-if-empty path. [PendingOffsetSet] is monitor-synchronized, so the diagnostic reads
+/// ([#frontier], [#statistics], [#partitionState]) that run outside the bucket lock stay safe.
+final class OffsetLedger {
+
+  /// Per-partition pending offsets: a sorted primitive-`long` window ([PendingOffsetSet]) rather
+  /// than a `ConcurrentSkipListSet<Long>`. The skiplist cost a `Long` box plus node/marker churn on
+  /// every track/mark; the primitive structure allocates nothing in steady state.
+  private final Map<TopicPartition, PendingOffsetSet> pendingOffsets = new ConcurrentHashMap<>();
+  private final Map<TopicPartition, Long> highestProcessedOffsets = new ConcurrentHashMap<>();
+
+  /// Per-partition [TopicPartition] cache keyed by topic name (outer map) then partition number
+  /// (inner map). Each [org.apache.kafka.clients.consumer.ConsumerRecord] carries `topic()` (a
+  /// `String`) + `partition()` (an `int`); constructing a fresh `TopicPartition` per call on every
+  /// record allocates twice per record on the hot path (track from the consumer thread, mark from
+  /// the worker), which at 100k rec/s is ~200k disposable instances/sec. The cache returns a stable
+  /// interned instance instead; entries are evicted in [#removePartitions] on rebalance.
+  private final Map<String, Map<Integer, TopicPartition>> topicPartitionCache = new ConcurrentHashMap<>();
+
+  /// Tracks an offset that is about to be processed.
+  ///
+  /// The `add` must happen INSIDE the bucket-locked `compute`, not as a trailing `.add()` on the
+  /// value `computeIfAbsent` returns. Otherwise the add races [#markProcessed]'s remove-if-empty:
+  /// that path can empty the set and atomically drop the key, leaving a trailing `.add()` to land on
+  /// an orphaned set no longer in the map — silently losing a pending offset and letting the commit
+  /// point advance past an in-flight record. `compute()` holds the bucket lock across the add.
+  ///
+  /// @param topic     the record's topic
+  /// @param partition the record's partition
+  /// @param offset    the record's offset
+  void track(final String topic, final int partition, final long offset) {
+    final var tp = cachedTopicPartition(topic, partition);
+    pendingOffsets.compute(tp, (_, set) -> {
+      final var pending = set == null ? new PendingOffsetSet() : set;
+      pending.add(offset);
+      return pending;
+    });
+  }
+
+  /// Marks an offset as successfully processed: bumps the partition's highest-processed mark and
+  /// drops the offset from the pending window (removing the key when the window empties).
+  ///
+  /// @param topic     the record's topic
+  /// @param partition the record's partition
+  /// @param offset    the record's offset
+  void markProcessed(final String topic, final int partition, final long offset) {
+    final var tp = cachedTopicPartition(topic, partition);
+    highestProcessedOffsets.compute(tp, (_, v) -> v == null ? offset : Math.max(v, offset));
+    pendingOffsets.computeIfPresent(tp, (_, set) -> {
+      set.remove(offset);
+      return set.isEmpty() ? null : set;
+    });
+  }
+
+  /// The commit-frontier rule for one partition. Lowest still-pending offset if any (can't commit
+  /// past an in-flight record); else highest-processed + 1 (Kafka's next-offset semantics); else
+  /// empty (nothing tracked for this partition).
+  ///
+  /// @param partition the partition to compute the frontier for
+  /// @return the offset that would next be committed, or empty if nothing is tracked
+  OptionalLong frontier(final TopicPartition partition) {
+    final var pending = pendingOffsets.get(partition);
+    final var lowestPending = pending != null ? pending.firstOrNull() : null;
+    return frontierOf(lowestPending, highestProcessedOffsets.get(partition));
+  }
+
+  /// Frontiers for every tracked partition, ready to hand to `commitSync`. Computed at call time
+  /// (not maintained continuously) from the current pending/processed state.
+  ///
+  /// @return partition → next-offset-to-commit for every partition with a frontier
+  Map<TopicPartition, OffsetAndMetadata> committableOffsets() {
+    return trackedPartitions()
+      .stream()
+      .flatMap(partition -> {
+        final var frontier = frontier(partition);
+        return frontier.isPresent()
+          ? Stream.of(Map.entry(partition, new OffsetAndMetadata(frontier.getAsLong())))
+          : Stream.empty();
+      })
+      .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+  }
+
+  /// Drops all tracked state for the given partitions — pending window, highest-processed mark, and
+  /// interned [TopicPartition] cache entry. Used on rebalance revoke (after the caller has read the
+  /// frontiers it wants to commit) and assign (to clear any stale state from a prior ownership).
+  /// Evicting a cache entry that isn't present is a no-op.
+  ///
+  /// @param partitions the partitions to forget
+  void removePartitions(final Collection<TopicPartition> partitions) {
+    partitions.forEach(partition -> {
+      pendingOffsets.remove(partition);
+      highestProcessedOffsets.remove(partition);
+      evictCachedTopicPartition(partition);
+    });
+  }
+
+  /// Overall statistics across all tracked partitions. The offset-derived fields are computed here;
+  /// the caller injects the two fields the ledger doesn't own — the manager's lifecycle state and
+  /// the pending-commit count.
+  ///
+  /// @param lifecycleState the offset manager's lifecycle state
+  /// @param pendingCommits commits issued but not yet acknowledged
+  /// @return a typed snapshot across all partitions
+  OffsetStatistics statistics(final OffsetState lifecycleState, final int pendingCommits) {
+    final var totalPending = pendingOffsets.values().stream().mapToInt(PendingOffsetSet::size).sum();
+
+    final Map<TopicPartition, Long> byPartition;
+    final double average;
+    if (!highestProcessedOffsets.isEmpty()) {
+      byPartition = new HashMap<>(highestProcessedOffsets);
+      average = highestProcessedOffsets.values().stream().mapToLong(Long::longValue).average().orElse(0);
+    } else {
+      byPartition = Map.of();
+      average = 0.0;
+    }
+
+    return new OffsetStatistics(
+      trackedPartitions().size(),
+      totalPending,
+      highestProcessedOffsets.size(),
+      lifecycleState,
+      byPartition,
+      average,
+      pendingCommits
+    );
+  }
+
+  /// A typed snapshot of one partition's offset-tracking state. Reads the pending window once so the
+  /// frontier and the pending-window fields come from a single consistent snapshot.
+  ///
+  /// @param partition     the partition to snapshot
+  /// @param lifecycleState the offset manager's lifecycle state
+  /// @return the partition's offset-tracking state
+  PartitionState partitionState(final TopicPartition partition, final OffsetState lifecycleState) {
+    final var pending = pendingOffsets.get(partition);
+    final var highestProcessed = highestProcessedOffsets.get(partition);
+    final var lowestPending = pending != null ? pending.firstOrNull() : null;
+
+    final var nextOffsetToCommit = frontierOf(lowestPending, highestProcessed).orElse(-1L);
+
+    var lowestPendingOffset = OptionalLong.empty();
+    var highestPendingOffset = OptionalLong.empty();
+    if (pending != null && lowestPending != null) {
+      lowestPendingOffset = OptionalLong.of(lowestPending);
+      final var highestPending = pending.lastOrNull();
+      if (highestPending != null) highestPendingOffset = OptionalLong.of(highestPending);
+    }
+
+    return new PartitionState(
+      nextOffsetToCommit,
+      highestProcessed != null ? highestProcessed : -1L,
+      lifecycleState,
+      pending != null ? pending.size() : 0,
+      lowestPendingOffset,
+      highestPendingOffset
+    );
+  }
+
+  /// Drops all tracked state. Called from [KafkaOffsetManager#close].
+  void clear() {
+    pendingOffsets.clear();
+    highestProcessedOffsets.clear();
+    topicPartitionCache.clear();
+  }
+
+  /// The commit-frontier rule as a pure function of a partition's two facts, so the single-read
+  /// callers ([#frontier], [#partitionState]) share one definition of the rule without either
+  /// re-reading the maps.
+  ///
+  /// @param lowestPending   the lowest in-flight offset, or `null` if none pending
+  /// @param highestProcessed the highest processed offset, or `null` if none processed
+  /// @return the offset that would next be committed, or empty if neither is present
+  private static OptionalLong frontierOf(final Long lowestPending, final Long highestProcessed) {
+    if (lowestPending != null) return OptionalLong.of(lowestPending);
+    return highestProcessed != null ? OptionalLong.of(highestProcessed + 1) : OptionalLong.empty();
+  }
+
+  /// Distinct partitions with either pending or processed state.
+  private Set<TopicPartition> trackedPartitions() {
+    final var all = new HashSet<TopicPartition>();
+    all.addAll(pendingOffsets.keySet());
+    all.addAll(highestProcessedOffsets.keySet());
+    return all;
+  }
+
+  /// Returns a cached [TopicPartition] for the given `(topic, partition)` pair, allocating one on
+  /// first observation and reusing it thereafter. `computeIfAbsent` on the outer map atomicizes the
+  /// inner-map creation; the inner-map lambda closes over `topic` from the local so the
+  /// `TopicPartition(topic, partition)` constructor sees the exact `String` the caller passed.
+  ///
+  /// Package-private (not `private`) so same-package tests can assert the interning/eviction
+  /// contract by identity (`assertSame` / `assertNotSame`) without reaching in by reflection.
+  TopicPartition cachedTopicPartition(final String topic, final int partition) {
+    return topicPartitionCache
+      .computeIfAbsent(topic, _ -> new ConcurrentHashMap<>())
+      .computeIfAbsent(partition, p -> new TopicPartition(topic, p));
+  }
+
+  /// Evicts the cached [TopicPartition] for a revoked partition. `computeIfPresent` bucket-locks the
+  /// inner-map removal and the outer-map cleanup together, so a concurrent [#cachedTopicPartition]
+  /// for a different partition under the same topic can't see a transient empty inner map and
+  /// double-allocate. Drops the outer entry when the last partition for a topic leaves.
+  private void evictCachedTopicPartition(final TopicPartition partition) {
+    topicPartitionCache.computeIfPresent(partition.topic(), (_, inner) -> {
+      inner.remove(partition.partition());
+      return inner.isEmpty() ? null : inner;
+    });
+  }
+}

--- a/lib/kpipe-consumer/src/main/java/io/github/eschizoid/kpipe/consumer/OffsetLedger.java
+++ b/lib/kpipe-consumer/src/main/java/io/github/eschizoid/kpipe/consumer/OffsetLedger.java
@@ -138,7 +138,7 @@ final class OffsetLedger {
     final Map<TopicPartition, Long> byPartition;
     final double average;
     if (!highestProcessedOffsets.isEmpty()) {
-      byPartition = new HashMap<>(highestProcessedOffsets);
+      byPartition = Map.copyOf(highestProcessedOffsets);
       average = highestProcessedOffsets.values().stream().mapToLong(Long::longValue).average().orElse(0);
     } else {
       byPartition = Map.of();

--- a/lib/kpipe-consumer/src/test/java/io/github/eschizoid/kpipe/consumer/KafkaOffsetManagerTest.java
+++ b/lib/kpipe-consumer/src/test/java/io/github/eschizoid/kpipe/consumer/KafkaOffsetManagerTest.java
@@ -1065,7 +1065,7 @@ class KafkaOffsetManagerTest {
     }
 
     @Test
-    void prepareOffsetsToCommitShouldNeverThrowUnderRace() throws Exception {
+    void committableOffsetComputationNeverThrowsUnderRace() throws Exception {
       final var manager = KafkaOffsetManager.builder(mockConsumer)
         .withCommandQueue(new LinkedBlockingQueue<>())
         .build();
@@ -1250,102 +1250,4 @@ class KafkaOffsetManagerTest {
     }
   }
 
-  /// Verifies the per-partition `TopicPartition` cache behavior in `trackOffset` /
-  /// `markOffsetProcessed`: same instance reused across calls, evicted on revoke, re-allocated
-  /// after re-assignment. The behavioral tests above (offset commit semantics, rebalance
-  /// handling, etc.) cover correctness; these tests verify the allocation contract that exists
-  /// to keep the hot path off the per-record `new TopicPartition(...)` path.
-  @Nested
-  class TopicPartitionCacheTests {
-
-    /// Reflection accessor for the cache so the test can inspect cached instances without
-    /// widening the production surface. Keeps the cache field private — only the tests reach
-    /// inside.
-    @SuppressWarnings("unchecked")
-    private Map<Integer, TopicPartition> innerCache(final KafkaOffsetManager manager, final String topic)
-      throws Exception {
-      final var field = KafkaOffsetManager.class.getDeclaredField("topicPartitionCache");
-      field.setAccessible(true);
-      final var outer = (Map<String, Map<Integer, TopicPartition>>) field.get(manager);
-      return outer.get(topic);
-    }
-
-    @Test
-    void cachedTopicPartitionIsTheSameInstanceAcrossCalls() throws Exception {
-      final var record1 = new ConsumerRecord<>(TOPIC, 0, 100L, "k".getBytes(UTF_8), "v".getBytes());
-      final var record2 = new ConsumerRecord<>(TOPIC, 0, 101L, "k".getBytes(UTF_8), "v".getBytes());
-
-      offsetManager.trackOffset(record1);
-      final var tp1 = innerCache(offsetManager, TOPIC).get(0);
-      assertNotNull(tp1, "trackOffset must populate the cache");
-
-      offsetManager.markOffsetProcessed(record1);
-      final var tp2 = innerCache(offsetManager, TOPIC).get(0);
-      assertSame(tp1, tp2, "markOffsetProcessed must reuse the cached TopicPartition");
-
-      offsetManager.trackOffset(record2);
-      offsetManager.markOffsetProcessed(record2);
-      final var tp3 = innerCache(offsetManager, TOPIC).get(0);
-      assertSame(tp1, tp3, "subsequent track/mark on the same partition must reuse the cached instance");
-    }
-
-    @Test
-    void revokedPartitionsAreEvictedFromTheCache() throws Exception {
-      final var record = new ConsumerRecord<>(TOPIC, 0, 100L, "k".getBytes(UTF_8), "v".getBytes());
-      offsetManager.trackOffset(record);
-      offsetManager.markOffsetProcessed(record);
-      assertNotNull(innerCache(offsetManager, TOPIC).get(0), "precondition: cache populated");
-
-      offsetManager.createRebalanceListener().onPartitionsRevoked(List.of(PARTITION));
-
-      final var inner = innerCache(offsetManager, TOPIC);
-      assertNull(inner, "revoking the only partition for a topic must drop the inner map entry");
-    }
-
-    @Test
-    void reAssignedPartitionAllocatesNewCachedInstance() throws Exception {
-      final var record = new ConsumerRecord<>(TOPIC, 0, 100L, "k".getBytes(UTF_8), "v".getBytes());
-      offsetManager.trackOffset(record);
-      final var original = innerCache(offsetManager, TOPIC).get(0);
-      assertNotNull(original, "precondition: cache populated");
-
-      final var listener = offsetManager.createRebalanceListener();
-      listener.onPartitionsRevoked(List.of(PARTITION));
-      listener.onPartitionsAssigned(List.of(PARTITION));
-
-      // Cache is empty after revoke — first track after re-assignment must repopulate it with a
-      // new instance (NOT the original — that one was evicted).
-      offsetManager.trackOffset(record);
-      final var reAllocated = innerCache(offsetManager, TOPIC).get(0);
-      assertNotNull(reAllocated, "track after re-assignment must repopulate the cache");
-      assertNotSame(
-        original,
-        reAllocated,
-        "re-assignment must allocate a fresh TopicPartition, not reuse the evicted one"
-      );
-      assertEquals(original, reAllocated, "value-equality must still hold (same topic + partition number)");
-    }
-
-    @Test
-    void evictionOfOnePartitionPreservesSiblingPartitionsForSameTopic() throws Exception {
-      final var p0 = new TopicPartition(TOPIC, 0);
-      final var p1 = new TopicPartition(TOPIC, 1);
-
-      final var r0 = new ConsumerRecord<>(TOPIC, 0, 100L, "k".getBytes(UTF_8), "v".getBytes());
-      final var r1 = new ConsumerRecord<>(TOPIC, 1, 200L, "k".getBytes(UTF_8), "v".getBytes());
-      offsetManager.trackOffset(r0);
-      offsetManager.trackOffset(r1);
-      final var tp1Before = innerCache(offsetManager, TOPIC).get(1);
-      assertNotNull(tp1Before, "precondition: partition 1 cached");
-
-      // Revoke only partition 0; partition 1 should remain cached.
-      offsetManager.createRebalanceListener().onPartitionsRevoked(List.of(p0));
-
-      final var inner = innerCache(offsetManager, TOPIC);
-      assertNotNull(inner, "topic entry should still exist while partition 1 remains");
-      assertNull(inner.get(0), "partition 0 must be evicted");
-      assertSame(tp1Before, inner.get(1), "partition 1 must remain cached as the same instance");
-      assertEquals(p1, inner.get(1), "value equality check");
-    }
-  }
 }

--- a/lib/kpipe-consumer/src/test/java/io/github/eschizoid/kpipe/consumer/OffsetLedgerTest.java
+++ b/lib/kpipe-consumer/src/test/java/io/github/eschizoid/kpipe/consumer/OffsetLedgerTest.java
@@ -1,0 +1,175 @@
+package io.github.eschizoid.kpipe.consumer;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+import java.util.OptionalLong;
+import org.apache.kafka.common.TopicPartition;
+import org.junit.jupiter.api.Test;
+
+/// Unit tests for [OffsetLedger] — the per-partition offset bookkeeping extracted from
+/// KafkaOffsetManager. Pins the commit-frontier rule (especially gap-hold, the honest core of
+/// at-least-once-with-parallelism), the reporting projections, and partition removal. Pure
+/// in-memory, no Kafka.
+class OffsetLedgerTest {
+
+  private static final TopicPartition P0 = new TopicPartition("topic", 0);
+  private static final TopicPartition P1 = new TopicPartition("topic", 1);
+
+  @Test
+  void frontierIsEmptyForAnUntrackedPartition() {
+    assertEquals(OptionalLong.empty(), new OffsetLedger().frontier(P0));
+  }
+
+  @Test
+  void frontierIsTheLowestPendingOffsetWhileInFlight() {
+    final var ledger = new OffsetLedger();
+    ledger.track("topic", 0, 100L);
+    ledger.track("topic", 0, 101L);
+    ledger.track("topic", 0, 102L);
+    assertEquals(OptionalLong.of(100L), ledger.frontier(P0));
+  }
+
+  @Test
+  void frontierHoldsAtTheGapWhenAHigherOffsetCompletesFirst() {
+    final var ledger = new OffsetLedger();
+    ledger.track("topic", 0, 100L);
+    ledger.track("topic", 0, 101L);
+    ledger.track("topic", 0, 102L);
+
+    // 102 finishes out of order — the frontier must NOT jump past the still-pending 100/101.
+    ledger.markProcessed("topic", 0, 102L);
+    assertEquals(OptionalLong.of(100L), ledger.frontier(P0), "commit point must not advance past an in-flight record");
+  }
+
+  @Test
+  void frontierAdvancesAsContiguousOffsetsComplete() {
+    final var ledger = new OffsetLedger();
+    ledger.track("topic", 0, 100L);
+    ledger.track("topic", 0, 101L);
+    ledger.track("topic", 0, 102L);
+    ledger.markProcessed("topic", 0, 102L);
+
+    ledger.markProcessed("topic", 0, 100L);
+    assertEquals(OptionalLong.of(101L), ledger.frontier(P0));
+
+    ledger.markProcessed("topic", 0, 101L);
+    // All pending drained; frontier is now highest-processed (102) + 1.
+    assertEquals(OptionalLong.of(103L), ledger.frontier(P0));
+  }
+
+  @Test
+  void frontierIsHighestProcessedPlusOneWhenNothingPending() {
+    final var ledger = new OffsetLedger();
+    ledger.track("topic", 0, 100L);
+    ledger.markProcessed("topic", 0, 100L);
+    assertEquals(OptionalLong.of(101L), ledger.frontier(P0));
+  }
+
+  @Test
+  void committableOffsetsSpansEveryTrackedPartition() {
+    final var ledger = new OffsetLedger();
+    ledger.track("topic", 0, 100L); // still pending -> frontier 100
+    ledger.track("topic", 1, 200L);
+    ledger.markProcessed("topic", 1, 200L); // drained -> frontier 201
+
+    final var committable = ledger.committableOffsets();
+    assertEquals(2, committable.size());
+    assertEquals(100L, committable.get(P0).offset());
+    assertEquals(201L, committable.get(P1).offset());
+  }
+
+  @Test
+  void removePartitionsForgetsAllState() {
+    final var ledger = new OffsetLedger();
+    ledger.track("topic", 0, 100L);
+    ledger.track("topic", 1, 200L);
+
+    ledger.removePartitions(List.of(P0));
+
+    assertEquals(OptionalLong.empty(), ledger.frontier(P0), "removed partition is forgotten");
+    assertEquals(OptionalLong.of(200L), ledger.frontier(P1), "sibling partition is untouched");
+    assertFalse(ledger.committableOffsets().containsKey(P0));
+  }
+
+  @Test
+  void statisticsAggregateOffsetStateAndInjectLifecycleFields() {
+    final var ledger = new OffsetLedger();
+    ledger.track("topic", 0, 100L); // pending
+    ledger.track("topic", 1, 200L);
+    ledger.markProcessed("topic", 1, 200L); // processed, drained
+
+    final var stats = ledger.statistics(OffsetState.RUNNING, 3);
+    assertEquals(2, stats.partitionCount());
+    assertEquals(1, stats.totalPendingOffsets(), "only P0 is still pending");
+    assertEquals(1, stats.totalProcessedPartitions(), "only P1 has a processed offset");
+    assertEquals(OffsetState.RUNNING, stats.managerState(), "lifecycle state is injected by the manager");
+    assertEquals(3, stats.pendingCommits(), "pending-commit count is injected by the manager");
+    assertEquals(200L, stats.highestProcessedOffsetsByPartition().get(P1));
+  }
+
+  @Test
+  void partitionStateSnapshotReportsFrontierAndPendingWindow() {
+    final var ledger = new OffsetLedger();
+    ledger.track("topic", 0, 100L);
+    ledger.track("topic", 0, 102L);
+    ledger.markProcessed("topic", 0, 102L); // gap: 100 pending, 102 processed
+
+    final var snapshot = ledger.partitionState(P0, OffsetState.RUNNING);
+    assertEquals(100L, snapshot.nextOffsetToCommit(), "frontier holds at the pending 100");
+    assertEquals(102L, snapshot.highestProcessedOffset());
+    assertEquals(OffsetState.RUNNING, snapshot.managerState());
+    assertEquals(1, snapshot.pendingCount());
+    assertTrue(snapshot.lowestPendingOffset().isPresent());
+    assertEquals(100L, snapshot.lowestPendingOffset().getAsLong());
+    assertEquals(100L, snapshot.highestPendingOffset().getAsLong());
+  }
+
+  @Test
+  void partitionStateForUntrackedPartitionUsesSentinels() {
+    final var snapshot = new OffsetLedger().partitionState(P0, OffsetState.CREATED);
+    assertEquals(-1L, snapshot.nextOffsetToCommit());
+    assertEquals(-1L, snapshot.highestProcessedOffset());
+    assertEquals(0, snapshot.pendingCount());
+    assertFalse(snapshot.lowestPendingOffset().isPresent());
+  }
+
+  // The interned TopicPartition cache exists to keep the track/mark hot path off the per-record
+  // `new TopicPartition(...)` allocation. Observed by identity through the package-private
+  // `cachedTopicPartition` accessor — no reflection.
+
+  @Test
+  void cachedTopicPartitionInternsTheSameInstance() {
+    final var ledger = new OffsetLedger();
+    final var first = ledger.cachedTopicPartition("topic", 0);
+    assertSame(first, ledger.cachedTopicPartition("topic", 0), "the same (topic, partition) reuses the cached instance");
+  }
+
+  @Test
+  void removePartitionsEvictsTheCachedInstance() {
+    final var ledger = new OffsetLedger();
+    final var original = ledger.cachedTopicPartition("topic", 0);
+
+    ledger.removePartitions(List.of(P0));
+
+    final var reAllocated = ledger.cachedTopicPartition("topic", 0);
+    assertNotSame(original, reAllocated, "after eviction a fresh instance is allocated, not the evicted one");
+    assertEquals(original, reAllocated, "value-equality still holds (same topic + partition number)");
+  }
+
+  @Test
+  void evictingOnePartitionPreservesSiblingsUnderTheSameTopic() {
+    final var ledger = new OffsetLedger();
+    final var p0 = ledger.cachedTopicPartition("topic", 0);
+    final var p1 = ledger.cachedTopicPartition("topic", 1);
+
+    ledger.removePartitions(List.of(P0));
+
+    assertSame(p1, ledger.cachedTopicPartition("topic", 1), "sibling partition 1 stays cached as the same instance");
+    assertNotSame(p0, ledger.cachedTopicPartition("topic", 0), "partition 0 was evicted, so it re-allocates");
+  }
+}

--- a/lib/kpipe-consumer/src/test/java/io/github/eschizoid/kpipe/consumer/OffsetLedgerTest.java
+++ b/lib/kpipe-consumer/src/test/java/io/github/eschizoid/kpipe/consumer/OffsetLedgerTest.java
@@ -110,6 +110,18 @@ class OffsetLedgerTest {
     assertEquals(OffsetState.RUNNING, stats.managerState(), "lifecycle state is injected by the manager");
     assertEquals(3, stats.pendingCommits(), "pending-commit count is injected by the manager");
     assertEquals(200L, stats.highestProcessedOffsetsByPartition().get(P1));
+    assertEquals(200.0, stats.averageHighestProcessedOffset(), "mean of the one processed partition's highest offset");
+  }
+
+  @Test
+  void statisticsForAnEmptyLedgerAreZeroed() {
+    final var stats = new OffsetLedger().statistics(OffsetState.CREATED, 0);
+    assertEquals(0, stats.partitionCount());
+    assertEquals(0, stats.totalPendingOffsets());
+    assertEquals(0, stats.totalProcessedPartitions());
+    assertEquals(0.0, stats.averageHighestProcessedOffset(), "no processed partitions -> zero average, not NaN");
+    assertTrue(stats.highestProcessedOffsetsByPartition().isEmpty());
+    assertEquals(OffsetState.CREATED, stats.managerState());
   }
 
   @Test


### PR DESCRIPTION
## What

`KafkaOffsetManager` mixed two concerns:
1. **Consumer-offset lifecycle** — state machine, periodic-commit scheduler, commit I/O, rebalance orchestration.
2. **Per-partition offset bookkeeping** — the pending-offset windows, highest-processed marks, the interned `TopicPartition` cache, and the **commit-frontier rule**.

The frontier rule — *"commit the lowest still-pending offset, else highest-processed + 1"* (the honest core of at-least-once-with-parallelism) — was **triplicated** across `prepareOffsetsToCommit`, `getPartitionState`, and the rebalance revoke path.

This extracts a package-private **`OffsetLedger`** that owns all partition-keyed state behind a narrow interface:

```
track(topic, partition, offset)
markProcessed(topic, partition, offset)
frontier(tp) -> OptionalLong          // the ONE rule (was 3 copies)
committableOffsets() -> Map<TP, OffsetAndMetadata>
removePartitions(collection)
statistics(lifecycleState, pendingCommits) -> OffsetStatistics
partitionState(tp, lifecycleState) -> PartitionState
```

The manager delegates all bookkeeping and keeps only what it owns — lifecycle, scheduling, commit I/O (command queue + `CommitCoordinator`), and the **inline rebalance listener**, which now just calls `ledger.frontier`/`removePartitions`. Reporting falls out as thin projections; the manager injects the two fields the ledger doesn't own (lifecycle `OffsetState`, pending-commit count).

## Why (deletion test)

Delete `OffsetLedger` and the two maps + interning cache + frontier rule reappear in the manager — triplicated, as they were. It concentrates real complexity behind a small interface: **deep, not a shallow satellite.** (A reporting-only extraction was considered and rejected — it would have shared the manager's mutable maps across a new seam, adding surface without concentrating anything.)

## Invariants preserved

- **No public-API change** — `OffsetManager` and the public `getStatistics()` / `getPartitionState()` signatures are identical. §16 n/a.
- **`commandQueue` single-writer invariant never crosses the seam** — the ledger touches no queue.
- All bucket-locked `compute` / `computeIfPresent` shapes and remove-if-empty atomicity move **verbatim**.
- `KafkaOffsetManager` 605 → 457 lines.

## Tests

- **New `OffsetLedgerTest`** — unit-tests the frontier rule (including **gap-hold**, the honest core), `committableOffsets`, `removePartitions`, and the reporting projections. Pure in-memory, no Kafka.
- **Zero reflection.** The `TopicPartition`-cache interning/eviction tests move to `OffsetLedgerTest` and assert **by identity** through a package-private `cachedTopicPartition` accessor (the class is module-internal, so no public surface widens). This **deletes** the reflection-based `TopicPartitionCacheTests` — no test in the tree uses `java.lang.reflect` anymore.
- The existing **`OffsetManager*` jcstress suite** (gap-hold, lowest-pending, revoke-race) is untouched and stays green as the **behavior-preserving regression guard**.

## Verification

- `:lib:kpipe-consumer:test` — BUILD SUCCESSFUL (full suite).
- `:lib:kpipe-consumer:compileJcstressJava` — BUILD SUCCESSFUL.