### PR TITLE
refactor(consumer): split ConsumerHealthController.Hook into pause-lifecycle + metrics-observer

### DIFF
--- a/lib/kpipe-consumer/src/jcstress/java/io/github/eschizoid/kpipe/consumer/BackpressureHandshakeJCStressTest.java
+++ b/lib/kpipe-consumer/src/jcstress/java/io/github/eschizoid/kpipe/consumer/BackpressureHandshakeJCStressTest.java
@@ -43,9 +43,10 @@ import org.openjdk.jcstress.infra.results.II_Result;
 @State
 public class BackpressureHandshakeJCStressTest {
 
-  private static final ConsumerHealthController.Hook NOOP_HOOK = new NoopHook();
+  private static final NoopHook NOOP_HOOK = new NoopHook();
 
-  private final ConsumerHealthController health = new ConsumerHealthController(null, null, null, NOOP_HOOK);
+  private final ConsumerHealthController health =
+    new ConsumerHealthController(null, null, null, NOOP_HOOK, NOOP_HOOK);
   private final AtomicLong inFlight = new AtomicLong(1);
 
   /// Consumer-thread side: publish the pause bit, then run the lost-wakeup guard's re-read of
@@ -66,7 +67,8 @@ public class BackpressureHandshakeJCStressTest {
 
   /// Side-effect-free hook: the stress test exercises only the pause mask, never the pause /
   /// resume choreography, so every callback is a no-op.
-  private static final class NoopHook implements ConsumerHealthController.Hook {
+  private static final class NoopHook
+    implements ConsumerHealthController.PauseLifecycleHook, ConsumerHealthController.HealthMetricsObserver {
 
     @Override
     public void onPause() {}

--- a/lib/kpipe-consumer/src/main/java/io/github/eschizoid/kpipe/consumer/ConsumerHealthController.java
+++ b/lib/kpipe-consumer/src/main/java/io/github/eschizoid/kpipe/consumer/ConsumerHealthController.java
@@ -23,8 +23,9 @@ import org.apache.kafka.clients.consumer.Consumer;
 /// Owns the pause bitmask, the CB state machine (`AtomicReference<CircuitBreakerState>`), the
 /// trip timestamp, the probe-timer `ScheduledFuture`, and the rolling success/failure window.
 /// Side effects (`kafkaConsumer.pause`, `LockSupport.unpark`, command-queue inserts) stay on
-/// [KPipeConsumer]; transitions are signalled through the [Hook] supplied at construction so the
-/// host owns the single site that drives the command queue.
+/// [KPipeConsumer]; pause/resume transitions are signalled through the [PauseLifecycleHook] and
+/// metric events through the [HealthMetricsObserver], both supplied at construction so the host
+/// owns the single site that drives the command queue.
 ///
 /// Surface used by [KPipeConsumer]:
 ///
@@ -53,16 +54,22 @@ final class ConsumerHealthController {
     }
   }
 
-  /// Side-effect surface the controller delegates to. KPipeConsumer wires this to its
-  /// `internalPause` / `internalResume` choreography and to the AtomicLong metrics map plus the
-  /// OTel `ConsumerMetrics`. Kept narrow so unit tests can substitute a recording fake.
-  interface Hook {
+  /// Pause-lifecycle side effects the controller drives during arbitration. KPipeConsumer wires
+  /// this to its `internalPause` / `internalResume` choreography — the two callbacks that flip
+  /// actual Kafka consumer state when the arbitrated pause set transitions between empty and
+  /// non-empty. Kept narrow so unit tests can substitute a recording fake.
+  interface PauseLifecycleHook {
     /// Invoked when an arbitrary source transitions the consumer into the paused state.
     void onPause();
 
     /// Invoked when the *last* held source releases the pause and the consumer resumes.
     void onResume();
+  }
 
+  /// Pure metric fan-out for backpressure and circuit-breaker events. KPipeConsumer wires this to
+  /// the AtomicLong metrics map plus the OTel `ConsumerMetrics`. These callbacks observe health
+  /// transitions — they never touch Kafka consumer state (that is [PauseLifecycleHook]'s job).
+  interface HealthMetricsObserver {
     /// Invoked when backpressure first crosses the high watermark and requests a pause.
     void onBackpressurePause();
 
@@ -100,33 +107,38 @@ final class ConsumerHealthController {
   private volatile ScheduledFuture<?> cbProbeFuture;
   private final ScheduledExecutorService scheduler;
 
-  private final Hook hook;
+  private final PauseLifecycleHook pauseHook;
+  private final HealthMetricsObserver metricsObserver;
 
   /// Constructs the controller. `scheduler` is only required when `cbController` is non-null —
   /// it is used to schedule the OPEN → HALF_OPEN probe timer.
   ///
   /// @param backpressure the backpressure decision module, or `null` to disable backpressure
   /// @param cbController the circuit-breaker decision module, or `null` to disable the breaker
-  /// @param scheduler    a scheduled executor used to fire the OPEN → HALF_OPEN probe; required
-  ///                     iff `cbController` is non-null
-  /// @param hook         side-effect callbacks (pause/resume + metric counters); must be non-null
+  /// @param scheduler       a scheduled executor used to fire the OPEN → HALF_OPEN probe; required
+  ///                        iff `cbController` is non-null
+  /// @param pauseHook       pause/resume lifecycle callbacks; must be non-null
+  /// @param metricsObserver backpressure + circuit-breaker metric callbacks; must be non-null
   /// @throws IllegalArgumentException if `cbController` is non-null and `scheduler` is null, or
-  ///         if `hook` is null
+  ///         if `pauseHook` or `metricsObserver` is null
   ConsumerHealthController(
     final BackpressureController backpressure,
     final CircuitBreakerController cbController,
     final ScheduledExecutorService scheduler,
-    final Hook hook
+    final PauseLifecycleHook pauseHook,
+    final HealthMetricsObserver metricsObserver
   ) {
     this.backpressure = backpressure;
     this.cbController = cbController;
     this.cbWindow = cbController != null ? new SlidingWindow(cbController.windowSize()) : null;
     this.scheduler = scheduler;
-    this.hook = hook;
+    this.pauseHook = pauseHook;
+    this.metricsObserver = metricsObserver;
     if (cbController != null && scheduler == null) {
       throw new IllegalArgumentException("scheduler is required when a CircuitBreakerController is configured");
     }
-    if (hook == null) throw new IllegalArgumentException("hook cannot be null");
+    if (pauseHook == null) throw new IllegalArgumentException("pauseHook cannot be null");
+    if (metricsObserver == null) throw new IllegalArgumentException("metricsObserver cannot be null");
   }
 
   // ─────────────────────────── Pause API ────────────────────────────────────
@@ -184,9 +196,9 @@ final class ConsumerHealthController {
           backpressure.getMetricName(),
           value
         );
-        hook.onBackpressurePause();
+        metricsObserver.onBackpressurePause();
         backpressurePauseStartNanos = System.nanoTime();
-        if (requestPause(Source.BACKPRESSURE)) hook.onPause();
+        if (requestPause(Source.BACKPRESSURE)) pauseHook.onPause();
         // Lost-wakeup guard. The PAUSE decision above came from a metric read taken BEFORE
         // `requestPause` published the BACKPRESSURE bit, but record completions only unpark the
         // consumer thread when they observe that bit after decrementing the in-flight count.
@@ -232,10 +244,10 @@ final class ConsumerHealthController {
   /// post-pause lost-wakeup guard above.
   private void releaseBackpressure() {
     final long duration = Math.max(1, TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - backpressurePauseStartNanos));
-    hook.onBackpressureTimeMs(duration);
+    metricsObserver.onBackpressureTimeMs(duration);
     if (releasePause(Source.BACKPRESSURE)) {
       LOGGER.log(Level.INFO, "Backpressure resolved: resuming consumer (paused for {0} ms)", duration);
-      hook.onResume();
+      pauseHook.onResume();
     } else {
       LOGGER.log(
         Level.INFO,
@@ -310,9 +322,9 @@ final class ConsumerHealthController {
       cbWindow.failureRate(),
       cbController.openDuration()
     );
-    hook.onCircuitBreakerTrip();
-    hook.onCircuitBreakerStateChange(CircuitBreakerState.OPEN);
-    if (requestPause(Source.CIRCUIT_BREAKER)) hook.onPause();
+    metricsObserver.onCircuitBreakerTrip();
+    metricsObserver.onCircuitBreakerStateChange(CircuitBreakerState.OPEN);
+    if (requestPause(Source.CIRCUIT_BREAKER)) pauseHook.onPause();
     final var existing = cbProbeFuture;
     if (existing != null) existing.cancel(false);
     cbProbeFuture = scheduler.schedule(
@@ -333,9 +345,9 @@ final class ConsumerHealthController {
     final var openedAt = cbOpenedAtNanos.get();
     final var openMs = openedAt == 0L ? 0L : TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - openedAt);
     LOGGER.log(Level.INFO, "Circuit breaker probing: open for {0} ms, resuming consumer", openMs);
-    hook.onCircuitBreakerTimeOpenMs(openMs);
-    hook.onCircuitBreakerStateChange(CircuitBreakerState.HALF_OPEN);
-    if (releasePause(Source.CIRCUIT_BREAKER)) hook.onResume();
+    metricsObserver.onCircuitBreakerTimeOpenMs(openMs);
+    metricsObserver.onCircuitBreakerStateChange(CircuitBreakerState.HALF_OPEN);
+    if (releasePause(Source.CIRCUIT_BREAKER)) pauseHook.onResume();
   }
 
   /// Transitions the breaker back to CLOSED after a successful probe. Resets stats so the next trip
@@ -344,7 +356,7 @@ final class ConsumerHealthController {
     LOGGER.log(Level.INFO, "Circuit breaker closed: probe succeeded, resuming normal operation");
     cbWindow.reset();
     cbOpenedAtNanos.set(0L);
-    hook.onCircuitBreakerStateChange(CircuitBreakerState.CLOSED);
+    metricsObserver.onCircuitBreakerStateChange(CircuitBreakerState.CLOSED);
   }
 
   // ─────────────────────────── Sliding window ───────────────────────────────

--- a/lib/kpipe-consumer/src/main/java/io/github/eschizoid/kpipe/consumer/ConsumerHealthController.java
+++ b/lib/kpipe-consumer/src/main/java/io/github/eschizoid/kpipe/consumer/ConsumerHealthController.java
@@ -69,7 +69,29 @@ final class ConsumerHealthController {
   /// Pure metric fan-out for backpressure and circuit-breaker events. KPipeConsumer wires this to
   /// the AtomicLong metrics map plus the OTel `ConsumerMetrics`. These callbacks observe health
   /// transitions — they never touch Kafka consumer state (that is [PauseLifecycleHook]'s job).
+  ///
+  /// Because it is a pure observer, a caller (or a test) that doesn't record metrics can substitute
+  /// [#NOOP] and pair it with a real [PauseLifecycleHook] — the point of keeping the two concerns as
+  /// separate interfaces rather than one 7-method hook.
   interface HealthMetricsObserver {
+    /// A no-op observer: drops every event. For callers wiring pause arbitration without metrics.
+    HealthMetricsObserver NOOP = new HealthMetricsObserver() {
+      @Override
+      public void onBackpressurePause() {}
+
+      @Override
+      public void onBackpressureTimeMs(final long ms) {}
+
+      @Override
+      public void onCircuitBreakerTrip() {}
+
+      @Override
+      public void onCircuitBreakerStateChange(final CircuitBreakerState state) {}
+
+      @Override
+      public void onCircuitBreakerTimeOpenMs(final long ms) {}
+    };
+
     /// Invoked when backpressure first crosses the high watermark and requests a pause.
     void onBackpressurePause();
 

--- a/lib/kpipe-consumer/src/main/java/io/github/eschizoid/kpipe/consumer/KPipeConsumer.java
+++ b/lib/kpipe-consumer/src/main/java/io/github/eschizoid/kpipe/consumer/KPipeConsumer.java
@@ -124,8 +124,8 @@ public class KPipeConsumer implements AutoCloseable {
   /// Composes pause arbitration + backpressure decision + circuit-breaker state machine. The
   /// underlying decision modules ([BackpressureController], [CircuitBreakerController]) remain
   /// public + testable on their own; this controller owns the side-effect choreography and
-  /// dispatches transitions through a Hook that points back at `internalPause` /
-  /// `internalResume` and the metric counters.
+  /// dispatches pause transitions through a PauseLifecycleHook that points back at `internalPause` /
+  /// `internalResume`, and metric events through a HealthMetricsObserver bound to the counters.
   private final ConsumerHealthController health;
 
   private final String deadLetterTopic;
@@ -313,7 +313,7 @@ public class KPipeConsumer implements AutoCloseable {
         bp,
         builder.circuitBreakerController,
         this.scheduler,
-        new ConsumerHealthController.Hook() {
+        new ConsumerHealthController.PauseLifecycleHook() {
           @Override
           public void onPause() {
             internalPause();
@@ -323,7 +323,8 @@ public class KPipeConsumer implements AutoCloseable {
           public void onResume() {
             internalResume();
           }
-
+        },
+        new ConsumerHealthController.HealthMetricsObserver() {
           @Override
           public void onBackpressurePause() {
             metrics.get(METRIC_BACKPRESSURE_PAUSE_COUNT).incrementAndGet();

--- a/lib/kpipe-consumer/src/test/java/io/github/eschizoid/kpipe/consumer/CircuitBreakerTransitionTest.java
+++ b/lib/kpipe-consumer/src/test/java/io/github/eschizoid/kpipe/consumer/CircuitBreakerTransitionTest.java
@@ -19,7 +19,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import org.junit.jupiter.api.Test;
 
 /// Deterministic state-machine transition tests for the circuit breaker, driven directly through
-/// [ConsumerHealthController] with a recording [ConsumerHealthController.Hook] and a
+/// [ConsumerHealthController] with a recording hook (pause-lifecycle + metrics-observer) and a
 /// hand-controlled
 /// scheduler. No Kafka, no `MockConsumer`, no timing-based `awaitCondition` — every transition is
 /// driven by an explicit `recordOutcome(...)` call or by firing the captured probe task by hand, so
@@ -39,12 +39,13 @@ import org.junit.jupiter.api.Test;
 ///   * the one-shot OPEN → HALF_OPEN probe is a single scheduled task, fired exactly once.
 class CircuitBreakerTransitionTest {
 
-  /// Records every Hook callback so a test can assert on the exact transition sequence. The
+  /// Records every hook callback so a test can assert on the exact transition sequence. The
   /// CB-relevant
   /// counters are the ones the state machine drives; pause/resume bookkeeping is recorded too
   /// because a
   /// trip must pause and a successful probe must resume.
-  private static final class RecordingHook implements ConsumerHealthController.Hook {
+  private static final class RecordingHook
+    implements ConsumerHealthController.PauseLifecycleHook, ConsumerHealthController.HealthMetricsObserver {
 
     final AtomicInteger pauses = new AtomicInteger();
     final AtomicInteger resumes = new AtomicInteger();
@@ -234,7 +235,7 @@ class CircuitBreakerTransitionTest {
   /// arithmetic obvious: a full window of 4 needs 2 failures to hit exactly 50%.
   private static ConsumerHealthController newController(final RecordingHook hook, final CapturingScheduler scheduler) {
     final var cb = new CircuitBreakerController(0.5, 4, Duration.ofMillis(300));
-    return new ConsumerHealthController(null, cb, scheduler, hook);
+    return new ConsumerHealthController(null, cb, scheduler, hook, hook);
   }
 
   /// Drives the breaker CLOSED → OPEN by feeding a full window of failures, then asserts the trip
@@ -382,7 +383,7 @@ class CircuitBreakerTransitionTest {
     final var hook = new RecordingHook();
     final var scheduler = new CapturingScheduler();
     // No CircuitBreakerController → breaker disabled. recordOutcome must be a clean no-op.
-    final var hc = new ConsumerHealthController(null, null, scheduler, hook);
+    final var hc = new ConsumerHealthController(null, null, scheduler, hook, hook);
 
     for (int i = 0; i < 50; i++) hc.recordOutcome(false);
 

--- a/lib/kpipe-consumer/src/test/java/io/github/eschizoid/kpipe/consumer/ConsumerHealthControllerTest.java
+++ b/lib/kpipe-consumer/src/test/java/io/github/eschizoid/kpipe/consumer/ConsumerHealthControllerTest.java
@@ -213,6 +213,43 @@ class ConsumerHealthControllerTest {
   }
 
   @Test
+  void pauseArbitrationIsTestableWithoutAMetricsFake() {
+    // The payoff of splitting the old 7-method Hook into PauseLifecycleHook + HealthMetricsObserver:
+    // a test that cares only about pause arbitration supplies a focused 2-method PauseLifecycleHook
+    // recorder and the shared no-op HealthMetricsObserver — two DISTINCT adapters, wired
+    // independently, with no obligation to stub the five metric callbacks.
+    final var pauses = new AtomicInteger();
+    final var resumes = new AtomicInteger();
+    final ConsumerHealthController.PauseLifecycleHook pauseOnly = new ConsumerHealthController.PauseLifecycleHook() {
+      @Override
+      public void onPause() {
+        pauses.incrementAndGet();
+      }
+
+      @Override
+      public void onResume() {
+        resumes.incrementAndGet();
+      }
+    };
+
+    final var inflight = new AtomicInteger(0);
+    final var bp = new BackpressureController(10, 3, BackpressureController.inFlightStrategy(inflight::get));
+    final var health =
+      new ConsumerHealthController(bp, null, scheduler, pauseOnly, ConsumerHealthController.HealthMetricsObserver.NOOP);
+    final var consumer = new MockConsumer<byte[], byte[]>("earliest");
+
+    inflight.set(15);
+    health.tickBackpressure(consumer);
+    assertEquals(1, pauses.get(), "pause fires through the PauseLifecycleHook alongside a no-op metrics observer");
+    assertTrue(health.isPaused());
+
+    inflight.set(2);
+    health.tickBackpressure(consumer);
+    assertEquals(1, resumes.get(), "resume fires through the PauseLifecycleHook");
+    assertFalse(health.isPaused());
+  }
+
+  @Test
   void tickBackpressureDispatchesPauseAndResumeViaInFlightStrategy() {
     final var inflight = new AtomicInteger(0);
     final var bp = new BackpressureController(10, 3, BackpressureController.inFlightStrategy(inflight::get));

--- a/lib/kpipe-consumer/src/test/java/io/github/eschizoid/kpipe/consumer/ConsumerHealthControllerTest.java
+++ b/lib/kpipe-consumer/src/test/java/io/github/eschizoid/kpipe/consumer/ConsumerHealthControllerTest.java
@@ -40,7 +40,7 @@ class ConsumerHealthControllerTest {
 
   @Test
   void requestPauseReturnsTrueOnlyOnTransition() {
-    final var health = new ConsumerHealthController(null, null, scheduler, hook);
+    final var health = new ConsumerHealthController(null, null, scheduler, hook, hook);
 
     assertTrue(health.requestPause(ConsumerHealthController.Source.MANUAL), "first request causes transition");
     assertFalse(health.requestPause(ConsumerHealthController.Source.MANUAL), "second request idempotent");
@@ -52,7 +52,7 @@ class ConsumerHealthControllerTest {
 
   @Test
   void releasePauseTransitionsOnlyOnLastRelease() {
-    final var health = new ConsumerHealthController(null, null, scheduler, hook);
+    final var health = new ConsumerHealthController(null, null, scheduler, hook, hook);
     health.requestPause(ConsumerHealthController.Source.MANUAL);
     health.requestPause(ConsumerHealthController.Source.BACKPRESSURE);
 
@@ -70,7 +70,7 @@ class ConsumerHealthControllerTest {
 
   @Test
   void currentSourcesReflectsHeldSet() {
-    final var health = new ConsumerHealthController(null, null, scheduler, hook);
+    final var health = new ConsumerHealthController(null, null, scheduler, hook, hook);
     health.requestPause(ConsumerHealthController.Source.MANUAL);
     health.requestPause(ConsumerHealthController.Source.CIRCUIT_BREAKER);
 
@@ -81,8 +81,19 @@ class ConsumerHealthControllerTest {
   }
 
   @Test
-  void hookRejectedAsNull() {
-    assertThrows(IllegalArgumentException.class, () -> new ConsumerHealthController(null, null, scheduler, null));
+  void pauseHookRejectedAsNull() {
+    assertThrows(
+      IllegalArgumentException.class,
+      () -> new ConsumerHealthController(null, null, scheduler, null, hook)
+    );
+  }
+
+  @Test
+  void metricsObserverRejectedAsNull() {
+    assertThrows(
+      IllegalArgumentException.class,
+      () -> new ConsumerHealthController(null, null, scheduler, hook, null)
+    );
   }
 
   // ─────────────────────────── Circuit breaker ──────────────────────────────
@@ -90,12 +101,12 @@ class ConsumerHealthControllerTest {
   @Test
   void cbControllerRequiresSchedulerWhenConfigured() {
     final var cb = new CircuitBreakerController(0.5, 10, Duration.ofMillis(500));
-    assertThrows(IllegalArgumentException.class, () -> new ConsumerHealthController(null, cb, null, hook));
+    assertThrows(IllegalArgumentException.class, () -> new ConsumerHealthController(null, cb, null, hook, hook));
   }
 
   @Test
   void recordOutcomeNoopWhenCircuitBreakerDisabled() {
-    final var health = new ConsumerHealthController(null, null, scheduler, hook);
+    final var health = new ConsumerHealthController(null, null, scheduler, hook, hook);
     health.recordOutcome(false);
     assertEquals(CircuitBreakerState.CLOSED, health.circuitBreakerState());
     assertEquals(0, hook.trips);
@@ -104,7 +115,7 @@ class ConsumerHealthControllerTest {
   @Test
   void breakerTripsAndPausesWhenThresholdCrossed() {
     final var cb = new CircuitBreakerController(0.5, 4, Duration.ofMillis(500));
-    final var health = new ConsumerHealthController(null, cb, scheduler, hook);
+    final var health = new ConsumerHealthController(null, cb, scheduler, hook, hook);
 
     health.recordOutcome(false);
     health.recordOutcome(false);
@@ -121,7 +132,7 @@ class ConsumerHealthControllerTest {
   @Test
   void openIgnoresIncomingOutcomes() {
     final var cb = new CircuitBreakerController(0.5, 2, Duration.ofMillis(500));
-    final var health = new ConsumerHealthController(null, cb, scheduler, hook);
+    final var health = new ConsumerHealthController(null, cb, scheduler, hook, hook);
     health.recordOutcome(false);
     health.recordOutcome(false);
     assertEquals(CircuitBreakerState.OPEN, health.circuitBreakerState());
@@ -136,7 +147,7 @@ class ConsumerHealthControllerTest {
   @Test
   void probeFiresAfterOpenDurationAndHalfOpens() throws InterruptedException {
     final var cb = new CircuitBreakerController(0.5, 2, Duration.ofMillis(150));
-    final var health = new ConsumerHealthController(null, cb, scheduler, hook);
+    final var health = new ConsumerHealthController(null, cb, scheduler, hook, hook);
 
     health.recordOutcome(false);
     health.recordOutcome(false);
@@ -152,7 +163,7 @@ class ConsumerHealthControllerTest {
   @Test
   void halfOpenSuccessClosesBreaker() throws InterruptedException {
     final var cb = new CircuitBreakerController(0.5, 2, Duration.ofMillis(100));
-    final var health = new ConsumerHealthController(null, cb, scheduler, hook);
+    final var health = new ConsumerHealthController(null, cb, scheduler, hook, hook);
 
     health.recordOutcome(false);
     health.recordOutcome(false);
@@ -166,7 +177,7 @@ class ConsumerHealthControllerTest {
   @Test
   void halfOpenFailureTripsBreakerAgain() throws InterruptedException {
     final var cb = new CircuitBreakerController(0.5, 2, Duration.ofMillis(100));
-    final var health = new ConsumerHealthController(null, cb, scheduler, hook);
+    final var health = new ConsumerHealthController(null, cb, scheduler, hook, hook);
 
     health.recordOutcome(false);
     health.recordOutcome(false);
@@ -181,7 +192,7 @@ class ConsumerHealthControllerTest {
   @Test
   void shutdownCancelsPendingProbe() throws InterruptedException {
     final var cb = new CircuitBreakerController(0.5, 2, Duration.ofMillis(200));
-    final var health = new ConsumerHealthController(null, cb, scheduler, hook);
+    final var health = new ConsumerHealthController(null, cb, scheduler, hook, hook);
     health.recordOutcome(false);
     health.recordOutcome(false);
     assertEquals(CircuitBreakerState.OPEN, health.circuitBreakerState());
@@ -195,7 +206,7 @@ class ConsumerHealthControllerTest {
 
   @Test
   void tickBackpressureNoopWhenDisabled() {
-    final var health = new ConsumerHealthController(null, null, scheduler, hook);
+    final var health = new ConsumerHealthController(null, null, scheduler, hook, hook);
     final var consumer = new MockConsumer<byte[], byte[]>("earliest");
     health.tickBackpressure(consumer);
     assertEquals(0, hook.pauseCalls);
@@ -205,7 +216,7 @@ class ConsumerHealthControllerTest {
   void tickBackpressureDispatchesPauseAndResumeViaInFlightStrategy() {
     final var inflight = new AtomicInteger(0);
     final var bp = new BackpressureController(10, 3, BackpressureController.inFlightStrategy(inflight::get));
-    final var health = new ConsumerHealthController(bp, null, scheduler, hook);
+    final var health = new ConsumerHealthController(bp, null, scheduler, hook, hook);
     final var consumer = new MockConsumer<byte[], byte[]>("earliest");
 
     // Below high watermark — no action.
@@ -237,7 +248,7 @@ class ConsumerHealthControllerTest {
   void tickBackpressureResumesWhenInFlightDrainsInsidePauseWindow() {
     final var inflight = new AtomicInteger(15);
     final var bp = new BackpressureController(10, 3, BackpressureController.inFlightStrategy(inflight::get));
-    final var health = new ConsumerHealthController(bp, null, scheduler, hook);
+    final var health = new ConsumerHealthController(bp, null, scheduler, hook, hook);
     final var consumer = new MockConsumer<byte[], byte[]>("earliest");
     // Simulate every in-flight record completing between the PAUSE decision and the pause bit
     // becoming visible: those completions all read the pause mask before the BACKPRESSURE bit
@@ -261,7 +272,7 @@ class ConsumerHealthControllerTest {
   void tickBackpressureResumeIgnoredWhenBackpressureDoesNotHoldThePause() {
     final var inflight = new AtomicInteger(0);
     final var bp = new BackpressureController(10, 3, BackpressureController.inFlightStrategy(inflight::get));
-    final var health = new ConsumerHealthController(bp, null, scheduler, hook);
+    final var health = new ConsumerHealthController(bp, null, scheduler, hook, hook);
     final var consumer = new MockConsumer<byte[], byte[]>("earliest");
     // MANUAL holds the pause; backpressure never paused, so its pause-start timestamp was never
     // set. The metric sits at/below the low watermark, so the raw check() answer is RESUME —
@@ -280,7 +291,7 @@ class ConsumerHealthControllerTest {
   @Test
   void backpressureMetricNameReflectsConfiguredStrategy() {
     final var bp = new BackpressureController(10, 3, BackpressureController.inFlightStrategy(() -> 0L));
-    final var health = new ConsumerHealthController(bp, null, scheduler, hook);
+    final var health = new ConsumerHealthController(bp, null, scheduler, hook, hook);
     assertEquals("in-flight", health.backpressureMetricName());
     assertTrue(health.backpressureEnabled());
   }
@@ -292,7 +303,7 @@ class ConsumerHealthControllerTest {
     // Verify the internal window keeps totals consistent under heavy concurrent writes — the
     // sliding-window invariant we used to test directly on the deleted CircuitBreakerStats class.
     final var cb = new CircuitBreakerController(0.99, 1000, Duration.ofSeconds(30));
-    final var health = new ConsumerHealthController(null, cb, scheduler, hook);
+    final var health = new ConsumerHealthController(null, cb, scheduler, hook, hook);
     final var totalWrites = 50_000;
     final var done = new CountDownLatch(totalWrites);
 
@@ -312,7 +323,8 @@ class ConsumerHealthControllerTest {
     assertEquals(CircuitBreakerState.CLOSED, health.circuitBreakerState());
   }
 
-  private static final class RecordingHook implements ConsumerHealthController.Hook {
+  private static final class RecordingHook
+    implements ConsumerHealthController.PauseLifecycleHook, ConsumerHealthController.HealthMetricsObserver {
 
     int pauseCalls;
     int resumeCalls;


### PR DESCRIPTION
## What

`ConsumerHealthController.Hook` was one interface with 7 methods mixing two unrelated concerns. Test fakes had to stub all 7 even to exercise one side. Split along the natural seam:

- **`PauseLifecycleHook`** — the pause-arbitration side effects that flip Kafka consumer state: `onPause()`, `onResume()`.
- **`HealthMetricsObserver`** — pure metric fan-out (never touches consumer state): `onBackpressurePause()`, `onBackpressureTimeMs(long)`, `onCircuitBreakerTrip()`, `onCircuitBreakerStateChange(...)`, `onCircuitBreakerTimeOpenMs(long)`.

`ConsumerHealthController` takes both at construction (null-checked), routing pause/resume through `pauseHook` and metric events through `metricsObserver`. `KPipeConsumer`'s inline `Hook` impl splits into two inline impls. §16: `Hook` deleted, all callers + test fakes migrated in this PR (no `@Deprecated`).

## Why

Testability: a fake for pause behavior no longer carries 5 dead metric-callback stubs, and vice versa. The interface now names precisely what a collaborator observes.

## Verification

- Behavior preserved exactly (interface reshape, no logic change): pause arbitration + every metric callback fire as before.
- `ConsumerHealthControllerTest` (19) + `CircuitBreakerTransitionTest` (8) pass; `compileJava` green. Grep: zero `ConsumerHealthController.Hook` references remain.
- (The broker Testcontainers integration tests can't run in the build sandbox — Docker-unavailable, unrelated; CI runs them.)