### PR TITLE
build: hoist duplicated java/toolchain/test/jacoco config into the lib subprojects block

### DIFF
--- a/lib/build.gradle.kts
+++ b/lib/build.gradle.kts
@@ -14,6 +14,56 @@ subprojects {
   group = rootProject.group
   version = rootProject.version
 
+  // Shared config for every java-library module. Reacting to the plugin id (rather than applying
+  // unconditionally) skips kpipe-bom, which applies `java-platform` and must not receive any
+  // java/toolchain/test configuration.
+  plugins.withId("java-library") {
+    extensions.configure<JavaPluginExtension> {
+      withSourcesJar()
+      withJavadocJar()
+      modularity.inferModulePath.set(true)
+      toolchain {
+        languageVersion = JavaLanguageVersion.of(25)
+      }
+    }
+
+    tasks.withType<Test>().configureEach {
+      useJUnitPlatform()
+
+      if (project.hasProperty("excludeTests")) {
+        val excludePattern = project.property("excludeTests").toString()
+        exclude("**/${excludePattern.replace(".", "/")}.class")
+      }
+    }
+
+    // Module-path wiring for real JPMS modules. kpipe-format-protobuf-confluent has no
+    // module-info.java (it compiles on the classpath because of the shaded Wire split-package),
+    // so the existence check skips it automatically.
+    if (file("src/main/java/module-info.java").exists()) {
+      tasks.named<JavaCompile>("compileJava") {
+        doFirst {
+          options.compilerArgs.addAll(listOf("--module-path", classpath.asPath))
+          classpath = files()
+        }
+      }
+
+      tasks.named<Javadoc>("javadoc") {
+        options.modulePath = classpath.toList()
+        classpath = files()
+      }
+    }
+  }
+
+  plugins.withId("jacoco") {
+    tasks.named<JacocoReport>("jacocoTestReport") {
+      reports {
+        csv.required.set(true)
+        xml.required.set(true)
+        html.required.set(true)
+      }
+    }
+  }
+
   afterEvaluate {
     extensions.configure<PublishingExtension> {
       publications {

--- a/lib/kpipe-api/build.gradle.kts
+++ b/lib/kpipe-api/build.gradle.kts
@@ -5,19 +5,6 @@ plugins {
 
 description = "KPipe API — fluent top-level KPipe entry point for the common consumer path"
 
-java {
-  withSourcesJar()
-  withJavadocJar()
-  modularity.inferModulePath.set(true)
-  toolchain {
-    languageVersion = JavaLanguageVersion.of(25)
-  }
-}
-
-repositories {
-  mavenCentral()
-}
-
 dependencies {
   api(project(":lib:kpipe-core"))
   api(project(":lib:kpipe-consumer"))
@@ -51,28 +38,4 @@ dependencies {
   testImplementation(libs.testcontainers)
   testImplementation(libs.testcontainersJunitJupiter)
   testImplementation(libs.testcontainersKafka)
-}
-
-tasks.test {
-  useJUnitPlatform()
-}
-
-tasks.jacocoTestReport {
-  reports {
-    csv.required.set(true)
-    xml.required.set(true)
-    html.required.set(true)
-  }
-}
-
-tasks.compileJava {
-  doFirst {
-    options.compilerArgs.addAll(listOf("--module-path", classpath.asPath))
-    classpath = files()
-  }
-}
-
-tasks.javadoc {
-  options.modulePath = classpath.toList()
-  classpath = files()
 }

--- a/lib/kpipe-consumer/build.gradle.kts
+++ b/lib/kpipe-consumer/build.gradle.kts
@@ -5,19 +5,6 @@ plugins {
 
 description = "KPipe Consumer - Functional Kafka consumer with virtual threads"
 
-java {
-  withSourcesJar()
-  withJavadocJar()
-  modularity.inferModulePath.set(true)
-  toolchain {
-    languageVersion = JavaLanguageVersion.of(25)
-  }
-}
-
-repositories {
-  mavenCentral()
-}
-
 dependencies {
   api(project(":lib:kpipe-core"))
   api(project(":lib:kpipe-producer"))
@@ -86,34 +73,7 @@ tasks.register<JavaExec>("jcstress") {
 }
 
 tasks.test {
-  useJUnitPlatform()
-
-  if (project.hasProperty("excludeTests")) {
-    val excludePattern = project.property("excludeTests").toString()
-    exclude("**/${excludePattern.replace(".", "/")}.class")
-  }
-
   minHeapSize = "1g"
   maxHeapSize = "4g"
   maxParallelForks = (Runtime.getRuntime().availableProcessors() / 2).coerceAtLeast(2)
-}
-
-tasks.jacocoTestReport {
-  reports {
-    csv.required.set(true)
-    xml.required.set(true)
-    html.required.set(true)
-  }
-}
-
-tasks.compileJava {
-  doFirst {
-    options.compilerArgs.addAll(listOf("--module-path", classpath.asPath))
-    classpath = files()
-  }
-}
-
-tasks.javadoc {
-  options.modulePath = classpath.toList()
-  classpath = files()
 }

--- a/lib/kpipe-core/build.gradle.kts
+++ b/lib/kpipe-core/build.gradle.kts
@@ -5,19 +5,6 @@ plugins {
 
 description = "KPipe Core - Format-agnostic pipeline machinery for KPipe"
 
-java {
-  withSourcesJar()
-  withJavadocJar()
-  modularity.inferModulePath.set(true)
-  toolchain {
-    languageVersion = JavaLanguageVersion.of(25)
-  }
-}
-
-repositories {
-  mavenCentral()
-}
-
 dependencies {
   testImplementation(platform(libs.junitBom))
   testImplementation(libs.junitJupiter)
@@ -68,28 +55,4 @@ tasks.register<JavaExec>("jcstress") {
   workingDir = outDir
   // -t matches every jcstress test in the core package by its shared JCStressTest suffix.
   args("-t", "JCStressTest", "-iters", "1", "-time", "50", "-f", "1", "-v", "-r", "results")
-}
-
-tasks.test {
-  useJUnitPlatform()
-}
-
-tasks.jacocoTestReport {
-  reports {
-    csv.required.set(true)
-    xml.required.set(true)
-    html.required.set(true)
-  }
-}
-
-tasks.compileJava {
-  doFirst {
-    options.compilerArgs.addAll(listOf("--module-path", classpath.asPath))
-    classpath = files()
-  }
-}
-
-tasks.javadoc {
-  options.modulePath = classpath.toList()
-  classpath = files()
 }

--- a/lib/kpipe-format-avro/build.gradle.kts
+++ b/lib/kpipe-format-avro/build.gradle.kts
@@ -5,19 +5,6 @@ plugins {
 
 description = "KPipe Avro format support — AvroFormat, Avro processors, and console sink"
 
-java {
-  withSourcesJar()
-  withJavadocJar()
-  modularity.inferModulePath.set(true)
-  toolchain {
-    languageVersion = JavaLanguageVersion.of(25)
-  }
-}
-
-repositories {
-  mavenCentral()
-}
-
 dependencies {
   api(project(":lib:kpipe-core"))
   implementation(libs.avro)
@@ -28,28 +15,4 @@ dependencies {
   testImplementation(libs.mockitoCore)
   testImplementation(libs.mockitoJunitJupiter)
   testImplementation(libs.slf4jSimple)
-}
-
-tasks.test {
-  useJUnitPlatform()
-}
-
-tasks.jacocoTestReport {
-  reports {
-    csv.required.set(true)
-    xml.required.set(true)
-    html.required.set(true)
-  }
-}
-
-tasks.compileJava {
-  doFirst {
-    options.compilerArgs.addAll(listOf("--module-path", classpath.asPath))
-    classpath = files()
-  }
-}
-
-tasks.javadoc {
-  options.modulePath = classpath.toList()
-  classpath = files()
 }

--- a/lib/kpipe-format-json/build.gradle.kts
+++ b/lib/kpipe-format-json/build.gradle.kts
@@ -5,19 +5,6 @@ plugins {
 
 description = "KPipe JSON format support — JsonFormat, JSON processors, and console sink"
 
-java {
-  withSourcesJar()
-  withJavadocJar()
-  modularity.inferModulePath.set(true)
-  toolchain {
-    languageVersion = JavaLanguageVersion.of(25)
-  }
-}
-
-repositories {
-  mavenCentral()
-}
-
 dependencies {
   api(project(":lib:kpipe-core"))
 
@@ -29,28 +16,4 @@ dependencies {
   testImplementation(libs.mockitoCore)
   testImplementation(libs.mockitoJunitJupiter)
   testImplementation(libs.slf4jSimple)
-}
-
-tasks.test {
-  useJUnitPlatform()
-}
-
-tasks.jacocoTestReport {
-  reports {
-    csv.required.set(true)
-    xml.required.set(true)
-    html.required.set(true)
-  }
-}
-
-tasks.compileJava {
-  doFirst {
-    options.compilerArgs.addAll(listOf("--module-path", classpath.asPath))
-    classpath = files()
-  }
-}
-
-tasks.javadoc {
-  options.modulePath = classpath.toList()
-  classpath = files()
 }

--- a/lib/kpipe-format-protobuf-confluent/build.gradle.kts
+++ b/lib/kpipe-format-protobuf-confluent/build.gradle.kts
@@ -10,19 +10,6 @@ description =
   "KPipe Protobuf Confluent Schema Registry support — ConfluentProtobufDescriptorCompiler " +
   "(runtime .proto compilation via Confluent ProtobufSchema)"
 
-java {
-  withSourcesJar()
-  withJavadocJar()
-  toolchain {
-    languageVersion = JavaLanguageVersion.of(25)
-  }
-}
-
-repositories {
-  mavenCentral()
-  maven { url = uri("https://packages.confluent.io/maven/") }
-}
-
 // This module compiles on the CLASSPATH, not the module path: Confluent's ProtobufSchema drags in
 // Square Wire as two jars that both export `com.squareup.wire` (an illegal split-package on the
 // module path). Shading + relocation collapses that split in the published jar; the module ships as
@@ -38,10 +25,6 @@ dependencies {
   testRuntimeOnly(libs.junitPlatformLauncher)
   // Gold-standard wire-compat check: Confluent's own serializer produces the bytes our parser reads.
   testImplementation(libs.kafkaProtobufSerializer)
-}
-
-tasks.test {
-  useJUnitPlatform()
 }
 
 // Bundle Confluent + Wire into one self-contained jar with conflict-prone packages relocated so a
@@ -105,12 +88,4 @@ configurations {
   runtimeElements.get().outgoing.artifacts.clear()
   apiElements.get().outgoing.artifact(tasks.named("shadowJar"))
   runtimeElements.get().outgoing.artifact(tasks.named("shadowJar"))
-}
-
-tasks.jacocoTestReport {
-  reports {
-    csv.required.set(true)
-    xml.required.set(true)
-    html.required.set(true)
-  }
 }

--- a/lib/kpipe-format-protobuf/build.gradle.kts
+++ b/lib/kpipe-format-protobuf/build.gradle.kts
@@ -5,19 +5,6 @@ plugins {
 
 description = "KPipe Protobuf format support — ProtobufFormat, processors, and console sink"
 
-java {
-  withSourcesJar()
-  withJavadocJar()
-  modularity.inferModulePath.set(true)
-  toolchain {
-    languageVersion = JavaLanguageVersion.of(25)
-  }
-}
-
-repositories {
-  mavenCentral()
-}
-
 dependencies {
   api(project(":lib:kpipe-core"))
   implementation(libs.protobufJava)
@@ -29,28 +16,4 @@ dependencies {
   testImplementation(libs.mockitoCore)
   testImplementation(libs.mockitoJunitJupiter)
   testImplementation(libs.slf4jSimple)
-}
-
-tasks.test {
-  useJUnitPlatform()
-}
-
-tasks.jacocoTestReport {
-  reports {
-    csv.required.set(true)
-    xml.required.set(true)
-    html.required.set(true)
-  }
-}
-
-tasks.compileJava {
-  doFirst {
-    options.compilerArgs.addAll(listOf("--module-path", classpath.asPath))
-    classpath = files()
-  }
-}
-
-tasks.javadoc {
-  options.modulePath = classpath.toList()
-  classpath = files()
 }

--- a/lib/kpipe-metrics-otel/build.gradle.kts
+++ b/lib/kpipe-metrics-otel/build.gradle.kts
@@ -5,19 +5,6 @@ plugins {
 
 description = "KPipe Metrics OTel - OpenTelemetry-backed implementation of kpipe-metrics interfaces"
 
-java {
-  withSourcesJar()
-  withJavadocJar()
-  modularity.inferModulePath.set(true)
-  toolchain {
-    languageVersion = JavaLanguageVersion.of(25)
-  }
-}
-
-repositories {
-  mavenCentral()
-}
-
 dependencies {
   api(project(":lib:kpipe-metrics"))
   api(project(":lib:kpipe-core"))
@@ -35,33 +22,4 @@ dependencies {
   // emission regressions land silently.
   testImplementation(libs.opentelemetrySdk)
   testImplementation(libs.opentelemetrySdkTesting)
-}
-
-tasks.test {
-  useJUnitPlatform()
-
-  if (project.hasProperty("excludeTests")) {
-    val excludePattern = project.property("excludeTests").toString()
-    exclude("**/${excludePattern.replace(".", "/")}.class")
-  }
-}
-
-tasks.jacocoTestReport {
-  reports {
-    csv.required.set(true)
-    xml.required.set(true)
-    html.required.set(true)
-  }
-}
-
-tasks.compileJava {
-  doFirst {
-    options.compilerArgs.addAll(listOf("--module-path", classpath.asPath))
-    classpath = files()
-  }
-}
-
-tasks.javadoc {
-  options.modulePath = classpath.toList()
-  classpath = files()
 }

--- a/lib/kpipe-metrics/build.gradle.kts
+++ b/lib/kpipe-metrics/build.gradle.kts
@@ -5,19 +5,6 @@ plugins {
 
 description = "KPipe Metrics - telemetry interfaces for KPipe (no-op default; bring your own backend)"
 
-java {
-  withSourcesJar()
-  withJavadocJar()
-  modularity.inferModulePath.set(true)
-  toolchain {
-    languageVersion = JavaLanguageVersion.of(25)
-  }
-}
-
-repositories {
-  mavenCentral()
-}
-
 dependencies {
   testImplementation(platform(libs.junitBom))
   testImplementation(libs.junitJupiter)
@@ -25,33 +12,4 @@ dependencies {
 
   testImplementation(libs.mockitoCore)
   testImplementation(libs.mockitoJunitJupiter)
-}
-
-tasks.test {
-  useJUnitPlatform()
-
-  if (project.hasProperty("excludeTests")) {
-    val excludePattern = project.property("excludeTests").toString()
-    exclude("**/${excludePattern.replace(".", "/")}.class")
-  }
-}
-
-tasks.jacocoTestReport {
-  reports {
-    csv.required.set(true)
-    xml.required.set(true)
-    html.required.set(true)
-  }
-}
-
-tasks.compileJava {
-  doFirst {
-    options.compilerArgs.addAll(listOf("--module-path", classpath.asPath))
-    classpath = files()
-  }
-}
-
-tasks.javadoc {
-  options.modulePath = classpath.toList()
-  classpath = files()
 }

--- a/lib/kpipe-producer/build.gradle.kts
+++ b/lib/kpipe-producer/build.gradle.kts
@@ -5,19 +5,6 @@ plugins {
 
 description = "KPipe Producer - Functional Kafka producer wrapper for KPipe"
 
-java {
-  withSourcesJar()
-  withJavadocJar()
-  modularity.inferModulePath.set(true)
-  toolchain {
-    languageVersion = JavaLanguageVersion.of(25)
-  }
-}
-
-repositories {
-  mavenCentral()
-}
-
 dependencies {
   api(project(":lib:kpipe-core"))
   api(project(":lib:kpipe-metrics"))
@@ -84,34 +71,7 @@ tasks.register<JavaExec>("jcstress") {
 }
 
 tasks.test {
-  useJUnitPlatform()
-
-  if (project.hasProperty("excludeTests")) {
-    val excludePattern = project.property("excludeTests").toString()
-    exclude("**/${excludePattern.replace(".", "/")}.class")
-  }
-
   minHeapSize = "512m"
   maxHeapSize = "2g"
   maxParallelForks = (Runtime.getRuntime().availableProcessors() / 2).coerceAtLeast(2)
-}
-
-tasks.jacocoTestReport {
-  reports {
-    csv.required.set(true)
-    xml.required.set(true)
-    html.required.set(true)
-  }
-}
-
-tasks.compileJava {
-  doFirst {
-    options.compilerArgs.addAll(listOf("--module-path", classpath.asPath))
-    classpath = files()
-  }
-}
-
-tasks.javadoc {
-  options.modulePath = classpath.toList()
-  classpath = files()
 }

--- a/lib/kpipe-schema-registry-confluent/build.gradle.kts
+++ b/lib/kpipe-schema-registry-confluent/build.gradle.kts
@@ -5,19 +5,6 @@ plugins {
 
 description = "KPipe Schema Registry Confluent - Confluent Schema Registry client (schema-by-ID lookup, JSON envelope unwrap)"
 
-java {
-  withSourcesJar()
-  withJavadocJar()
-  modularity.inferModulePath.set(true)
-  toolchain {
-    languageVersion = JavaLanguageVersion.of(25)
-  }
-}
-
-repositories {
-  mavenCentral()
-}
-
 dependencies {
   api(project(":lib:kpipe-core"))
 
@@ -28,15 +15,6 @@ dependencies {
   testImplementation(libs.testcontainers)
   testImplementation(libs.testcontainersJunitJupiter)
   testImplementation(libs.testcontainersKafka)
-}
-
-tasks.test {
-  useJUnitPlatform()
-
-  if (project.hasProperty("excludeTests")) {
-    val excludePattern = project.property("excludeTests").toString()
-    exclude("**/${excludePattern.replace(".", "/")}.class")
-  }
 }
 
 // jcstress concurrency-stress harness. Lives in its own source set so the generated test
@@ -80,24 +58,4 @@ tasks.register<JavaExec>("jcstress") {
   workingDir = outDir
   // -t matches every jcstress test in this module's package by its shared JCStressTest suffix.
   args("-t", "JCStressTest", "-iters", "1", "-time", "50", "-f", "1", "-v", "-r", "results")
-}
-
-tasks.jacocoTestReport {
-  reports {
-    csv.required.set(true)
-    xml.required.set(true)
-    html.required.set(true)
-  }
-}
-
-tasks.compileJava {
-  doFirst {
-    options.compilerArgs.addAll(listOf("--module-path", classpath.asPath))
-    classpath = files()
-  }
-}
-
-tasks.javadoc {
-  options.modulePath = classpath.toList()
-  classpath = files()
 }

--- a/lib/kpipe-test/build.gradle.kts
+++ b/lib/kpipe-test/build.gradle.kts
@@ -5,19 +5,6 @@ plugins {
 
 description = "KPipe test kit — TestStream driver and CapturingSink for Docker-free pipeline unit tests"
 
-java {
-  withSourcesJar()
-  withJavadocJar()
-  modularity.inferModulePath.set(true)
-  toolchain {
-    languageVersion = JavaLanguageVersion.of(25)
-  }
-}
-
-repositories {
-  mavenCentral()
-}
-
 dependencies {
   api(project(":lib:kpipe-core"))
   api(project(":lib:kpipe-consumer"))
@@ -29,28 +16,4 @@ dependencies {
   testImplementation(libs.junitJupiter)
   testRuntimeOnly(libs.junitPlatformLauncher)
   testImplementation(libs.slf4jSimple)
-}
-
-tasks.test {
-  useJUnitPlatform()
-}
-
-tasks.jacocoTestReport {
-  reports {
-    csv.required.set(true)
-    xml.required.set(true)
-    html.required.set(true)
-  }
-}
-
-tasks.compileJava {
-  doFirst {
-    options.compilerArgs.addAll(listOf("--module-path", classpath.asPath))
-    classpath = files()
-  }
-}
-
-tasks.javadoc {
-  options.modulePath = classpath.toList()
-  classpath = files()
 }

--- a/lib/kpipe-tracing-otel/build.gradle.kts
+++ b/lib/kpipe-tracing-otel/build.gradle.kts
@@ -5,19 +5,6 @@ plugins {
 
 description = "KPipe Tracing OTel - OpenTelemetry-backed implementation of the kpipe Tracer SPI"
 
-java {
-  withSourcesJar()
-  withJavadocJar()
-  modularity.inferModulePath.set(true)
-  toolchain {
-    languageVersion = JavaLanguageVersion.of(25)
-  }
-}
-
-repositories {
-  mavenCentral()
-}
-
 dependencies {
   api(project(":lib:kpipe-producer"))
   api(libs.opentelemetryApi)
@@ -39,33 +26,4 @@ dependencies {
   testImplementation(libs.testcontainers)
   testImplementation(libs.testcontainersJunitJupiter)
   testImplementation(libs.testcontainersKafka)
-}
-
-tasks.test {
-  useJUnitPlatform()
-
-  if (project.hasProperty("excludeTests")) {
-    val excludePattern = project.property("excludeTests").toString()
-    exclude("**/${excludePattern.replace(".", "/")}.class")
-  }
-}
-
-tasks.jacocoTestReport {
-  reports {
-    csv.required.set(true)
-    xml.required.set(true)
-    html.required.set(true)
-  }
-}
-
-tasks.compileJava {
-  doFirst {
-    options.compilerArgs.addAll(listOf("--module-path", classpath.asPath))
-    classpath = files()
-  }
-}
-
-tasks.javadoc {
-  options.modulePath = classpath.toList()
-  classpath = files()
 }


### PR DESCRIPTION
Closes the build-config duplication item: 13 `lib/kpipe-*/build.gradle.kts` files repeated the same java/toolchain/test/jacoco/repositories blocks. **+50/−495 lines.**

Hoisted into `lib/build.gradle.kts` `subprojects {}` under `plugins.withId("java-library")` (matching the file's existing reactive style):
- `java {}` (sources/javadoc jars, `inferModulePath`, toolchain 25)
- `useJUnitPlatform` + the `-PexcludeTests` handler (now uniform across all 13 — was 6; no-op unless the property is passed)
- JPMS module-path wiring, guarded by `module-info.java` existence (auto-skips the shaded `-confluent` classpath-only module)
- jacoco report config under `plugins.withId("jacoco")`
- per-module `repositories {}` deleted outright (root `allprojects` already declares them)

**BOM excluded structurally**: `java-platform` never applies `java-library`/`jacoco`, so both reactions skip it — `verifyBomCoverage` green.

**Kept per-module** (genuinely local): plugins, description, deps, jcstress source-sets, test heap/fork tuning, all shadow/relocation config.

## Verification
- whole-repo `compileJava compileTestJava` green · `verifyBomCoverage` green · jcstress source-set compiles · sample tests demonstrably ran
- **Toolchain proof**: `javap -verbose` on a freshly compiled class → major 69 (Java 25), with GraalVM 17 among ambient JDKs and `options.release=25` set — a 17 compiler would have hard-failed
- `spotlessKotlinGradleCheck` green

CI's own full build is the ultimate validator for a build-config change.