### PR TITLE
refactor(metrics,consumer): shared ConsumerMetricKeys + builder fail-fast validations

### DIFF
--- a/lib/kpipe-consumer/src/main/java/io/github/eschizoid/kpipe/consumer/ConsumerDefaults.java
+++ b/lib/kpipe-consumer/src/main/java/io/github/eschizoid/kpipe/consumer/ConsumerDefaults.java
@@ -10,6 +10,10 @@ import java.time.Duration;
 /// scaffolding meant a change to that demo config could ripple into the consumer's shutdown timing.
 final class ConsumerDefaults {
 
+  /// Default `Consumer.poll` timeout — bounds each consumer-loop iteration (and therefore the
+  /// paused-loop backpressure re-check cadence).
+  static final Duration POLL_TIMEOUT = Duration.ofMillis(100);
+
   /// Max time `waitForInFlightDrain` / graceful shutdown waits for in-flight records to finish.
   static final Duration WAIT_FOR_MESSAGES = Duration.ofMillis(5000);
 

--- a/lib/kpipe-consumer/src/main/java/io/github/eschizoid/kpipe/consumer/KPipeConsumer.java
+++ b/lib/kpipe-consumer/src/main/java/io/github/eschizoid/kpipe/consumer/KPipeConsumer.java
@@ -1,6 +1,7 @@
 package io.github.eschizoid.kpipe.consumer;
 
 import io.github.eschizoid.kpipe.consumer.config.AppConfig;
+import io.github.eschizoid.kpipe.metrics.ConsumerMetricKeys;
 import io.github.eschizoid.kpipe.metrics.ConsumerMetrics;
 import io.github.eschizoid.kpipe.metrics.KPipeMetricsReporter;
 import io.github.eschizoid.kpipe.producer.KPipeProducer;
@@ -79,17 +80,20 @@ public class KPipeConsumer implements AutoCloseable {
 
   private static final Logger LOGGER = System.getLogger(KPipeConsumer.class.getName());
 
-  private static final String METRIC_MESSAGES_RECEIVED = "messagesReceived";
-  private static final String METRIC_MESSAGES_PROCESSED = "messagesProcessed";
-  private static final String METRIC_PROCESSING_ERRORS = "processingErrors";
-  private static final String METRIC_PROCESSING_DURATION_TOTAL_MS = "processingDurationTotalMs";
-  private static final String METRIC_RETRIES = "retries";
-  static final String METRIC_BACKPRESSURE_PAUSE_COUNT = "backpressurePauseCount";
-  static final String METRIC_BACKPRESSURE_TIME_MS = "backpressureTimeMs";
-  static final String METRIC_CIRCUIT_BREAKER_TRIPS = "circuitBreakerTrips";
-  static final String METRIC_CIRCUIT_BREAKER_TIME_OPEN_MS = "circuitBreakerTimeOpenMs";
-  private static final String METRIC_DLQ_SENT = "dlqSent";
-  private static final String METRIC_DLQ_FAILED = "dlqFailed";
+  // Aliases of the shared public key set (ConsumerMetricKeys) — the single source of truth also
+  // read by ConsumerMetricsReporter and the kpipe-test quiescence check. Never re-declare the
+  // literals here; aliasing keeps every call site short while making drift impossible.
+  private static final String METRIC_MESSAGES_RECEIVED = ConsumerMetricKeys.MESSAGES_RECEIVED;
+  private static final String METRIC_MESSAGES_PROCESSED = ConsumerMetricKeys.MESSAGES_PROCESSED;
+  private static final String METRIC_PROCESSING_ERRORS = ConsumerMetricKeys.PROCESSING_ERRORS;
+  private static final String METRIC_PROCESSING_DURATION_TOTAL_MS = ConsumerMetricKeys.PROCESSING_DURATION_TOTAL_MS;
+  private static final String METRIC_RETRIES = ConsumerMetricKeys.RETRIES;
+  static final String METRIC_BACKPRESSURE_PAUSE_COUNT = ConsumerMetricKeys.BACKPRESSURE_PAUSE_COUNT;
+  static final String METRIC_BACKPRESSURE_TIME_MS = ConsumerMetricKeys.BACKPRESSURE_TIME_MS;
+  static final String METRIC_CIRCUIT_BREAKER_TRIPS = ConsumerMetricKeys.CIRCUIT_BREAKER_TRIPS;
+  static final String METRIC_CIRCUIT_BREAKER_TIME_OPEN_MS = ConsumerMetricKeys.CIRCUIT_BREAKER_TIME_OPEN_MS;
+  private static final String METRIC_DLQ_SENT = ConsumerMetricKeys.DLQ_SENT;
+  private static final String METRIC_DLQ_FAILED = ConsumerMetricKeys.DLQ_FAILED;
 
   private final Queue<ConsumerCommand> commandQueue;
   private final Consumer<byte[], byte[]> kafkaConsumer;
@@ -838,7 +842,7 @@ public class KPipeConsumer implements AutoCloseable {
       .entrySet()
       .stream()
       .collect(Collectors.toMap(Map.Entry::getKey, e -> e.getValue().get(), (a, _) -> a, HashMap::new));
-    snapshot.put("inFlight", totalInFlight());
+    snapshot.put(ConsumerMetricKeys.IN_FLIGHT, totalInFlight());
     return Collections.unmodifiableMap(snapshot);
   }
 

--- a/lib/kpipe-consumer/src/main/java/io/github/eschizoid/kpipe/consumer/KPipeConsumerBuilder.java
+++ b/lib/kpipe-consumer/src/main/java/io/github/eschizoid/kpipe/consumer/KPipeConsumerBuilder.java
@@ -39,7 +39,7 @@ public final class KPipeConsumerBuilder {
   MessagePipeline<?> pipeline;
   Map<String, MessagePipeline<?>> pipelinesPerTopic;
   final Map<String, BatchSpec<?>> batchSpecs = new LinkedHashMap<>();
-  Duration pollTimeout = Duration.ofMillis(100);
+  Duration pollTimeout = ConsumerDefaults.POLL_TIMEOUT;
   KPipeConsumer.ErrorHandler errorHandler = e ->
     LOGGER.log(
       Level.WARNING,
@@ -204,8 +204,12 @@ public final class KPipeConsumerBuilder {
   /// @param backoff Duration to wait between retry attempts
   /// @return This builder instance for method chaining
   public KPipeConsumerBuilder withRetry(final int maxRetries, final Duration backoff) {
+    if (maxRetries < 0) throw new IllegalArgumentException("maxRetries cannot be negative, got " + maxRetries);
+    Objects.requireNonNull(backoff, "backoff cannot be null");
+    // Zero is legitimate (retry immediately, bounded by maxRetries); only negative is a misconfig.
+    if (backoff.isNegative()) throw new IllegalArgumentException("backoff cannot be negative, got " + backoff);
     this.maxRetries = maxRetries;
-    this.retryBackoff = Objects.requireNonNull(backoff, "backoff cannot be null");
+    this.retryBackoff = backoff;
     return this;
   }
 
@@ -246,7 +250,10 @@ public final class KPipeConsumerBuilder {
   /// @param timeout Maximum time to wait for in-flight messages to complete
   /// @return This builder instance for method chaining
   public KPipeConsumerBuilder withWaitForMessagesTimeout(final Duration timeout) {
-    this.waitForMessagesTimeout = Objects.requireNonNull(timeout);
+    Objects.requireNonNull(timeout, "timeout cannot be null");
+    // Zero is legitimate ("don't wait" on shutdown); only negative is a misconfig.
+    if (timeout.isNegative()) throw new IllegalArgumentException("timeout cannot be negative, got " + timeout);
+    this.waitForMessagesTimeout = timeout;
     return this;
   }
 
@@ -255,7 +262,10 @@ public final class KPipeConsumerBuilder {
   /// @param timeout Maximum time to wait for the consumer thread to finish
   /// @return This builder instance for method chaining
   public KPipeConsumerBuilder withThreadTerminationTimeout(final Duration timeout) {
-    this.threadTerminationTimeout = Objects.requireNonNull(timeout);
+    Objects.requireNonNull(timeout, "timeout cannot be null");
+    // Zero is legitimate ("don't wait" on shutdown); only negative is a misconfig.
+    if (timeout.isNegative()) throw new IllegalArgumentException("timeout cannot be negative, got " + timeout);
+    this.threadTerminationTimeout = timeout;
     return this;
   }
 

--- a/lib/kpipe-metrics/src/main/java/io/github/eschizoid/kpipe/metrics/ConsumerMetricKeys.java
+++ b/lib/kpipe-metrics/src/main/java/io/github/eschizoid/kpipe/metrics/ConsumerMetricKeys.java
@@ -1,0 +1,49 @@
+package io.github.eschizoid.kpipe.metrics;
+
+/// The map keys of the consumer's metrics snapshot (`KPipeConsumer.getMetrics()`), in one place.
+///
+/// These strings are a public contract: the consumer publishes them, `ConsumerMetricsReporter`
+/// formats them, and the kpipe-test kit's quiescence check reads them. Before this holder each of
+/// those sites carried its own private copies of the same literals — a rename in one place would
+/// silently desynchronize the others (the reporter would log zeros; the test kit would hang).
+/// Reference these constants instead of re-declaring the strings.
+public final class ConsumerMetricKeys {
+
+  /// Records polled from Kafka.
+  public static final String MESSAGES_RECEIVED = "messagesReceived";
+
+  /// Records successfully processed (includes intentional filters).
+  public static final String MESSAGES_PROCESSED = "messagesProcessed";
+
+  /// Records that failed processing.
+  public static final String PROCESSING_ERRORS = "processingErrors";
+
+  /// Total per-record processing time, milliseconds.
+  public static final String PROCESSING_DURATION_TOTAL_MS = "processingDurationTotalMs";
+
+  /// Retry attempts made.
+  public static final String RETRIES = "retries";
+
+  /// Times backpressure paused the consumer.
+  public static final String BACKPRESSURE_PAUSE_COUNT = "backpressurePauseCount";
+
+  /// Total time paused under backpressure, milliseconds.
+  public static final String BACKPRESSURE_TIME_MS = "backpressureTimeMs";
+
+  /// Circuit-breaker CLOSED→OPEN (and HALF_OPEN→OPEN) transitions.
+  public static final String CIRCUIT_BREAKER_TRIPS = "circuitBreakerTrips";
+
+  /// Total time the circuit breaker spent OPEN, milliseconds.
+  public static final String CIRCUIT_BREAKER_TIME_OPEN_MS = "circuitBreakerTimeOpenMs";
+
+  /// Records durably parked in the dead-letter topic.
+  public static final String DLQ_SENT = "dlqSent";
+
+  /// Failed dead-letter sends (offset held pending; record reprocessed on restart).
+  public static final String DLQ_FAILED = "dlqFailed";
+
+  /// Live count of records currently held by the consumer (dispatcher pending + batch-buffered).
+  public static final String IN_FLIGHT = "inFlight";
+
+  private ConsumerMetricKeys() {}
+}

--- a/lib/kpipe-metrics/src/main/java/io/github/eschizoid/kpipe/metrics/ConsumerMetricsReporter.java
+++ b/lib/kpipe-metrics/src/main/java/io/github/eschizoid/kpipe/metrics/ConsumerMetricsReporter.java
@@ -36,12 +36,13 @@ public record ConsumerMetricsReporter(
 ) implements KPipeMetricsReporter {
   private static final Logger LOGGER = System.getLogger(ConsumerMetricsReporter.class.getName());
   private static final long APP_START_TIME = System.currentTimeMillis();
-  private static final String METRIC_MESSAGES_RECEIVED = "messagesReceived";
-  private static final String METRIC_MESSAGES_PROCESSED = "messagesProcessed";
-  private static final String METRIC_PROCESSING_ERRORS = "processingErrors";
-  private static final String METRIC_PROCESSING_DURATION_TOTAL_MS = "processingDurationTotalMs";
-  private static final String METRIC_BACKPRESSURE_PAUSE_COUNT = "backpressurePauseCount";
-  private static final String METRIC_BACKPRESSURE_TIME_MS = "backpressureTimeMs";
+  // Aliases of the shared key set (ConsumerMetricKeys) — never re-declare the literals here.
+  private static final String METRIC_MESSAGES_RECEIVED = ConsumerMetricKeys.MESSAGES_RECEIVED;
+  private static final String METRIC_MESSAGES_PROCESSED = ConsumerMetricKeys.MESSAGES_PROCESSED;
+  private static final String METRIC_PROCESSING_ERRORS = ConsumerMetricKeys.PROCESSING_ERRORS;
+  private static final String METRIC_PROCESSING_DURATION_TOTAL_MS = ConsumerMetricKeys.PROCESSING_DURATION_TOTAL_MS;
+  private static final String METRIC_BACKPRESSURE_PAUSE_COUNT = ConsumerMetricKeys.BACKPRESSURE_PAUSE_COUNT;
+  private static final String METRIC_BACKPRESSURE_TIME_MS = ConsumerMetricKeys.BACKPRESSURE_TIME_MS;
 
   /// Creates a new ConsumerMetricsReporter, defaulting to log-based reporting when reporter is
   /// null.

--- a/lib/kpipe-test/src/main/java/io/github/eschizoid/kpipe/test/TestKitMetrics.java
+++ b/lib/kpipe-test/src/main/java/io/github/eschizoid/kpipe/test/TestKitMetrics.java
@@ -1,6 +1,7 @@
 package io.github.eschizoid.kpipe.test;
 
 import io.github.eschizoid.kpipe.consumer.KPipeConsumer;
+import io.github.eschizoid.kpipe.metrics.ConsumerMetricKeys;
 import java.time.Duration;
 import java.util.Map;
 
@@ -13,10 +14,11 @@ import java.util.Map;
 /// identical constants + `accountedFor` + `quiescent`.
 final class TestKitMetrics {
 
-  private static final String METRIC_RECEIVED = "messagesReceived";
-  private static final String METRIC_PROCESSED = "messagesProcessed";
-  private static final String METRIC_ERRORS = "processingErrors";
-  private static final String METRIC_IN_FLIGHT = "inFlight";
+  // Aliases of the shared key set (ConsumerMetricKeys) — never re-declare the literals here.
+  private static final String METRIC_RECEIVED = ConsumerMetricKeys.MESSAGES_RECEIVED;
+  private static final String METRIC_PROCESSED = ConsumerMetricKeys.MESSAGES_PROCESSED;
+  private static final String METRIC_ERRORS = ConsumerMetricKeys.PROCESSING_ERRORS;
+  private static final String METRIC_IN_FLIGHT = ConsumerMetricKeys.IN_FLIGHT;
 
   private TestKitMetrics() {}
 


### PR DESCRIPTION
Pass-3 sweep (dirt/asymmetry), hand-verified findings.

## 1. `ConsumerMetricKeys` — kill the 3-way metric-key duplication
The consumer's metric-map keys were declared **three times**: KPipeConsumer (11 constants + `"inFlight"` as a bare literal at the `getMetrics` call site), `ConsumerMetricsReporter` (6), `TestKitMetrics` (4). A rename in one place silently desynchronizes the others — the reporter logs zeros, the test-kit quiescence check hangs. New public 12-key holder in kpipe-metrics; all three sites alias it (zero call-site churn; drift now impossible).

## 2. Builder fail-fast
- `withRetry`: negative `maxRetries` now rejected at the setter (was build()-time only); negative `backoff` rejected. **Zero backoff stays legal** — retry-immediately is a valid bounded config, and an existing DLQ test uses it deliberately (the first cut rejected zero and that test failed — relaxed with reasoning in comments).
- `withWaitForMessagesTimeout` / `withThreadTerminationTimeout`: negative rejected; **zero stays legal** ("don't wait" on shutdown).

## 3. `ConsumerDefaults.POLL_TIMEOUT`
The builder hardcoded `ofMillis(100)`. The sweep suggested referencing `AppConfig.DEFAULT_POLL_TIMEOUT` — **rejected**: that re-couples the builder to demo scaffolding (deliberately severed in #252). Added the default to `ConsumerDefaults` (next to its 3 siblings) instead.

## Verification
kpipe-metrics + kpipe-consumer + kpipe-test suites green (full re-run).