### PR TITLE
refactor: surface polish — config constants + fail-fast, MultiBuilder messages, varint extraction

### DIFF
--- a/lib/kpipe-api/src/main/java/io/github/eschizoid/kpipe/MultiBuilder.java
+++ b/lib/kpipe-api/src/main/java/io/github/eschizoid/kpipe/MultiBuilder.java
@@ -133,7 +133,7 @@ public final class MultiBuilder {
   /// @param backoff delay between attempts (must be non-null)
   /// @return this builder
   public MultiBuilder withRetry(final int maxRetries, final Duration backoff) {
-    if (maxRetries < 0) throw new IllegalArgumentException("maxRetries cannot be negative");
+    if (maxRetries < 0) throw new IllegalArgumentException("maxRetries cannot be negative, got " + maxRetries);
     this.maxRetries = maxRetries;
     this.retryBackoff = Objects.requireNonNull(backoff, "backoff cannot be null");
     return this;
@@ -183,7 +183,9 @@ public final class MultiBuilder {
   /// @param dlqTopic the dead-letter topic (must be non-null and non-blank)
   /// @return this builder
   public MultiBuilder withDeadLetterTopic(final String dlqTopic) {
-    if (dlqTopic == null || dlqTopic.isBlank()) throw new IllegalArgumentException("dlqTopic cannot be null or blank");
+    if (dlqTopic == null || dlqTopic.isBlank()) throw new IllegalArgumentException(
+      "dlqTopic cannot be null or blank, got '" + dlqTopic + "'"
+    );
     this.deadLetterTopic = dlqTopic;
     return this;
   }

--- a/lib/kpipe-consumer/src/main/java/io/github/eschizoid/kpipe/consumer/config/KafkaConsumerConfig.java
+++ b/lib/kpipe-consumer/src/main/java/io/github/eschizoid/kpipe/consumer/config/KafkaConsumerConfig.java
@@ -2,6 +2,7 @@ package io.github.eschizoid.kpipe.consumer.config;
 
 import java.util.Properties;
 import java.util.function.UnaryOperator;
+import org.apache.kafka.common.serialization.ByteArrayDeserializer;
 
 /// A utility class for creating and customizing Kafka consumer configuration properties.
 ///
@@ -41,6 +42,14 @@ import java.util.function.UnaryOperator;
 /// ```
 public final class KafkaConsumerConfig {
 
+  // The Kafka property keys this class writes, named once. The deserializer default is derived
+  // from the class itself (refactor-safe, compile-checked) rather than a hand-typed FQCN string.
+  private static final String BOOTSTRAP_SERVERS = "bootstrap.servers";
+  private static final String GROUP_ID = "group.id";
+  private static final String KEY_DESERIALIZER = "key.deserializer";
+  private static final String VALUE_DESERIALIZER = "value.deserializer";
+  private static final String ENABLE_AUTO_COMMIT = "enable.auto.commit";
+
   private KafkaConsumerConfig() {}
 
   /// Creates configuration properties for a Kafka consumer with customization.
@@ -76,12 +85,14 @@ public final class KafkaConsumerConfig {
     final String groupId,
     final UnaryOperator<Properties> customizer
   ) {
+    requireNonBlank(bootstrapServers, "bootstrapServers");
+    requireNonBlank(groupId, "groupId");
     final var props = new Properties();
-    props.put("bootstrap.servers", bootstrapServers);
-    props.put("group.id", groupId);
-    props.put("key.deserializer", "org.apache.kafka.common.serialization.ByteArrayDeserializer");
-    props.put("value.deserializer", "org.apache.kafka.common.serialization.ByteArrayDeserializer");
-    props.put("enable.auto.commit", "true");
+    props.put(BOOTSTRAP_SERVERS, bootstrapServers);
+    props.put(GROUP_ID, groupId);
+    props.put(KEY_DESERIALIZER, ByteArrayDeserializer.class.getName());
+    props.put(VALUE_DESERIALIZER, ByteArrayDeserializer.class.getName());
+    props.put(ENABLE_AUTO_COMMIT, "true");
 
     return customizer != null ? customizer.apply(props) : props;
   }
@@ -127,8 +138,8 @@ public final class KafkaConsumerConfig {
     return props -> {
       final var newProps = new Properties();
       newProps.putAll(props);
-      newProps.put("key.deserializer", keyDeserializer);
-      newProps.put("value.deserializer", valueDeserializer);
+      newProps.put(KEY_DESERIALIZER, keyDeserializer);
+      newProps.put(VALUE_DESERIALIZER, valueDeserializer);
       return newProps;
     };
   }
@@ -150,7 +161,7 @@ public final class KafkaConsumerConfig {
     return props -> {
       final var newProps = new Properties();
       newProps.putAll(props);
-      newProps.put("enable.auto.commit", "false");
+      newProps.put(ENABLE_AUTO_COMMIT, "false");
       return newProps;
     };
   }
@@ -213,6 +224,14 @@ public final class KafkaConsumerConfig {
   ///     .withAutoCommit(false)
   ///     .build();
   /// ```
+  /// Rejects null or blank required strings with the offending value in the message — a blank
+  /// bootstrap-servers or group id otherwise surfaces much later as a cryptic broker error.
+  private static void requireNonBlank(final String value, final String name) {
+    if (value == null || value.isBlank()) throw new IllegalArgumentException(
+      name + " cannot be null or blank, got '" + value + "'"
+    );
+  }
+
   public static class ConsumerConfigBuilder {
 
     private ConsumerConfigBuilder() {}
@@ -224,7 +243,8 @@ public final class KafkaConsumerConfig {
     /// @param bootstrapServers Comma-separated list of host:port pairs
     /// @return This builder for chaining
     public ConsumerConfigBuilder withBootstrapServers(final String bootstrapServers) {
-      props.put("bootstrap.servers", bootstrapServers);
+      requireNonBlank(bootstrapServers, "bootstrapServers");
+      props.put(BOOTSTRAP_SERVERS, bootstrapServers);
       return this;
     }
 
@@ -233,7 +253,8 @@ public final class KafkaConsumerConfig {
     /// @param groupId The consumer group ID
     /// @return This builder for chaining
     public ConsumerConfigBuilder withGroupId(final String groupId) {
-      props.put("group.id", groupId);
+      requireNonBlank(groupId, "groupId");
+      props.put(GROUP_ID, groupId);
       return this;
     }
 
@@ -241,8 +262,8 @@ public final class KafkaConsumerConfig {
     ///
     /// @return This builder for chaining
     public ConsumerConfigBuilder withByteArrayDeserializers() {
-      props.put("key.deserializer", "org.apache.kafka.common.serialization.ByteArrayDeserializer");
-      props.put("value.deserializer", "org.apache.kafka.common.serialization.ByteArrayDeserializer");
+      props.put(KEY_DESERIALIZER, ByteArrayDeserializer.class.getName());
+      props.put(VALUE_DESERIALIZER, ByteArrayDeserializer.class.getName());
       return this;
     }
 
@@ -251,7 +272,7 @@ public final class KafkaConsumerConfig {
     /// @param enable True to enable auto-commit, false to disable
     /// @return This builder for chaining
     public ConsumerConfigBuilder withAutoCommit(final boolean enable) {
-      props.put("enable.auto.commit", Boolean.toString(enable));
+      props.put(ENABLE_AUTO_COMMIT, Boolean.toString(enable));
       return this;
     }
 

--- a/lib/kpipe-format-protobuf/src/main/java/io/github/eschizoid/kpipe/format/protobuf/ProtobufFormat.java
+++ b/lib/kpipe-format-protobuf/src/main/java/io/github/eschizoid/kpipe/format/protobuf/ProtobufFormat.java
@@ -182,23 +182,7 @@ public final class ProtobufFormat implements MessageFormat<Message> {
     final int schemaId = ConfluentEnvelope.readSchemaId(data);
 
     final var cursor = new VarintCursor(data, ConfluentEnvelope.HEADER_LENGTH);
-    final var size = cursor.readZigZagVarint();
-    final int[] messageIndex;
-    if (size == 0) {
-      messageIndex = FIRST_MESSAGE_INDEX;
-    } else if (size < 0) {
-      throw new IllegalStateException("Negative message-index size " + size + " for schema id " + schemaId);
-    } else if (size > data.length - cursor.offset()) {
-      // Each index entry needs at least one byte, so a size larger than the bytes that remain is a
-      // corrupt envelope — reject before allocating (guards against a huge int[] from a bad
-      // varint).
-      throw new IllegalStateException(
-        "Message-index size " + size + " exceeds remaining envelope bytes for schema id " + schemaId
-      );
-    } else {
-      messageIndex = new int[size];
-      for (var i = 0; i < size; i++) messageIndex[i] = cursor.readZigZagVarint();
-    }
+    final var messageIndex = readMessageIndex(cursor, data, schemaId);
     final var payloadOffset = cursor.offset();
 
     final var messageDescriptor = resolvedDescriptors.computeIfAbsent(
@@ -221,6 +205,34 @@ public final class ProtobufFormat implements MessageFormat<Message> {
         e
       );
     }
+  }
+
+  /// Reads the Confluent message-index array at the cursor: a zig-zag varint `size` followed by
+  /// `size` zig-zag varint path elements, with the `size == 0` shorthand meaning the array `[0]`
+  /// (first top-level message — the common single-message case). Advances `cursor` past the array,
+  /// leaving it at the payload offset.
+  ///
+  /// @param cursor   positioned at the start of the message-index array; advanced past it
+  /// @param data     the full record bytes (for the remaining-length bound check)
+  /// @param schemaId the envelope's schema id, for diagnostics only
+  /// @return the message-index path
+  /// @throws IllegalStateException on a negative size or a size exceeding the remaining bytes
+  ///     (each index entry needs at least one byte, so a larger size is a corrupt envelope —
+  ///     rejected before allocating, guarding against a huge `int[]` from a bad varint)
+  private static int[] readMessageIndex(final VarintCursor cursor, final byte[] data, final int schemaId) {
+    final var size = cursor.readZigZagVarint();
+    if (size == 0) return FIRST_MESSAGE_INDEX;
+    if (size < 0) {
+      throw new IllegalStateException("Negative message-index size " + size + " for schema id " + schemaId);
+    }
+    if (size > data.length - cursor.offset()) {
+      throw new IllegalStateException(
+        "Message-index size " + size + " exceeds remaining envelope bytes for schema id " + schemaId
+      );
+    }
+    final var messageIndex = new int[size];
+    for (var i = 0; i < size; i++) messageIndex[i] = cursor.readZigZagVarint();
+    return messageIndex;
   }
 
   /// Reads Kafka-style zig-zag varints from a byte array — the encoding Confluent uses for the


### PR DESCRIPTION
Pass-3 sweep (dirt/asymmetry), hand-verified findings — the surface-half companion to #269.

## 1. KafkaConsumerConfig
- The 5 Kafka property keys were repeated literals across factory/transformers/builder → named once.
- Deserializer default was a hand-typed FQCN string → `ByteArrayDeserializer.class.getName()` (compile-checked; exact mirror of the #257 producer fix).
- `requireNonBlank` on `bootstrapServers`/`groupId` (factory + builder): blank previously surfaced later as a cryptic broker error; now fails at config time with the offending value in the message.

## 2. MultiBuilder message consistency
Validation messages now always include the passed value (`maxRetries`, `dlqTopic`) — previously only the backpressure check showed it.

## 3. ProtobufFormat readability
The 18-line message-index varint parse extracted from `deserializeFromEnvelope` into `readMessageIndex` — same guards, same messages, byte-for-byte semantics; the envelope method drops to ~35 lines. (The varint-overflow + truncation tests from #266 pin the behavior.)

## Verification
consumer + api + format-protobuf suites green. One `MultiBuilderBatchIntegrationTest` failure in the first full run was a Testcontainers topic-metadata timing flake — passes on `--rerun-tasks`, unrelated to the diff.