### PR TITLE
chore(examples): dogfood CapturingSink, drop DemoConfig dead fields, note avro static-fetch footgun

### DIFF
--- a/examples/avro/build.gradle.kts
+++ b/examples/avro/build.gradle.kts
@@ -15,4 +15,6 @@ dependencies {
   implementation(project(":lib:kpipe-format-avro"))
   implementation(project(":lib:kpipe-schema-registry-confluent"))
   implementation(libs.avro)
+
+  testImplementation(project(":lib:kpipe-test"))
 }

--- a/examples/avro/src/main/java/io/github/eschizoid/kpipe/App.java
+++ b/examples/avro/src/main/java/io/github/eschizoid/kpipe/App.java
@@ -11,6 +11,23 @@ import java.lang.System.Logger.Level;
 /// Reads `AppConfig` from environment, fetches the `com.kpipe.customer` schema from the registry
 /// URL, and starts a `KPipe.avro(...)` stream that strips the 5-byte Confluent envelope before
 /// decoding.
+///
+/// ## Static-fetch footgun (this example is the deliberately UNSAFE path)
+///
+/// The `AvroFormat.of(resolver.lookupBySubjectVersion(...))` call below fetches ONE schema at
+/// startup and then decodes every record against it, forever — the schema id in each record's
+/// 5-byte wire envelope is thrown away by `skipBytes(5)`. This is fine only while the producer
+/// never rolls the schema. The moment a producer writes with an evolved v2 (a field removed,
+/// promoted, or a union reordered under FORWARD compatibility), those v2 bytes are silently
+/// mis-decoded against the frozen v1 reader — extra fields bleed into the next field, or offsets
+/// shift — and the corruption is invisible because deserialization still "succeeds".
+///
+/// For per-record correctness use registry mode instead:
+/// `KPipe.avro(topic, props, resolver)`. It reads the schema id from each record's envelope,
+/// looks the writer schema up (cached by id, immutable in SR), and projects to the reader schema
+/// via Avro's schema-resolution rules — so schema evolution decodes correctly. Registry mode reads
+/// the envelope itself, so drop the `skipBytes(5)` when you switch. This example keeps the static
+/// path on purpose to demonstrate the fetch-at-startup shape and its hazard.
 public final class App {
 
   private static final Logger LOGGER = System.getLogger(App.class.getName());

--- a/examples/avro/src/test/java/io/github/eschizoid/kpipe/AppIntegrationTest.java
+++ b/examples/avro/src/test/java/io/github/eschizoid/kpipe/AppIntegrationTest.java
@@ -8,15 +8,13 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import io.github.eschizoid.kpipe.format.avro.AvroFormat;
 import io.github.eschizoid.kpipe.producer.config.KafkaProducerConfig;
-import io.github.eschizoid.kpipe.sink.MessageSink;
+import io.github.eschizoid.kpipe.test.CapturingSink;
 import java.io.ByteArrayOutputStream;
 import java.nio.ByteBuffer;
 import java.time.Duration;
 import java.util.Collections;
-import java.util.List;
 import java.util.Properties;
 import java.util.UUID;
-import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.TimeUnit;
 import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericData;
@@ -59,15 +57,14 @@ class AppIntegrationTest {
   @Test
   void testAvroAppEndToEnd() throws Exception {
     final var topic = "avro-topic-" + UUID.randomUUID().toString().substring(0, 8);
-    final var captured = new CopyOnWriteArrayList<GenericRecord>();
-    final MessageSink<GenericRecord> capturingSink = captured::add;
+    final var capturingSink = new CapturingSink<GenericRecord>();
 
     try (final var handle = KPipe.avro(topic, consumerProps(), format).skipBytes(5).toCustom(capturingSink).start()) {
       assertTrue(handle.isHealthy(), "Handle should be healthy after start()");
 
-      produceUntilConsumed(topic, createConfluentWirePayload(), captured, Duration.ofSeconds(15));
+      produceUntilConsumed(topic, createConfluentWirePayload(), capturingSink, Duration.ofSeconds(15));
 
-      final var processed = captured.getFirst();
+      final var processed = capturingSink.captured().getFirst();
       assertAll(
         () -> assertEquals(1L, processed.get("id")),
         () -> assertEquals("Test User", processed.get("name").toString()),
@@ -114,7 +111,7 @@ class AppIntegrationTest {
   private static void produceUntilConsumed(
     final String topic,
     final byte[] payload,
-    final List<?> sink,
+    final CapturingSink<?> sink,
     final Duration timeout
   ) throws Exception {
     final var producerProps = KafkaProducerConfig.createProducerConfig(kafka.getBootstrapServers());
@@ -122,7 +119,7 @@ class AppIntegrationTest {
     try (final var producer = new KafkaProducer<byte[], byte[]>(producerProps)) {
       while (System.nanoTime() < deadline) {
         producer.send(new ProducerRecord<>(topic, payload)).get();
-        if (!sink.isEmpty()) return;
+        if (sink.count() > 0) return;
         TimeUnit.MILLISECONDS.sleep(250);
       }
     }

--- a/examples/demo/src/main/java/io/github/eschizoid/kpipe/demo/DemoConfig.java
+++ b/examples/demo/src/main/java/io/github/eschizoid/kpipe/demo/DemoConfig.java
@@ -1,7 +1,5 @@
 package io.github.eschizoid.kpipe.demo;
 
-import java.time.Duration;
-
 /// Configuration for the demo application with all three pipeline topics.
 ///
 /// @param bootstrapServers Kafka bootstrap servers
@@ -10,19 +8,13 @@ import java.time.Duration;
 /// @param jsonTopic Topic for JSON messages
 /// @param avroTopic Topic for Avro messages
 /// @param protoTopic Topic for Protobuf messages
-/// @param pollTimeout Poll timeout duration
-/// @param shutdownTimeout Shutdown timeout duration
-/// @param metricsInterval Metrics reporting interval
 public record DemoConfig(
   String bootstrapServers,
   String consumerGroup,
   String schemaRegistryUrl,
   String jsonTopic,
   String avroTopic,
-  String protoTopic,
-  Duration pollTimeout,
-  Duration shutdownTimeout,
-  Duration metricsInterval
+  String protoTopic
 ) {
   private static final String DEFAULT_SCHEMA_REGISTRY_URL = "http://schema-registry:8081";
 
@@ -34,10 +26,7 @@ public record DemoConfig(
       env("SCHEMA_REGISTRY_URL", DEFAULT_SCHEMA_REGISTRY_URL),
       env("JSON_TOPIC", "json-topic"),
       env("AVRO_TOPIC", "avro-topic"),
-      env("PROTO_TOPIC", "proto-topic"),
-      Duration.ofMillis(Long.parseLong(env("KAFKA_POLL_TIMEOUT_MS", "100"))),
-      Duration.ofSeconds(Long.parseLong(env("SHUTDOWN_TIMEOUT_SEC", "30"))),
-      Duration.ofSeconds(Long.parseLong(env("METRICS_INTERVAL_SEC", "60")))
+      env("PROTO_TOPIC", "proto-topic")
     );
   }
 

--- a/examples/demo/src/test/java/io/github/eschizoid/kpipe/demo/DemoAppIntegrationTest.java
+++ b/examples/demo/src/test/java/io/github/eschizoid/kpipe/demo/DemoAppIntegrationTest.java
@@ -46,10 +46,7 @@ class DemoAppIntegrationTest {
       "http://localhost:8081", // unused — formats built above
       "json-test-topic",
       "avro-test-topic",
-      "proto-test-topic",
-      Duration.ofMillis(100),
-      Duration.ofSeconds(5),
-      Duration.ofSeconds(60)
+      "proto-test-topic"
     );
 
     try (final var _ = new DemoApp(config, avroFormat, protoFormat)) {

--- a/examples/json/build.gradle.kts
+++ b/examples/json/build.gradle.kts
@@ -12,4 +12,6 @@ description = "KPipe - Kafka Consumer Application Using JSON"
 
 dependencies {
   implementation(project(":lib:kpipe-format-json"))
+
+  testImplementation(project(":lib:kpipe-test"))
 }

--- a/examples/json/src/test/java/io/github/eschizoid/kpipe/AppIntegrationTest.java
+++ b/examples/json/src/test/java/io/github/eschizoid/kpipe/AppIntegrationTest.java
@@ -6,14 +6,12 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import io.github.eschizoid.kpipe.producer.config.KafkaProducerConfig;
-import io.github.eschizoid.kpipe.sink.MessageSink;
+import io.github.eschizoid.kpipe.test.CapturingSink;
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
-import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 import java.util.UUID;
-import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.TimeUnit;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.producer.KafkaProducer;
@@ -38,8 +36,7 @@ class AppIntegrationTest {
   @Test
   void testJsonAppEndToEnd() throws Exception {
     final var topic = "json-topic-" + UUID.randomUUID().toString().substring(0, 8);
-    final var captured = new CopyOnWriteArrayList<Map<String, Object>>();
-    final MessageSink<Map<String, Object>> capturingSink = captured::add;
+    final var capturingSink = new CapturingSink<Map<String, Object>>();
 
     try (
       final var handle = KPipe.json(topic, consumerProps())
@@ -62,9 +59,9 @@ class AppIntegrationTest {
 
       final var message = """
         {"id":1,"message":"Hello JSON"}""".getBytes(StandardCharsets.UTF_8);
-      produceUntilConsumed(topic, message, captured, Duration.ofSeconds(15));
+      produceUntilConsumed(topic, message, capturingSink, Duration.ofSeconds(15));
 
-      final var processed = captured.getFirst();
+      final var processed = capturingSink.captured().getFirst();
       assertAll(
         () -> assertEquals(1.0, ((Number) processed.get("id")).doubleValue()),
         () -> assertEquals("Hello JSON", processed.get("message")),
@@ -91,7 +88,7 @@ class AppIntegrationTest {
   private static void produceUntilConsumed(
     final String topic,
     final byte[] payload,
-    final List<?> sink,
+    final CapturingSink<?> sink,
     final Duration timeout
   ) throws Exception {
     final var producerProps = KafkaProducerConfig.createProducerConfig(kafka.getBootstrapServers());
@@ -99,7 +96,7 @@ class AppIntegrationTest {
     try (final var producer = new KafkaProducer<byte[], byte[]>(producerProps)) {
       while (System.nanoTime() < deadline) {
         producer.send(new ProducerRecord<>(topic, payload)).get();
-        if (!sink.isEmpty()) return;
+        if (sink.count() > 0) return;
         TimeUnit.MILLISECONDS.sleep(250);
       }
     }

--- a/examples/protobuf-schema-registry/build.gradle.kts
+++ b/examples/protobuf-schema-registry/build.gradle.kts
@@ -24,4 +24,5 @@ dependencies {
   // protobuf module must both be on the test compile+runtime classpath.
   testImplementation(project(":lib:kpipe-format-protobuf"))
   testImplementation(project(":lib:kpipe-format-protobuf-confluent"))
+  testImplementation(project(":lib:kpipe-test"))
 }

--- a/examples/protobuf-schema-registry/src/test/java/io/github/eschizoid/kpipe/AppIntegrationTest.java
+++ b/examples/protobuf-schema-registry/src/test/java/io/github/eschizoid/kpipe/AppIntegrationTest.java
@@ -23,7 +23,7 @@ import io.github.eschizoid.kpipe.consumer.ProcessingMode;
 import io.github.eschizoid.kpipe.format.protobuf.ProtobufFormat;
 import io.github.eschizoid.kpipe.registry.MessageProcessorRegistry;
 import io.github.eschizoid.kpipe.registry.SchemaResolver;
-import io.github.eschizoid.kpipe.sink.MessageSink;
+import io.github.eschizoid.kpipe.test.CapturingSink;
 import java.io.ByteArrayOutputStream;
 import java.time.Duration;
 import java.util.Collection;
@@ -32,7 +32,6 @@ import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.function.BooleanSupplier;
 import org.apache.kafka.clients.consumer.ConsumerRebalanceListener;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
@@ -95,8 +94,7 @@ class AppIntegrationTest {
       return CUSTOMER_PROTO;
     };
 
-    final var captured = new CopyOnWriteArrayList<Message>();
-    final MessageSink<Message> capturingSink = captured::add;
+    final var capturingSink = new CapturingSink<Message>();
     final var pipeline = new MessageProcessorRegistry()
       .pipeline(ProtobufFormat.withRegistry(resolver))
       .toSink(capturingSink)
@@ -118,9 +116,9 @@ class AppIntegrationTest {
 
     try {
       consumer.start();
-      awaitCondition(() -> !captured.isEmpty() && offsetManager.marked.contains(0L), 10_000);
+      awaitCondition(() -> capturingSink.count() > 0 && offsetManager.marked.contains(0L), 10_000);
 
-      final var decoded = captured.getFirst();
+      final var decoded = capturingSink.captured().getFirst();
       final var desc = decoded.getDescriptorForType();
       assertAll(
         () -> assertEquals("Customer", desc.getName(), "decoded the writer message type resolved from the envelope"),

--- a/examples/protobuf/build.gradle.kts
+++ b/examples/protobuf/build.gradle.kts
@@ -14,4 +14,6 @@ dependencies {
   implementation(project(":lib:kpipe-format-protobuf"))
   implementation(rootProject.libs.protobufJava)
   implementation(rootProject.libs.protobufUtil)
+
+  testImplementation(project(":lib:kpipe-test"))
 }

--- a/examples/protobuf/src/test/java/io/github/eschizoid/kpipe/AppIntegrationTest.java
+++ b/examples/protobuf/src/test/java/io/github/eschizoid/kpipe/AppIntegrationTest.java
@@ -9,12 +9,10 @@ import com.google.protobuf.DynamicMessage;
 import com.google.protobuf.Message;
 import io.github.eschizoid.kpipe.format.protobuf.ProtobufFormat;
 import io.github.eschizoid.kpipe.producer.config.KafkaProducerConfig;
-import io.github.eschizoid.kpipe.sink.MessageSink;
+import io.github.eschizoid.kpipe.test.CapturingSink;
 import java.time.Duration;
-import java.util.List;
 import java.util.Properties;
 import java.util.UUID;
-import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.TimeUnit;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.producer.KafkaProducer;
@@ -47,8 +45,7 @@ class AppIntegrationTest {
   @Test
   void testProtobufAppEndToEnd() throws Exception {
     final var topic = "protobuf-topic-" + UUID.randomUUID().toString().substring(0, 8);
-    final var captured = new CopyOnWriteArrayList<Message>();
-    final MessageSink<Message> capturingSink = captured::add;
+    final var capturingSink = new CapturingSink<Message>();
 
     final var descriptor = format.descriptor();
 
@@ -72,9 +69,9 @@ class AppIntegrationTest {
         .build()
         .toByteArray();
 
-      produceUntilConsumed(topic, payload, captured, Duration.ofSeconds(15));
+      produceUntilConsumed(topic, payload, capturingSink, Duration.ofSeconds(15));
 
-      final var processed = captured.getFirst();
+      final var processed = capturingSink.captured().getFirst();
       final var desc = processed.getDescriptorForType();
       assertAll(
         () -> assertEquals(1L, processed.getField(desc.findFieldByName("id"))),
@@ -101,7 +98,7 @@ class AppIntegrationTest {
   private static void produceUntilConsumed(
     final String topic,
     final byte[] payload,
-    final List<?> sink,
+    final CapturingSink<?> sink,
     final Duration timeout
   ) throws Exception {
     final var producerProps = KafkaProducerConfig.createProducerConfig(kafka.getBootstrapServers());
@@ -109,7 +106,7 @@ class AppIntegrationTest {
     try (final var producer = new KafkaProducer<byte[], byte[]>(producerProps)) {
       while (System.nanoTime() < deadline) {
         producer.send(new ProducerRecord<>(topic, payload)).get();
-        if (!sink.isEmpty()) return;
+        if (sink.count() > 0) return;
         TimeUnit.MILLISECONDS.sleep(250);
       }
     }

--- a/examples/schema-registry/build.gradle.kts
+++ b/examples/schema-registry/build.gradle.kts
@@ -14,4 +14,6 @@ dependencies {
   implementation(project(":lib:kpipe-format-avro"))
   implementation(project(":lib:kpipe-schema-registry-confluent"))
   implementation(rootProject.libs.avro)
+
+  testImplementation(project(":lib:kpipe-test"))
 }

--- a/examples/schema-registry/src/test/java/io/github/eschizoid/kpipe/AppIntegrationTest.java
+++ b/examples/schema-registry/src/test/java/io/github/eschizoid/kpipe/AppIntegrationTest.java
@@ -6,7 +6,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import io.github.eschizoid.kpipe.consumer.ProcessingMode;
 import io.github.eschizoid.kpipe.format.avro.AvroFormat;
 import io.github.eschizoid.kpipe.schemaregistry.confluent.ConfluentSchemaResolver;
-import io.github.eschizoid.kpipe.sink.MessageSink;
+import io.github.eschizoid.kpipe.test.CapturingSink;
 import java.io.ByteArrayOutputStream;
 import java.net.URI;
 import java.net.http.HttpClient;
@@ -17,7 +17,6 @@ import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.util.Properties;
 import java.util.UUID;
-import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.TimeUnit;
 import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericData;
@@ -90,8 +89,7 @@ class AppIntegrationTest {
       format = AvroFormat.of(fetched);
     }
 
-    final var captured = new CopyOnWriteArrayList<GenericRecord>();
-    final MessageSink<GenericRecord> capturingSink = captured::add;
+    final var capturingSink = new CapturingSink<GenericRecord>();
 
     try (
       final var handle = KPipe.avro(topic, consumerProps(), format)
@@ -106,8 +104,9 @@ class AppIntegrationTest {
       }
 
       final var deadline = System.nanoTime() + Duration.ofSeconds(20).toNanos();
-      while (System.nanoTime() < deadline && captured.size() < 2) TimeUnit.MILLISECONDS.sleep(100);
+      while (System.nanoTime() < deadline && capturingSink.count() < 2) TimeUnit.MILLISECONDS.sleep(100);
 
+      final var captured = capturingSink.captured();
       assertEquals(2, captured.size(), "consumer should have received both Avro records");
       assertEquals(1L, captured.get(0).get("id"));
       assertEquals("alice", captured.get(0).get("name").toString());

--- a/examples/tracing/build.gradle.kts
+++ b/examples/tracing/build.gradle.kts
@@ -19,4 +19,5 @@ dependencies {
   implementation(rootProject.libs.opentelemetryAutoconfigure)
 
   testImplementation(rootProject.libs.opentelemetrySdkTesting)
+  testImplementation(project(":lib:kpipe-test"))
 }

--- a/examples/tracing/src/test/java/io/github/eschizoid/kpipe/AppIntegrationTest.java
+++ b/examples/tracing/src/test/java/io/github/eschizoid/kpipe/AppIntegrationTest.java
@@ -3,7 +3,7 @@ package io.github.eschizoid.kpipe;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import io.github.eschizoid.kpipe.sink.MessageSink;
+import io.github.eschizoid.kpipe.test.CapturingSink;
 import io.github.eschizoid.kpipe.tracing.otel.OtelTracer;
 import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.api.trace.propagation.W3CTraceContextPropagator;
@@ -18,7 +18,6 @@ import java.util.Collections;
 import java.util.Map;
 import java.util.Properties;
 import java.util.UUID;
-import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.TimeUnit;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.producer.KafkaProducer;
@@ -51,7 +50,7 @@ class AppIntegrationTest {
   @Test
   void consumerSpanChainsOffInboundTraceparent() throws Exception {
     final var topic = "trace-ex-" + UUID.randomUUID().toString().substring(0, 8);
-    final var captured = new CopyOnWriteArrayList<Map<String, Object>>();
+    final var capturingSink = new CapturingSink<Map<String, Object>>();
 
     // Wire an OTel SDK with W3C propagator + an InMemorySpanExporter we can assert against.
     final var spanExporter = InMemorySpanExporter.create();
@@ -61,7 +60,6 @@ class AppIntegrationTest {
       .build();
 
     final var tracer = new OtelTracer(sdk, "tracing-example-test");
-    final MessageSink<Map<String, Object>> capturingSink = captured::add;
 
     try (final var handle = KPipe.json(topic, consumerProps()).withTracer(tracer).toCustom(capturingSink).start()) {
       // Produce a record carrying a known traceparent.
@@ -85,11 +83,13 @@ class AppIntegrationTest {
 
       // Wait for the record to be processed and the span exported.
       final var deadline = System.nanoTime() + Duration.ofSeconds(15).toNanos();
-      while (System.nanoTime() < deadline && (captured.isEmpty() || spanExporter.getFinishedSpanItems().isEmpty())) {
+      while (
+        System.nanoTime() < deadline && (capturingSink.count() == 0 || spanExporter.getFinishedSpanItems().isEmpty())
+      ) {
         TimeUnit.MILLISECONDS.sleep(100);
       }
 
-      assertEquals(1, captured.size(), "consumer should have received the produced record");
+      assertEquals(1, capturingSink.count(), "consumer should have received the produced record");
       final var spans = spanExporter.getFinishedSpanItems();
       assertEquals(1, spans.size(), "exactly one consumer span should have been exported");
 


### PR DESCRIPTION
Three example-module polish items.

1. **Dogfood `CapturingSink`** — 6 example `AppIntegrationTest`s (json, avro, protobuf, schema-registry, tracing, protobuf-schema-registry) now use the shipped `io.github.eschizoid.kpipe.test.CapturingSink<T>` instead of hand-rolled `CopyOnWriteArrayList`. `testImplementation(project(":lib:kpipe-test"))` added to each. All assertions preserved.
2. **`DemoConfig` dead fields** — deleted the 3 genuinely-unused fields (`pollTimeout`/`shutdownTimeout`/`metricsInterval` — populated in `fromEnv()`, never read; the agent correctly found these are the dead ones, NOT the topic fields which `DemoApp` does read).
3. **avro static-fetch footgun note** — `///` note on `examples/avro` App explaining the §19 static-schema-corruption risk and pointing to registry mode. Behavior unchanged.

compileJava/compileTestJava green for all touched modules; the Docker-free protobuf-SR test passes with the CapturingSink swap (others are Testcontainers, verified at compile bar; CI runs them).