### PR TITLE
fix(api): wire result observers into the batch pipeline — toBatch() silently dropped them

### DIFF
--- a/lib/kpipe-api/src/main/java/io/github/eschizoid/kpipe/DefaultBatchSink.java
+++ b/lib/kpipe-api/src/main/java/io/github/eschizoid/kpipe/DefaultBatchSink.java
@@ -64,12 +64,17 @@ final class DefaultBatchSink<T> implements Sink<T> {
   }
 
   /// Builds the typed pipeline (deserialize → operators → return value) used by the consumer to
-  /// turn each `byte[]` into a `T` before enqueueing into the batch buffer.
+  /// turn each `byte[]` into a `T` before enqueueing into the batch buffer. Observer dispatch
+  /// (`onFiltered` / `onFailed` / `peekResult`) is wired by [DefaultStream#wrapWithObservers] —
+  /// the same site [DefaultSink] uses, so the two sink types can't drift on it (the batch path
+  /// previously had no observer dispatch, silently dropping observers set on a `toBatch(...)`
+  /// stream). Observers fire on the per-record pipeline outcome, before buffering; batch-sink
+  /// failures are routed through the batch DLQ machinery, not `onFailed`.
   MessagePipeline<T> buildPipeline() {
     final var registry = new MessageProcessorRegistry();
     final var pipelineBuilder = registry.pipeline(stream.format()).skipBytes(stream.skipBytes());
     for (final var op : stream.operators()) pipelineBuilder.add(op);
-    return pipelineBuilder.build();
+    return stream.wrapWithObservers(pipelineBuilder.build());
   }
 
   @Override

--- a/lib/kpipe-api/src/main/java/io/github/eschizoid/kpipe/DefaultSink.java
+++ b/lib/kpipe-api/src/main/java/io/github/eschizoid/kpipe/DefaultSink.java
@@ -3,13 +3,9 @@ package io.github.eschizoid.kpipe;
 import io.github.eschizoid.kpipe.consumer.KPipeConsumer;
 import io.github.eschizoid.kpipe.registry.MessagePipeline;
 import io.github.eschizoid.kpipe.registry.MessageProcessorRegistry;
-import io.github.eschizoid.kpipe.registry.Result;
 import io.github.eschizoid.kpipe.sink.MessageSink;
-import java.lang.System.Logger;
-import java.lang.System.Logger.Level;
 import java.util.Objects;
 import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.function.Consumer;
 
 /// Package-private [Sink] impl. Holds the configured [DefaultStream] plus the chosen terminal
 /// [MessageSink] and constructs a fully-wired [KPipeConsumer] on `start()`. The consumer hosts
@@ -22,7 +18,6 @@ import java.util.function.Consumer;
 ///
 /// @param <T> the deserialized message type
 final class DefaultSink<T> implements Sink<T> {
-  private static final Logger LOGGER = System.getLogger(DefaultSink.class.getName());
 
   private final DefaultStream<T> stream;
   private final MessageSink<T> terminalSink;
@@ -51,70 +46,15 @@ final class DefaultSink<T> implements Sink<T> {
   }
 
   /// Builds the [MessagePipeline] for this sink's stream + terminal sink. Reused by
-  /// [MultiBuilder] when assembling a per-topic pipeline map. Wraps the built pipeline with
-  /// observer dispatch when any of `onFiltered` / `onFailed` / `peekResult` is configured.
+  /// [MultiBuilder] when assembling a per-topic pipeline map. Observer dispatch (`onFiltered` /
+  /// `onFailed` / `peekResult`) is wired by [DefaultStream#wrapWithObservers] — shared with
+  /// [DefaultBatchSink] so the two sink types can't drift on it.
   MessagePipeline<?> buildPipeline() {
     final var registry = new MessageProcessorRegistry();
     final var pipelineBuilder = registry.pipeline(stream.format()).skipBytes(stream.skipBytes());
     for (final var op : stream.operators()) pipelineBuilder.add(op);
     final var base = pipelineBuilder.toSink(terminalSink).build();
-    return wrapWithObservers(base);
-  }
-
-  private MessagePipeline<T> wrapWithObservers(final MessagePipeline<T> base) {
-    final var onFiltered = stream.onFilteredObserver();
-    final var onFailed = stream.onFailedObserver();
-    final var peek = stream.peekResultObserver();
-    if (onFiltered == null && onFailed == null && peek == null) return base;
-    return new MessagePipeline<>() {
-      @Override
-      public T deserialize(final byte[] data) {
-        return base.deserialize(data);
-      }
-
-      @Override
-      public byte[] serialize(final T data) {
-        return base.serialize(data);
-      }
-
-      @Override
-      public Result<T> process(final T data) {
-        final var result = base.process(data);
-        if (peek != null) safeAccept(peek, result, "peekResult");
-        switch (result) {
-          case Result.Passed<T> _ -> {
-          }
-          case Result.Filtered<T> _ -> {
-            if (onFiltered != null) safeRun(onFiltered);
-          }
-          case Result.Failed<T> failed -> {
-            if (onFailed != null) safeAccept(onFailed, failed.cause(), "onFailed");
-          }
-        }
-        return result;
-      }
-
-      @Override
-      public MessageSink<T> getSink() {
-        return base.getSink();
-      }
-    };
-  }
-
-  private static void safeRun(final Runnable observer) {
-    try {
-      observer.run();
-    } catch (final RuntimeException e) {
-      LOGGER.log(Level.WARNING, "onFiltered observer threw; swallowing to keep the pipeline running", e);
-    }
-  }
-
-  private static <A> void safeAccept(final Consumer<A> observer, final A arg, final String name) {
-    try {
-      observer.accept(arg);
-    } catch (final RuntimeException e) {
-      LOGGER.log(Level.WARNING, () -> name + " observer threw; swallowing to keep the pipeline running", e);
-    }
+    return stream.wrapWithObservers(base);
   }
 
   /// Exposes the configured stream for test inspection of composition.

--- a/lib/kpipe-api/src/main/java/io/github/eschizoid/kpipe/DefaultStream.java
+++ b/lib/kpipe-api/src/main/java/io/github/eschizoid/kpipe/DefaultStream.java
@@ -10,6 +10,7 @@ import io.github.eschizoid.kpipe.format.protobuf.ProtobufFormat;
 import io.github.eschizoid.kpipe.metrics.ConsumerMetrics;
 import io.github.eschizoid.kpipe.producer.tracing.Tracer;
 import io.github.eschizoid.kpipe.registry.MessageFormat;
+import io.github.eschizoid.kpipe.registry.MessagePipeline;
 import io.github.eschizoid.kpipe.registry.Operators;
 import io.github.eschizoid.kpipe.registry.Result;
 import io.github.eschizoid.kpipe.registry.SchemaResolver;
@@ -17,6 +18,8 @@ import io.github.eschizoid.kpipe.sink.BatchPolicy;
 import io.github.eschizoid.kpipe.sink.BatchSink;
 import io.github.eschizoid.kpipe.sink.CompositeMessageSink;
 import io.github.eschizoid.kpipe.sink.MessageSink;
+import java.lang.System.Logger;
+import java.lang.System.Logger.Level;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -63,6 +66,8 @@ record DefaultStream<T>(
   Consumer<Throwable> onFailedObserver,
   Consumer<Result<T>> peekResultObserver
 ) implements Stream<T> {
+  private static final Logger LOGGER = System.getLogger(DefaultStream.class.getName());
+
   /// Public constructor used by [KPipe] factories — single topic, empty pipeline, default
   /// retry / backpressure settings.
   DefaultStream(
@@ -321,6 +326,71 @@ record DefaultStream<T>(
     if (pollTimeout != null) builder.withPollTimeout(pollTimeout);
     if (tracer != null) builder.withTracer(tracer);
     if (circuitBreaker != null) builder.withCircuitBreaker(circuitBreaker);
+  }
+
+  /// Wraps `base` with dispatch to the configured result observers (`onFiltered` / `onFailed` /
+  /// `peekResult`), or returns `base` unchanged when none is set. Lives here — next to
+  /// [#applyCommonConsumerConfig], and for the same reason — so both [DefaultSink] and
+  /// [DefaultBatchSink] share one wiring site: the batch path previously had no observer dispatch
+  /// at all, silently dropping observers set on a `toBatch(...)` stream.
+  ///
+  /// Observers fire on the PIPELINE outcome at `process()` time — for the batch path that is
+  /// before the record is buffered; batch-sink failures are a separate concern routed through the
+  /// batch DLQ machinery, not `onFailed`.
+  MessagePipeline<T> wrapWithObservers(final MessagePipeline<T> base) {
+    final var onFiltered = onFilteredObserver;
+    final var onFailed = onFailedObserver;
+    final var peek = peekResultObserver;
+    if (onFiltered == null && onFailed == null && peek == null) return base;
+    return new MessagePipeline<>() {
+      @Override
+      public T deserialize(final byte[] data) {
+        return base.deserialize(data);
+      }
+
+      @Override
+      public byte[] serialize(final T data) {
+        return base.serialize(data);
+      }
+
+      @Override
+      public Result<T> process(final T data) {
+        final var result = base.process(data);
+        if (peek != null) safeAccept(peek, result, "peekResult");
+        switch (result) {
+          case Result.Passed<T> _ -> {
+          }
+          case Result.Filtered<T> _ -> {
+            if (onFiltered != null) safeRun(onFiltered);
+          }
+          case Result.Failed<T> failed -> {
+            if (onFailed != null) safeAccept(onFailed, failed.cause(), "onFailed");
+          }
+        }
+        return result;
+      }
+
+      @Override
+      public MessageSink<T> getSink() {
+        return base.getSink();
+      }
+    };
+  }
+
+  private static void safeRun(final Runnable observer) {
+    try {
+      observer.run();
+    } catch (final RuntimeException e) {
+      LOGGER.log(Level.WARNING, "onFiltered observer threw; swallowing to keep the pipeline running", e);
+    }
+  }
+
+  private static <A> void safeAccept(final Consumer<A> observer, final A arg, final String name) {
+    try {
+      observer.accept(arg);
+    } catch (final RuntimeException e) {
+      LOGGER.log(Level.WARNING, () -> name + " observer threw; swallowing to keep the pipeline running", e);
+    }
   }
 
   /// Single funnel for every wither: snapshot this record into a [Mut], let the caller change

--- a/lib/kpipe-api/src/test/java/io/github/eschizoid/kpipe/StreamResultObserversTest.java
+++ b/lib/kpipe-api/src/test/java/io/github/eschizoid/kpipe/StreamResultObserversTest.java
@@ -8,6 +8,9 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import io.github.eschizoid.kpipe.registry.MessagePipeline;
 import io.github.eschizoid.kpipe.registry.Result;
+import io.github.eschizoid.kpipe.sink.BatchPolicy;
+import io.github.eschizoid.kpipe.sink.BatchSink;
+import java.time.Duration;
 import java.util.Map;
 import java.util.Properties;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -212,5 +215,66 @@ class StreamResultObserversTest {
     drive(pipeline, "{\"drop\":\"me\"}".getBytes());
 
     assertEquals(0, failedFired.get());
+  }
+
+  // ── Batch path — observers must fire through toBatch(...) too ─────────────
+  // Regression guard: DefaultBatchSink previously built its pipeline WITHOUT observer dispatch,
+  // silently dropping onFiltered/onFailed/peekResult set on a toBatch(...) stream (the same
+  // silent-drop class as the tracer/circuit-breaker drop fixed on this path earlier).
+
+  @Test
+  void batchPipelineFiresPeekResultOnEveryOutcome() {
+    final var passed = new AtomicInteger();
+    final var filtered = new AtomicInteger();
+    final var failed = new AtomicInteger();
+    final var sink = (DefaultBatchSink<Map<String, Object>>) KPipe.json("topic", props())
+      .filter(m -> m.containsKey("keep"))
+      .pipe(m -> {
+        if (m.containsKey("explode")) throw new RuntimeException("nope");
+        return m;
+      })
+      .peekResult(result -> {
+        switch (result) {
+          case Result.Passed<Map<String, Object>> _ -> passed.incrementAndGet();
+          case Result.Filtered<Map<String, Object>> _ -> filtered.incrementAndGet();
+          case Result.Failed<Map<String, Object>> _ -> failed.incrementAndGet();
+        }
+      })
+      .toBatch(BatchSink.ofVoid(_ -> {}), new BatchPolicy(10, Duration.ofDays(1)));
+
+    final var pipeline = sink.buildPipeline();
+    final var keep = pipeline.deserializeOrFail("{\"keep\":\"yes\"}".getBytes());
+    pipeline.process(keep);
+    final var drop = pipeline.deserializeOrFail("{\"drop\":\"me\"}".getBytes());
+    pipeline.process(drop);
+    final var explode = pipeline.deserializeOrFail("{\"keep\":\"yes\",\"explode\":1}".getBytes());
+    pipeline.process(explode);
+
+    assertEquals(1, passed.get(), "batch pipeline must dispatch peekResult for Passed");
+    assertEquals(1, filtered.get(), "batch pipeline must dispatch peekResult for Filtered");
+    assertEquals(1, failed.get(), "batch pipeline must dispatch peekResult for Failed");
+  }
+
+  @Test
+  void batchPipelineFiresOnFilteredAndOnFailed() {
+    final var filteredFired = new AtomicInteger();
+    final var capturedCause = new AtomicReference<Throwable>();
+    final var boom = new RuntimeException("boom");
+    final var sink = (DefaultBatchSink<Map<String, Object>>) KPipe.json("topic", props())
+      .filter(m -> !m.containsKey("drop"))
+      .pipe(m -> {
+        if (m.containsKey("explode")) throw boom;
+        return m;
+      })
+      .onFiltered(filteredFired::incrementAndGet)
+      .onFailed(capturedCause::set)
+      .toBatch(BatchSink.ofVoid(_ -> {}), new BatchPolicy(10, Duration.ofDays(1)));
+
+    final var pipeline = sink.buildPipeline();
+    pipeline.process(pipeline.deserializeOrFail("{\"drop\":\"me\"}".getBytes()));
+    pipeline.process(pipeline.deserializeOrFail("{\"explode\":1}".getBytes()));
+
+    assertEquals(1, filteredFired.get(), "batch pipeline must dispatch onFiltered");
+    assertSame(boom, capturedCause.get(), "batch pipeline must dispatch onFailed with the cause");
   }
 }


### PR DESCRIPTION
## What

**Tier-1 defect from the 2nd whole-repo architecture pass (verified by hand):** `DefaultStream` carries `onFiltered`/`onFailed`/`peekResult` and `DefaultSink` dispatched them, but `DefaultBatchSink.buildPipeline()` had **zero observer wiring** — `.onFailed(x).toBatch(...)` silently dropped `x`. Same silent-drop class as the tracer/circuit-breaker drop fixed on this exact path earlier, same root cause: per-sink wiring instead of shared.

## Fix (mirrors the tracer/CB precedent)

Hoist the observer-wrapping onto `DefaultStream.wrapWithObservers` — right next to `applyCommonConsumerConfig`, which exists for the identical reason — and have **both** sinks call it. `DefaultSink`'s private copy (wrapper + `safeRun`/`safeAccept` + LOGGER) is deleted: one wiring site, the two sink types can't drift. `MultiBuilder`'s batch-route folding goes through the same `buildPipeline()`, so multi-topic batch routes get observers too.

**Semantics:** observers fire on the per-record **pipeline** outcome at `process()` time — for batch that's before buffering. Batch-sink failures stay routed through the batch DLQ machinery, not `onFailed` (documented on `buildPipeline`).

## Tests

`StreamResultObserversTest` gains a batch section: `peekResult` fires for all three outcomes, and `onFiltered`/`onFailed` dispatch through the `toBatch()` pipeline — the regression guard for the silent drop. Existing non-batch observer tests (10) pin that the hoist changed nothing.