### PR TITLE
fix(core): correct RegistryEntry average-time precision + small nits

### DIFF
--- a/lib/kpipe-api/src/main/java/io/github/eschizoid/kpipe/KPipe.java
+++ b/lib/kpipe-api/src/main/java/io/github/eschizoid/kpipe/KPipe.java
@@ -10,6 +10,7 @@ import io.github.eschizoid.kpipe.sink.MessageSink;
 import java.lang.System.Logger;
 import java.lang.System.Logger.Level;
 import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.HexFormat;
 import java.util.Map;
@@ -261,7 +262,7 @@ public final class KPipe {
 
   private static String renderBytes(final byte[] value) {
     if (looksLikeText(value)) return new String(value, StandardCharsets.UTF_8);
-    final var preview = value.length > 64 ? java.util.Arrays.copyOf(value, 64) : value;
+    final var preview = value.length > 64 ? Arrays.copyOf(value, 64) : value;
     final var suffix = value.length > 64 ? "...(%d bytes total)".formatted(value.length) : "";
     return "0x%s%s".formatted(HexFormat.of().formatHex(preview), suffix);
   }

--- a/lib/kpipe-core/src/main/java/io/github/eschizoid/kpipe/registry/RegistryEntry.java
+++ b/lib/kpipe-core/src/main/java/io/github/eschizoid/kpipe/registry/RegistryEntry.java
@@ -2,7 +2,6 @@ package io.github.eschizoid.kpipe.registry;
 
 import io.github.eschizoid.kpipe.sink.MessageSink;
 import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.LongAdder;
 import java.util.function.UnaryOperator;
 
@@ -34,11 +33,10 @@ class RegistryEntry<T> {
     final long count = invocationCount.sum();
     final long errors = errorCount.sum();
     final long timeNs = totalProcessingTimeNs.sum();
-    final var metrics = new ConcurrentHashMap<String, Object>();
-    metrics.put("invocationCount", count);
-    metrics.put("errorCount", errors);
-    metrics.put("averageProcessingTimeMs", count > 0 ? (timeNs / count) / 1_000_000.0 : 0.0);
-    return metrics;
+    // Divide by (count * 1e6) in one step: `(timeNs / count) / 1e6` would integer-divide first and
+    // drop sub-millisecond precision.
+    final var averageProcessingTimeMs = count > 0 ? timeNs / (count * 1_000_000.0) : 0.0;
+    return Map.of("invocationCount", count, "errorCount", errors, "averageProcessingTimeMs", averageProcessingTimeMs);
   }
 
   /// Executes the entry as a UnaryOperator.

--- a/lib/kpipe-producer/src/main/java/io/github/eschizoid/kpipe/producer/config/KafkaProducerConfig.java
+++ b/lib/kpipe-producer/src/main/java/io/github/eschizoid/kpipe/producer/config/KafkaProducerConfig.java
@@ -2,6 +2,7 @@ package io.github.eschizoid.kpipe.producer.config;
 
 import java.util.Properties;
 import java.util.function.UnaryOperator;
+import org.apache.kafka.common.serialization.ByteArraySerializer;
 
 /// A utility class for creating and customizing Kafka producer configuration properties.
 ///
@@ -70,8 +71,8 @@ public final class KafkaProducerConfig {
   ) {
     final var props = new Properties();
     props.put("bootstrap.servers", bootstrapServers);
-    props.put("key.serializer", "org.apache.kafka.common.serialization.ByteArraySerializer");
-    props.put("value.serializer", "org.apache.kafka.common.serialization.ByteArraySerializer");
+    props.put("key.serializer", ByteArraySerializer.class.getName());
+    props.put("value.serializer", ByteArraySerializer.class.getName());
     props.put("acks", "1");
 
     return customizer != null ? customizer.apply(props) : props;
@@ -215,8 +216,8 @@ public final class KafkaProducerConfig {
     ///
     /// @return This builder for chaining
     public ProducerConfigBuilder withByteArraySerializers() {
-      props.put("key.serializer", "org.apache.kafka.common.serialization.ByteArraySerializer");
-      props.put("value.serializer", "org.apache.kafka.common.serialization.ByteArraySerializer");
+      props.put("key.serializer", ByteArraySerializer.class.getName());
+      props.put("value.serializer", ByteArraySerializer.class.getName());
       return this;
     }
 


### PR DESCRIPTION
## What

Three small fixes bundled.

### 1. RegistryEntry average-time **precision bug** (real defect)
`getMetrics()` computed `(timeNs / count) / 1_000_000.0` — integer-divides `timeNs/count` FIRST, dropping sub-millisecond precision. Now `timeNs / (count * 1_000_000.0)` in one step. Also returns an immutable `Map.of(...)` instead of allocating + populating a throwaway `ConcurrentHashMap` per call. (Test-only observability, but a genuine bug.)

### 2. KafkaProducerConfig serializer strings
Replace the 4 hardcoded FQCN `"org.apache.kafka...ByteArraySerializer"` strings with `ByteArraySerializer.class.getName()` (refactor-safe, compile-checked).

### 3. KPipe.renderBytes FQCN
`java.util.Arrays.copyOf` → import `Arrays` (coding standard: no FQCN in code).

## Deliberately NOT included
`JsonFormat.consoleSink` static→instance vs Avro/Protobuf: Json's console sink is stateless/schemaless so `static` is correct; Avro/Protobuf are instance methods because they need the schema/descriptor. The asymmetry reflects a real difference, not drift — left as-is.

## Verification
core + producer + api test suites green. No test asserts the average value, so the precision change breaks nothing.