### PR TITLE
refactor(test): extract shared TestKitMetrics from TestStream + CrashRestartHarness

### DIFF
--- a/lib/kpipe-test/src/main/java/io/github/eschizoid/kpipe/test/CrashRestartHarness.java
+++ b/lib/kpipe-test/src/main/java/io/github/eschizoid/kpipe/test/CrashRestartHarness.java
@@ -72,11 +72,6 @@ public final class CrashRestartHarness<T> {
   private static final Duration POLL_TIMEOUT = Duration.ofMillis(10);
   private static final String TOPIC = "kpipe-crash-restart-topic";
 
-  private static final String METRIC_RECEIVED = "messagesReceived";
-  private static final String METRIC_PROCESSED = "messagesProcessed";
-  private static final String METRIC_ERRORS = "processingErrors";
-  private static final String METRIC_IN_FLIGHT = "inFlight";
-
   private final MessageFormat<T> format;
   private final List<UnaryOperator<T>> operators = new ArrayList<>();
   private ProcessingMode processingMode = ProcessingMode.SEQUENTIAL;
@@ -265,7 +260,7 @@ public final class CrashRestartHarness<T> {
   private static void awaitQuiescent(final KPipeConsumer consumer, final long target) {
     final var deadline = System.nanoTime() + QUIESCE_TIMEOUT.toNanos();
     while (System.nanoTime() < deadline) {
-      if (quiescent(consumer, target)) return;
+      if (TestKitMetrics.quiescent(consumer, target)) return;
       try {
         //noinspection BusyWait — deadline-bounded quiescence poll, not a spin
         Thread.sleep(5);
@@ -275,19 +270,6 @@ public final class CrashRestartHarness<T> {
       }
     }
     throw new AssertionError("crash-restart phase timed out awaiting " + target + " records: " + consumer.getMetrics());
-  }
-
-  private static boolean quiescent(final KPipeConsumer consumer, final long target) {
-    final var snapshot = consumer.getMetrics();
-    if (snapshot.get(METRIC_RECEIVED) < target) return false;
-    if (accountedFor(snapshot) < target) return false;
-    if (!consumer.waitForInFlightDrain(Duration.ofMillis(1))) return false;
-    final var settled = consumer.getMetrics();
-    return settled.get(METRIC_RECEIVED) >= target && accountedFor(settled) >= target;
-  }
-
-  private static long accountedFor(final Map<String, Long> snapshot) {
-    return snapshot.get(METRIC_PROCESSED) + snapshot.get(METRIC_ERRORS) + snapshot.get(METRIC_IN_FLIGHT);
   }
 
   /// Minimal, never-contacted config — the `MockConsumer` supplier bypasses the real

--- a/lib/kpipe-test/src/main/java/io/github/eschizoid/kpipe/test/TestKitMetrics.java
+++ b/lib/kpipe-test/src/main/java/io/github/eschizoid/kpipe/test/TestKitMetrics.java
@@ -1,0 +1,51 @@
+package io.github.eschizoid.kpipe.test;
+
+import io.github.eschizoid.kpipe.consumer.KPipeConsumer;
+import java.time.Duration;
+import java.util.Map;
+
+/// Shared quiescence + accounting over [KPipeConsumer#getMetrics] for the Docker-free test kit.
+///
+/// Both harnesses need the same "everything sent has been polled, terminally accounted for, and
+/// drained" check: [TestStream] (live drive) drives it in its `flush()` loop, and
+/// [CrashRestartHarness] drives it between its crash and restart phases. Holding the metric-key
+/// names and the accounting formula here stops the two from drifting — before this, both hand-rolled
+/// identical constants + `accountedFor` + `quiescent`.
+final class TestKitMetrics {
+
+  private static final String METRIC_RECEIVED = "messagesReceived";
+  private static final String METRIC_PROCESSED = "messagesProcessed";
+  private static final String METRIC_ERRORS = "processingErrors";
+  private static final String METRIC_IN_FLIGHT = "inFlight";
+
+  private TestKitMetrics() {}
+
+  /// True once every sent record is (1) polled (`messagesReceived` ≥ target), (2) terminally
+  /// accounted for, and (3) drained (`waitForInFlightDrain`, then a re-read of (1)+(2)).
+  ///
+  /// Records move strictly forward (unpolled → in-flight → buffered/terminal), so observing "all
+  /// accounted for" *before* observing "in-flight drained" cannot yield a false positive — a record
+  /// still unpolled keeps the sum below target, and a record still processing fails the drain check.
+  /// The final re-read confirms the accounting after the drain.
+  ///
+  /// @param consumer the consumer to inspect
+  /// @param target   the number of records expected to have been sent
+  /// @return true if the consumer has quiesced at or above `target`
+  static boolean quiescent(final KPipeConsumer consumer, final long target) {
+    final var snapshot = consumer.getMetrics();
+    if (snapshot.get(METRIC_RECEIVED) < target) return false;
+    if (accountedFor(snapshot) < target) return false;
+    if (!consumer.waitForInFlightDrain(Duration.ofMillis(1))) return false;
+    final var settled = consumer.getMetrics();
+    return settled.get(METRIC_RECEIVED) >= target && accountedFor(settled) >= target;
+  }
+
+  /// Terminal records plus in-flight ones (`inFlight` = dispatcher pending + batch-buffered; after a
+  /// drain, pending is zero so the in-flight component is exactly the buffered count).
+  ///
+  /// @param snapshot a [KPipeConsumer#getMetrics] snapshot
+  /// @return processed + errored + in-flight
+  private static long accountedFor(final Map<String, Long> snapshot) {
+    return snapshot.get(METRIC_PROCESSED) + snapshot.get(METRIC_ERRORS) + snapshot.get(METRIC_IN_FLIGHT);
+  }
+}

--- a/lib/kpipe-test/src/main/java/io/github/eschizoid/kpipe/test/TestStream.java
+++ b/lib/kpipe-test/src/main/java/io/github/eschizoid/kpipe/test/TestStream.java
@@ -69,12 +69,6 @@ public final class TestStream<T> implements AutoCloseable {
   private static final Duration DEFAULT_FLUSH_TIMEOUT = Duration.ofSeconds(10);
   private static final Duration CLOSE_AGE_CAP = Duration.ofDays(1);
 
-  // Public metric-map keys of KPipeConsumer.getMetrics(); see the metrics table in README.
-  private static final String METRIC_RECEIVED = "messagesReceived";
-  private static final String METRIC_PROCESSED = "messagesProcessed";
-  private static final String METRIC_ERRORS = "processingErrors";
-  private static final String METRIC_IN_FLIGHT = "inFlight";
-
   private final String topic;
   private final MessageFormat<T> format;
   private final KPipeConsumer consumer;
@@ -171,7 +165,7 @@ public final class TestStream<T> implements AutoCloseable {
     final var target = nextOffset.get();
     final var deadline = System.nanoTime() + timeout.toNanos();
     while (System.nanoTime() < deadline) {
-      if (quiescent(target)) return this;
+      if (TestKitMetrics.quiescent(consumer, target)) return this;
       try {
         //noinspection BusyWait — deadline-bounded quiescence poll, not a spin
         Thread.sleep(5);
@@ -208,27 +202,6 @@ public final class TestStream<T> implements AutoCloseable {
   @Override
   public void close() {
     if (closed.compareAndSet(false, true)) consumer.close();
-  }
-
-  /// All sent records are either terminal (processed / filtered / failed) or buffered in a batch
-  /// wrapper, and no dispatcher worker is mid-record. Checked in a deliberate order: records move
-  /// strictly forward (unpolled → in-flight → buffered/terminal), so observing "all accounted
-  /// for" *before* observing "in-flight drained" cannot yield a false positive — a record that
-  /// was still unpolled at the first check keeps the sum below target, and a record still
-  /// processing fails the drain check. The final re-read confirms the accounting after the drain.
-  private boolean quiescent(final long target) {
-    final var snapshot = metrics();
-    if (snapshot.get(METRIC_RECEIVED) < target) return false;
-    if (accountedFor(snapshot) < target) return false;
-    if (!consumer.waitForInFlightDrain(Duration.ofMillis(1))) return false;
-    final var settled = metrics();
-    return settled.get(METRIC_RECEIVED) >= target && accountedFor(settled) >= target;
-  }
-
-  /// Terminal records plus in-flight ones (`inFlight` = dispatcher pending + batch-buffered;
-  /// after a drain, pending is zero so the in-flight component is exactly the buffered count).
-  private static long accountedFor(final Map<String, Long> snapshot) {
-    return snapshot.get(METRIC_PROCESSED) + snapshot.get(METRIC_ERRORS) + snapshot.get(METRIC_IN_FLIGHT);
   }
 
   private void ensureOpen() {


### PR DESCRIPTION
## What

`TestStream` (live drive) and `CrashRestartHarness` (crash/restart) hand-rolled **byte-identical** quiescence logic: the same 4 metric-key constants (`messagesReceived/Processed/Errors/inFlight`), the same `accountedFor` formula, and a near-identical `quiescent()` check. That is the 'parallel lists that drift' hazard — a metric-key rename or accounting change had to land in two places or the two harnesses silently disagree.

Extract a package-private **`TestKitMetrics`** holding the constants + `accountedFor` (now private) + `quiescent(KPipeConsumer, long)`. Both harnesses call `TestKitMetrics.quiescent(consumer, target)`; each keeps its own deadline loop. One source of truth, unit-testable in isolation. `CLOSE_AGE_CAP` stays on `TestStream` — it's a batch-policy age cap, not a metrics concern.

## Why

Kills the drift hazard; no behavior change (the two `quiescent` bodies were identical modulo instance-vs-static receiver, both over `consumer.getMetrics()`).

## Verification
`:lib:kpipe-test:test` green (behavior-preserving).