### PR TITLE
refactor(core): extract ConfluentEnvelope, dedup the Avro+Protobuf wire-envelope parse

### DIFF
--- a/lib/kpipe-core/src/main/java/io/github/eschizoid/kpipe/registry/ConfluentEnvelope.java
+++ b/lib/kpipe-core/src/main/java/io/github/eschizoid/kpipe/registry/ConfluentEnvelope.java
@@ -1,0 +1,41 @@
+package io.github.eschizoid.kpipe.registry;
+
+/// The Confluent Schema Registry wire-envelope prefix shared by the Avro and Protobuf registry-mode
+/// formats: a 1-byte magic (`0x00`) followed by a 4-byte big-endian schema id. The format-specific
+/// remainder — the Avro payload, or the Protobuf message-index array — begins at [#HEADER_LENGTH].
+///
+/// Both formats read the same prefix the same way; centralizing the magic check and the big-endian
+/// id read here keeps them from drifting on the envelope contract, and gives one place to enrich the
+/// diagnostics (both paths now render the leading bytes via [WireDiagnostics] on a bad envelope).
+public final class ConfluentEnvelope {
+
+  private static final byte MAGIC = 0x00;
+
+  /// Bytes consumed by the magic byte + 4-byte schema id. The format-specific payload / message-index
+  /// array starts at this offset.
+  public static final int HEADER_LENGTH = 5;
+
+  private ConfluentEnvelope() {}
+
+  /// Validates the magic byte and reads the 4-byte big-endian schema id. The caller's payload or
+  /// message-index array begins at [#HEADER_LENGTH]; formats that need at least one further byte
+  /// (e.g. Protobuf's message-index) should length-check that separately before calling.
+  ///
+  /// @param data the full record bytes (must be non-null; callers null-check the record value first)
+  /// @return the schema id encoded in the envelope
+  /// @throws IllegalStateException if the record is shorter than [#HEADER_LENGTH] or the magic byte
+  ///     is not `0x00`
+  public static int readSchemaId(final byte[] data) {
+    if (data.length < HEADER_LENGTH) throw new IllegalStateException(
+      "Record too short for Confluent wire envelope: " + data.length + " bytes; expected at least " + HEADER_LENGTH +
+        " (first bytes " + WireDiagnostics.hexPreview(data) + ")"
+    );
+    if (data[0] != MAGIC) throw new IllegalStateException(
+      "Unexpected magic byte 0x%02x; expected 0x00 (Confluent Schema Registry envelope; first bytes %s)".formatted(
+        data[0] & 0xff,
+        WireDiagnostics.hexPreview(data)
+      )
+    );
+    return ((data[1] & 0xff) << 24) | ((data[2] & 0xff) << 16) | ((data[3] & 0xff) << 8) | (data[4] & 0xff);
+  }
+}

--- a/lib/kpipe-core/src/test/java/io/github/eschizoid/kpipe/registry/ConfluentEnvelopeTest.java
+++ b/lib/kpipe-core/src/test/java/io/github/eschizoid/kpipe/registry/ConfluentEnvelopeTest.java
@@ -1,0 +1,52 @@
+package io.github.eschizoid.kpipe.registry;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+/// Unit tests for [ConfluentEnvelope] — the shared magic-byte check + big-endian schema-id read that
+/// the Avro and Protobuf registry-mode formats delegate to.
+class ConfluentEnvelopeTest {
+
+  @Test
+  void readsTheBigEndianSchemaIdAfterTheMagicByte() {
+    // magic 0x00, then schema id 7 as 4 big-endian bytes, then one payload byte.
+    final var data = new byte[] { 0x00, 0x00, 0x00, 0x00, 0x07, 0x2a };
+    assertEquals(7, ConfluentEnvelope.readSchemaId(data));
+  }
+
+  @Test
+  void readsAMultiByteSchemaId() {
+    // 0x01020304 = 16909060.
+    final var data = new byte[] { 0x00, 0x01, 0x02, 0x03, 0x04, 0x00 };
+    assertEquals(0x01020304, ConfluentEnvelope.readSchemaId(data));
+  }
+
+  @Test
+  void treatsTheHighBitOfEachIdByteAsUnsigned() {
+    // 0xFFFFFFFF must read back as -1, not sign-extend wrong through the shifts.
+    final var data = new byte[] { 0x00, (byte) 0xff, (byte) 0xff, (byte) 0xff, (byte) 0xff };
+    assertEquals(-1, ConfluentEnvelope.readSchemaId(data));
+  }
+
+  @Test
+  void rejectsAWrongMagicByte() {
+    final var data = new byte[] { 0x01, 0x00, 0x00, 0x00, 0x07 };
+    final var ex = assertThrows(IllegalStateException.class, () -> ConfluentEnvelope.readSchemaId(data));
+    assertTrue(ex.getMessage().contains("magic byte"), ex.getMessage());
+  }
+
+  @Test
+  void rejectsARecordShorterThanTheHeader() {
+    final var data = new byte[] { 0x00, 0x00, 0x00 }; // 3 bytes < HEADER_LENGTH (5)
+    final var ex = assertThrows(IllegalStateException.class, () -> ConfluentEnvelope.readSchemaId(data));
+    assertTrue(ex.getMessage().contains("too short"), ex.getMessage());
+  }
+
+  @Test
+  void headerLengthIsFiveMagicPlusFourByteId() {
+    assertEquals(5, ConfluentEnvelope.HEADER_LENGTH);
+  }
+}

--- a/lib/kpipe-format-avro/src/main/java/io/github/eschizoid/kpipe/format/avro/AvroFormat.java
+++ b/lib/kpipe-format-avro/src/main/java/io/github/eschizoid/kpipe/format/avro/AvroFormat.java
@@ -1,5 +1,6 @@
 package io.github.eschizoid.kpipe.format.avro;
 
+import io.github.eschizoid.kpipe.registry.ConfluentEnvelope;
 import io.github.eschizoid.kpipe.registry.MessageFormat;
 import io.github.eschizoid.kpipe.registry.SchemaResolver;
 import io.github.eschizoid.kpipe.registry.WireDiagnostics;
@@ -48,10 +49,6 @@ import org.apache.avro.io.EncoderFactory;
 /// Do **not** combine `withRegistry(...)` with `skipBytes(5)` — the format already consumes
 /// the envelope.
 public final class AvroFormat implements MessageFormat<GenericRecord> {
-
-  /// Confluent wire envelope: 1-byte magic (0x00) + 4-byte big-endian schema ID.
-  private static final int ENVELOPE_LENGTH = 5;
-  private static final byte CONFLUENT_MAGIC = 0x00;
 
   private final Schema staticSchema;
   private final SchemaResolver resolver;
@@ -171,18 +168,7 @@ public final class AvroFormat implements MessageFormat<GenericRecord> {
   }
 
   private GenericRecord deserializeFromEnvelope(final byte[] data) {
-    if (data.length < ENVELOPE_LENGTH) throw new IllegalStateException(
-      "Record too short for Confluent wire envelope: " + data.length + " bytes; expected at least " + ENVELOPE_LENGTH +
-        " (first bytes " + WireDiagnostics.hexPreview(data) + ")"
-    );
-    if (data[0] != CONFLUENT_MAGIC) throw new IllegalStateException(
-      "Unexpected magic byte 0x%02x; expected 0x00 (Confluent Schema Registry envelope; first bytes %s)".formatted(
-        data[0] & 0xff,
-        WireDiagnostics.hexPreview(data)
-      )
-    );
-    final int schemaId =
-      ((data[1] & 0xff) << 24) | ((data[2] & 0xff) << 16) | ((data[3] & 0xff) << 8) | (data[4] & 0xff);
+    final int schemaId = ConfluentEnvelope.readSchemaId(data);
 
     final var schema = resolvedSchemas.computeIfAbsent(schemaId, id -> {
       final var json = resolver.lookupById(id);
@@ -193,7 +179,8 @@ public final class AvroFormat implements MessageFormat<GenericRecord> {
     });
 
     final var reader = new GenericDatumReader<GenericRecord>(schema);
-    final var decoder = DecoderFactory.get().binaryDecoder(data, ENVELOPE_LENGTH, data.length - ENVELOPE_LENGTH, null);
+    final var decoder = DecoderFactory.get()
+      .binaryDecoder(data, ConfluentEnvelope.HEADER_LENGTH, data.length - ConfluentEnvelope.HEADER_LENGTH, null);
     try {
       return reader.read(null, decoder);
     } catch (final IOException | RuntimeException e) {

--- a/lib/kpipe-format-protobuf/src/main/java/io/github/eschizoid/kpipe/format/protobuf/ProtobufFormat.java
+++ b/lib/kpipe-format-protobuf/src/main/java/io/github/eschizoid/kpipe/format/protobuf/ProtobufFormat.java
@@ -5,6 +5,7 @@ import com.google.protobuf.Descriptors.Descriptor;
 import com.google.protobuf.DynamicMessage;
 import com.google.protobuf.InvalidProtocolBufferException;
 import com.google.protobuf.Message;
+import io.github.eschizoid.kpipe.registry.ConfluentEnvelope;
 import io.github.eschizoid.kpipe.registry.MessageFormat;
 import io.github.eschizoid.kpipe.registry.SchemaResolver;
 import io.github.eschizoid.kpipe.registry.WireDiagnostics;
@@ -45,11 +46,6 @@ public final class ProtobufFormat implements MessageFormat<Message> {
   /// The resolver caches the `.proto` text; this caches the compiled [Descriptor] so a repeat
   /// (id, index) pair skips both the lookup and the compile. Null in static mode.
   private final ConcurrentHashMap<DescriptorKey, Descriptor> resolvedDescriptors;
-
-  /// Confluent wire envelope: 1-byte magic (0x00) + 4-byte big-endian schema id, then the
-  /// message-index array.
-  private static final byte CONFLUENT_MAGIC = 0x00;
-  private static final int MAGIC_AND_ID_LENGTH = 5;
 
   /// The `[0]` path — Confluent's single-`0x00`-byte shorthand for "the first top-level message".
   private static final int[] FIRST_MESSAGE_INDEX = { 0 };
@@ -174,16 +170,12 @@ public final class ProtobufFormat implements MessageFormat<Message> {
   /// followed by `size` zig-zag varint path elements — with the shorthand that `size == 0` means
   /// the array `[0]` (the first top-level message), the common single-message case.
   private Message deserializeFromEnvelope(final byte[] data) {
-    if (data.length < MAGIC_AND_ID_LENGTH + 1) throw new IllegalStateException(
+    if (data.length < ConfluentEnvelope.HEADER_LENGTH + 1) throw new IllegalStateException(
       "Record too short for Confluent Protobuf wire envelope: " + data.length + " bytes; expected at least 6"
     );
-    if (data[0] != CONFLUENT_MAGIC) throw new IllegalStateException(
-      "Unexpected magic byte 0x%02x; expected 0x00 (Confluent Schema Registry envelope)".formatted(data[0] & 0xff)
-    );
-    final int schemaId =
-      ((data[1] & 0xff) << 24) | ((data[2] & 0xff) << 16) | ((data[3] & 0xff) << 8) | (data[4] & 0xff);
+    final int schemaId = ConfluentEnvelope.readSchemaId(data);
 
-    final var cursor = new VarintCursor(data, MAGIC_AND_ID_LENGTH);
+    final var cursor = new VarintCursor(data, ConfluentEnvelope.HEADER_LENGTH);
     final var size = cursor.readZigZagVarint();
     final int[] messageIndex;
     if (size == 0) {


### PR DESCRIPTION
## What

`AvroFormat` and `ProtobufFormat` each hand-rolled the **identical** Confluent wire-envelope prefix parse: a `0x00` magic-byte check and a **byte-identical** 4-byte big-endian schema-id read (`((data[1]&0xff)<<24)|...`), plus their own `CONFLUENT_MAGIC`/length constants. Two copies of a correctness-critical parse that had to stay in lockstep.

Extract **`ConfluentEnvelope`** in kpipe-core (next to the sibling `WireDiagnostics`, which both formats already depend on):
- `readSchemaId(byte[])` validates the magic byte + `>= HEADER_LENGTH (5)` and returns the big-endian id.
- `HEADER_LENGTH` = where the format-specific remainder (Avro payload / Protobuf message-index) begins.

Both formats delegate:
- **AvroFormat** drops `ENVELOPE_LENGTH`/`CONFLUENT_MAGIC` + the inline parse; the binary-decoder offset uses `ConfluentEnvelope.HEADER_LENGTH`.
- **ProtobufFormat** drops `MAGIC_AND_ID_LENGTH`/`CONFLUENT_MAGIC`; keeps its own `>= 6` guard (needs a message-index byte) + `VarintCursor`, both starting at `HEADER_LENGTH`.

## Deletion test

Delete `ConfluentEnvelope` → the magic check + big-endian read reappear, duplicated, in both formats. It concentrates the envelope contract in one place — a future format (or a fix to the magic/id handling) lands once.

## Behavior

Byte-for-byte identical id read + magic check. **One small improvement:** Protobuf's magic-mismatch error now renders the leading bytes via `WireDiagnostics` (matching Avro) — it was terser before; no test pinned the old text. Read-path failures stay `IllegalStateException` (§12).

## Verification

- New `ConfluentEnvelopeTest` (big-endian read incl. high-bit `0xFFFFFFFF`→-1, magic mismatch, too-short).
- **Full avro + protobuf + protobuf-confluent (the gold-standard `KafkaProtobufSerializer` wire-compat round-trip) + core suites green.**