### PR TITLE
fix: robustness bundle — Sink single-shot guard, close() WARN log, span-scope CAS, ServiceLoader determinism

### DIFF
--- a/lib/kpipe-api/src/main/java/io/github/eschizoid/kpipe/DefaultBatchSink.java
+++ b/lib/kpipe-api/src/main/java/io/github/eschizoid/kpipe/DefaultBatchSink.java
@@ -6,6 +6,7 @@ import io.github.eschizoid.kpipe.registry.MessageProcessorRegistry;
 import io.github.eschizoid.kpipe.sink.BatchPolicy;
 import io.github.eschizoid.kpipe.sink.BatchSink;
 import java.util.Objects;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 /// Package-private [Sink] impl for batch terminals. Builds a sink-less
 /// [io.github.eschizoid.kpipe.registry.MessagePipeline]
@@ -20,19 +21,40 @@ import java.util.Objects;
 /// topic instances per route and collects them at `start()` time into one consumer subscribing
 /// to multiple topics.
 ///
+/// Single-shot: the [#started] guard makes a second [#start()] throw. [MultiBuilder] reads
+/// [#buildPipeline()] / [#batchSink()] / [#batchPolicy()] rather than calling this route's
+/// `start()`, so folding a batch route into a multi-topic consumer leaves the guard untripped.
+///
 /// @param <T> the deserialized value type
-record DefaultBatchSink<T>(
-  DefaultStream<T> stream,
-  BatchSink<T> batchSink,
-  BatchPolicy batchPolicy
-) implements Sink<T> {
-  DefaultBatchSink {
-    Objects.requireNonNull(stream, "stream cannot be null");
-    Objects.requireNonNull(batchSink, "batchSink cannot be null");
-    Objects.requireNonNull(batchPolicy, "batchPolicy cannot be null");
+final class DefaultBatchSink<T> implements Sink<T> {
+
+  private final DefaultStream<T> stream;
+  private final BatchSink<T> batchSink;
+  private final BatchPolicy batchPolicy;
+  private final AtomicBoolean started = new AtomicBoolean(false);
+
+  DefaultBatchSink(final DefaultStream<T> stream, final BatchSink<T> batchSink, final BatchPolicy batchPolicy) {
+    this.stream = Objects.requireNonNull(stream, "stream cannot be null");
+    this.batchSink = Objects.requireNonNull(batchSink, "batchSink cannot be null");
+    this.batchPolicy = Objects.requireNonNull(batchPolicy, "batchPolicy cannot be null");
     if (stream.topics().size() != 1) throw new IllegalArgumentException(
       "DefaultBatchSink expects a single-topic stream; got %d topics".formatted(stream.topics().size())
     );
+  }
+
+  /// Exposes the configured stream (route folding + test inspection).
+  DefaultStream<T> stream() {
+    return stream;
+  }
+
+  /// Exposes the batch sink for route folding in [MultiBuilder].
+  BatchSink<T> batchSink() {
+    return batchSink;
+  }
+
+  /// Exposes the batch policy for route folding in [MultiBuilder].
+  BatchPolicy batchPolicy() {
+    return batchPolicy;
   }
 
   /// The topic this batch route is bound to. Single-topic by construction; multi-topic
@@ -52,6 +74,9 @@ record DefaultBatchSink<T>(
 
   @Override
   public Handle start() {
+    if (!started.compareAndSet(false, true)) throw new IllegalStateException(
+      "Sink already started — a Sink is single-shot; build a fresh Stream/Sink to run another consumer"
+    );
     final var consumerBuilder = KPipeConsumer.builder()
       .withProperties(stream.kafkaProps())
       .withProcessingMode(stream.processingMode())

--- a/lib/kpipe-api/src/main/java/io/github/eschizoid/kpipe/DefaultSink.java
+++ b/lib/kpipe-api/src/main/java/io/github/eschizoid/kpipe/DefaultSink.java
@@ -8,15 +8,25 @@ import io.github.eschizoid.kpipe.sink.MessageSink;
 import java.lang.System.Logger;
 import java.lang.System.Logger.Level;
 import java.util.Objects;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Consumer;
 
 /// Package-private [Sink] impl. Holds the configured [DefaultStream] plus the chosen terminal
 /// [MessageSink] and constructs a fully-wired [KPipeConsumer] on `start()`. The consumer hosts
 /// its own lifecycle since the 1.13 KPipeRunner fold.
 ///
+/// Single-shot: the [#started] guard makes a second [#start()] throw rather than silently spin up
+/// a second live consumer (the underlying consumer cannot be restarted). [MultiBuilder] does not
+/// call this sink's `start()` — it reads [#buildPipeline()] to fold the route into one shared
+/// consumer — so each route-sink stays independently single-shot.
+///
 /// @param <T> the deserialized message type
-record DefaultSink<T>(DefaultStream<T> stream, MessageSink<T> terminalSink) implements Sink<T> {
+final class DefaultSink<T> implements Sink<T> {
   private static final Logger LOGGER = System.getLogger(DefaultSink.class.getName());
+
+  private final DefaultStream<T> stream;
+  private final MessageSink<T> terminalSink;
+  private final AtomicBoolean started = new AtomicBoolean(false);
 
   DefaultSink(final DefaultStream<T> stream, final MessageSink<T> terminalSink) {
     this.stream = Objects.requireNonNull(stream, "stream cannot be null");
@@ -25,6 +35,9 @@ record DefaultSink<T>(DefaultStream<T> stream, MessageSink<T> terminalSink) impl
 
   @Override
   public Handle start() {
+    if (!started.compareAndSet(false, true)) throw new IllegalStateException(
+      "Sink already started — a Sink is single-shot; build a fresh Stream/Sink to run another consumer"
+    );
     final var consumerBuilder = KPipeConsumer.builder()
       .withProperties(stream.kafkaProps())
       .withTopics(stream.topics())
@@ -105,15 +118,13 @@ record DefaultSink<T>(DefaultStream<T> stream, MessageSink<T> terminalSink) impl
   }
 
   /// Exposes the configured stream for test inspection of composition.
-  @Override
-  public DefaultStream<T> stream() {
+  DefaultStream<T> stream() {
     return stream;
   }
 
   /// Exposes the terminal sink for test inspection of composition (verifies
   /// that `toConsole()` / `toCustom()` / `toMulti()` produced the expected sink type).
-  @Override
-  public MessageSink<T> terminalSink() {
+  MessageSink<T> terminalSink() {
     return terminalSink;
   }
 }

--- a/lib/kpipe-api/src/main/java/io/github/eschizoid/kpipe/Sink.java
+++ b/lib/kpipe-api/src/main/java/io/github/eschizoid/kpipe/Sink.java
@@ -4,7 +4,7 @@ package io.github.eschizoid.kpipe;
 /// pipeline but has not started consuming yet — call [#start] to launch the underlying KPipe
 /// consumer and obtain a runtime [Handle].
 ///
-/// A `Sink<T>` is single-shot: calling `start()` more than once produces undefined behavior
+/// A `Sink<T>` is single-shot: calling `start()` a second time throws `IllegalStateException`
 /// (the underlying consumer cannot be restarted). To run multiple pipelines, build separate
 /// `Sink<T>` instances from independent `Stream<T>` chains.
 ///
@@ -23,5 +23,6 @@ public interface Sink<T> {
   /// hook via `KPipeConsumerBuilder.withShutdownHook(true)` on the explicit-API path.
   ///
   /// @return a [Handle] for monitoring and shutdown
+  /// @throws IllegalStateException if `start()` has already been called on this sink (single-shot)
   Handle start();
 }

--- a/lib/kpipe-api/src/test/java/io/github/eschizoid/kpipe/KPipeFacadeBuildTest.java
+++ b/lib/kpipe-api/src/test/java/io/github/eschizoid/kpipe/KPipeFacadeBuildTest.java
@@ -8,6 +8,8 @@ import io.github.eschizoid.kpipe.consumer.ProcessingMode;
 import io.github.eschizoid.kpipe.format.json.JsonFormat;
 import io.github.eschizoid.kpipe.metrics.ConsumerMetrics;
 import io.github.eschizoid.kpipe.producer.tracing.Tracer;
+import io.github.eschizoid.kpipe.sink.BatchPolicy;
+import io.github.eschizoid.kpipe.sink.BatchSink;
 import java.time.Duration;
 import java.util.Map;
 import java.util.Properties;
@@ -118,6 +120,35 @@ class KPipeFacadeBuildTest {
         .withProcessingMode(ProcessingMode.PARALLEL)
         .toCustom(_ -> {})
     );
+  }
+
+  @Test
+  void sinkStartIsSingleShot() {
+    // A Sink is single-shot — a second start() must throw rather than silently spin up a second
+    // live consumer. The first start() opens a lazy KafkaConsumer (no broker connection at
+    // construction) and returns immediately; close it before asserting so no thread leaks.
+    final var sink = KPipe.json("topic", props()).toCustom(_ -> {});
+    try (final var handle = sink.start()) {
+      final var ex = assertThrows(IllegalStateException.class, sink::start);
+      assertTrue(
+        ex.getMessage().contains("single-shot"),
+        () -> "message should explain the single-shot contract: " + ex.getMessage()
+      );
+    }
+  }
+
+  @Test
+  void batchSinkStartIsSingleShot() {
+    final var sink = KPipe.json("topic", props())
+      .withProcessingMode(ProcessingMode.SEQUENTIAL)
+      .toBatch(BatchSink.ofVoid(_ -> {}), new BatchPolicy(10, Duration.ofSeconds(1)));
+    try (final var handle = sink.start()) {
+      final var ex = assertThrows(IllegalStateException.class, sink::start);
+      assertTrue(
+        ex.getMessage().contains("single-shot"),
+        () -> "message should explain the single-shot contract: " + ex.getMessage()
+      );
+    }
   }
 
   @Test

--- a/lib/kpipe-format-protobuf/src/main/java/io/github/eschizoid/kpipe/format/protobuf/ProtobufFormat.java
+++ b/lib/kpipe-format-protobuf/src/main/java/io/github/eschizoid/kpipe/format/protobuf/ProtobufFormat.java
@@ -11,6 +11,7 @@ import io.github.eschizoid.kpipe.registry.SchemaResolver;
 import io.github.eschizoid.kpipe.registry.WireDiagnostics;
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Objects;
 import java.util.ServiceLoader;
@@ -92,15 +93,20 @@ public final class ProtobufFormat implements MessageFormat<Message> {
   /// @return a registry-mode Protobuf codec
   /// @throws IllegalStateException if no [ProtobufDescriptorCompiler] is on the runtime path
   public static ProtobufFormat withRegistry(final SchemaResolver resolver) {
-    final var compilers = ServiceLoader.load(ProtobufDescriptorCompiler.class).stream().toList();
-    if (compilers.isEmpty()) throw new IllegalStateException(
+    // ServiceLoader iteration order is unspecified — sort providers by implementation class name so
+    // the pick is deterministic across classpath layouts. Sort on `provider.type()` (the Class,
+    // no instantiation) and only `get()` the chosen provider.
+    final var providers = ServiceLoader.load(ProtobufDescriptorCompiler.class).stream()
+      .sorted(Comparator.comparing(provider -> provider.type().getName()))
+      .toList();
+    if (providers.isEmpty()) throw new IllegalStateException(
       "No ProtobufDescriptorCompiler found — add kpipe-format-protobuf-confluent to your runtime"
     );
-    final var compiler = compilers.getFirst().get();
-    if (compilers.size() > 1) LOGGER.log(
+    final var compiler = providers.getFirst().get();
+    if (providers.size() > 1) LOGGER.log(
       System.Logger.Level.WARNING,
       "Found {0} ProtobufDescriptorCompiler implementations on the path — using {1}",
-      compilers.size(),
+      providers.size(),
       compiler.getClass().getName()
     );
     return new ProtobufFormat(resolver, compiler);

--- a/lib/kpipe-schema-registry-confluent/src/main/java/io/github/eschizoid/kpipe/schemaregistry/confluent/CachedSchemaResolver.java
+++ b/lib/kpipe-schema-registry-confluent/src/main/java/io/github/eschizoid/kpipe/schemaregistry/confluent/CachedSchemaResolver.java
@@ -1,6 +1,8 @@
 package io.github.eschizoid.kpipe.schemaregistry.confluent;
 
 import io.github.eschizoid.kpipe.registry.SchemaResolver;
+import java.lang.System.Logger;
+import java.lang.System.Logger.Level;
 import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicLong;
@@ -33,6 +35,8 @@ import java.util.concurrent.atomic.AtomicLong;
 /// final var format = AvroFormat.withRegistry(cached);  // per-record auto-lookup
 /// ```
 public final class CachedSchemaResolver implements SchemaResolver, AutoCloseable {
+
+  private static final Logger LOGGER = System.getLogger(CachedSchemaResolver.class.getName());
 
   private final SchemaResolver delegate;
   private final ConcurrentHashMap<Integer, String> cache = new ConcurrentHashMap<>();
@@ -87,6 +91,7 @@ public final class CachedSchemaResolver implements SchemaResolver, AutoCloseable
       try {
         closeable.close();
       } catch (final Exception e) {
+        LOGGER.log(Level.WARNING, "Failed to close delegate resolver", e);
         throw new RuntimeException("Failed to close delegate resolver", e);
       }
     }

--- a/lib/kpipe-tracing-otel/src/main/java/io/github/eschizoid/kpipe/tracing/otel/OtelTracer.java
+++ b/lib/kpipe-tracing-otel/src/main/java/io/github/eschizoid/kpipe/tracing/otel/OtelTracer.java
@@ -16,6 +16,7 @@ import java.lang.System.Logger.Level;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Objects;
+import java.util.concurrent.atomic.AtomicBoolean;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.common.header.Header;
 import org.apache.kafka.common.header.Headers;
@@ -130,7 +131,7 @@ public final class OtelTracer implements Tracer {
 
     private final Span span;
     private final Scope scope;
-    private volatile boolean closed = false;
+    private final AtomicBoolean closed = new AtomicBoolean(false);
 
     OtelSpanScope(final Span span, final Scope scope) {
       this.span = span;
@@ -139,7 +140,7 @@ public final class OtelTracer implements Tracer {
 
     @Override
     public void recordException(final Throwable t) {
-      if (closed || t == null) return;
+      if (closed.get() || t == null) return;
       try {
         span.recordException(t);
         span.setStatus(StatusCode.ERROR, t.getClass().getSimpleName());
@@ -150,8 +151,7 @@ public final class OtelTracer implements Tracer {
 
     @Override
     public void close() {
-      if (closed) return;
-      closed = true;
+      if (!closed.compareAndSet(false, true)) return;
       // Always detach the Context (scope) before ending the span; otherwise a subsequent
       // injection on the same carrier thread would read a stale span.
       try {


### PR DESCRIPTION
Four small, independent robustness/consistency fixes.

1. **`Sink.start()` single-shot guard** — `DefaultSink`/`DefaultBatchSink` gain an `AtomicBoolean` guard; a 2nd `start()` throws `IllegalStateException` (was: silently spun a 2nd live consumer). Both were records → converted to `final class` (records can't hold a non-component field); all call sites use `instanceof` + accessors, not record equals/hashCode. `MultiBuilder` never calls a route-sink's `start()`, so multi-route wiring is unaffected.
2. **`CachedSchemaResolver.close()`** — logs at WARNING before rethrowing the delegate's close failure (was §14 catch-rewrap-without-log).
3. **`OtelSpanScope.close()`** — `volatile boolean` read-then-write → `AtomicBoolean.compareAndSet` (§11 single-read CAS). Consistency hardening, not a live bug (OTel Span/Scope are already idempotent).
4. **`ProtobufFormat.withRegistry` ServiceLoader** — sorts providers by `type().getName()` (no instantiation) before `getFirst()` for a deterministic pick across classpath layouts; keeps the WARN-on-multiple.

New test `KPipeFacadeBuildTest` asserts the double-`start()` throws for both sink types. All four modules' non-Docker tests green.