### PR TITLE
refactor(consumer): rename Dispatcher.pendingCount() to activeCount()

### DIFF
--- a/lib/kpipe-consumer/src/jcstress/java/io/github/eschizoid/kpipe/consumer/DispatcherActiveCountJCStressTest.java
+++ b/lib/kpipe-consumer/src/jcstress/java/io/github/eschizoid/kpipe/consumer/DispatcherActiveCountJCStressTest.java
@@ -32,7 +32,7 @@ import org.openjdk.jcstress.infra.results.JJJ_Result;
 /// Awaiting that latch establishes a happens-before edge: by the time an actor returns, its
 /// own record's decrement is visible. One actor dispatches a record whose task returns
 /// normally; the other dispatches a record whose task throws, exercising the throw-path
-/// finally. Each actor reads `pendingCount()` after its own completion and records it; the
+/// finally. Each actor reads `activeCount()` after its own completion and records it; the
 /// arbiter reads the final settled count once both actors finish.
 ///
 /// jcstress runs the two actors against fresh state under every interleaving its scheduler
@@ -66,7 +66,7 @@ import org.openjdk.jcstress.infra.results.JJJ_Result;
   desc = "A negative observation or non-zero final count: an increment or decrement was lost."
 )
 @State
-public class DispatcherPendingCountJCStressTest {
+public class DispatcherActiveCountJCStressTest {
 
   private static final String TOPIC = "jcstress-topic";
 
@@ -96,7 +96,7 @@ public class DispatcherPendingCountJCStressTest {
   public void observe(final JJJ_Result r) {
     awaitQuietly(normalDone);
     awaitQuietly(throwDone);
-    r.r3 = dispatcher.pendingCount();
+    r.r3 = dispatcher.activeCount();
   }
 
   /// Blocks until this record's completion fires, then snapshots the live count. A snapshot
@@ -105,7 +105,7 @@ public class DispatcherPendingCountJCStressTest {
   /// without a matching increment.
   private long awaitThenObserve(final CountDownLatch done) {
     awaitQuietly(done);
-    return dispatcher.pendingCount();
+    return dispatcher.activeCount();
   }
 
   private static void awaitQuietly(final CountDownLatch done) {

--- a/lib/kpipe-consumer/src/jcstress/java/io/github/eschizoid/kpipe/consumer/KeyOrderedLruJCStressTest.java
+++ b/lib/kpipe-consumer/src/jcstress/java/io/github/eschizoid/kpipe/consumer/KeyOrderedLruJCStressTest.java
@@ -36,7 +36,7 @@ import org.openjdk.jcstress.infra.results.I_Result;
 /// Scenario. Both actors dispatch a record for the same key. Each dispatched task increments
 /// a shared counter once; the dispatcher's per-task `onComplete` then counts down a latch the
 /// arbiter awaits. Awaiting the latch establishes a happens-before edge that BOTH tasks have
-/// fully run before the counter is read — closing the early-exit window a `pendingCount()` spin
+/// fully run before the counter is read — closing the early-exit window a `activeCount()` spin
 /// had (the count can momentarily read zero between an enqueue and the task body executing). The
 /// only acceptable outcome is 2: both tasks ran exactly once. A lost enqueue means a task never
 /// runs, the latch never reaches zero, the await times out, and the run reports the forbidden -1.
@@ -68,7 +68,7 @@ public class KeyOrderedLruJCStressTest {
   public void observe(final I_Result r) {
     // Await both tasks' onComplete (fired per task by the dispatcher after task.run()). The await
     // is the happens-before edge guaranteeing both task bodies fully ran before tasksRun is read,
-    // so a momentary pendingCount==0 between enqueue and execution can't make the read fire early.
+    // so a momentary activeCount==0 between enqueue and execution can't make the read fire early.
     // A lost enqueue leaves the latch above zero; the await times out and the run reports -1.
     try {
       if (!done.await(5, TimeUnit.SECONDS)) {

--- a/lib/kpipe-consumer/src/main/java/io/github/eschizoid/kpipe/consumer/Dispatcher.java
+++ b/lib/kpipe-consumer/src/main/java/io/github/eschizoid/kpipe/consumer/Dispatcher.java
@@ -51,7 +51,7 @@ sealed interface Dispatcher
   /// Sequential mode returns 0 or 1 (one inline record at a time). Lag-based backpressure
   /// doesn't consult this value, but it's still tracked so `inFlight` metrics and
   /// `shutdownGracefully(timeout)` drain reporting are accurate.
-  long pendingCount();
+  long activeCount();
 
   /// Snapshot of the top-`n` keys by current queue depth, ordered deepest-first. Intended for
   /// ad-hoc diagnostics (heap-dump replacement, REPL/JMX inspection) — not for continuous

--- a/lib/kpipe-consumer/src/main/java/io/github/eschizoid/kpipe/consumer/KPipeConsumer.java
+++ b/lib/kpipe-consumer/src/main/java/io/github/eschizoid/kpipe/consumer/KPipeConsumer.java
@@ -495,7 +495,7 @@ public class KPipeConsumer implements AutoCloseable {
   /// the calling thread is interrupted. Replaces the former standalone
   /// `MessageTracker.waitForCompletion(...)`.
   ///
-  /// Waits on `dispatcher.pendingCount()` — records a worker is actively processing — NOT
+  /// Waits on `dispatcher.activeCount()` — records a worker is actively processing — NOT
   /// `totalInFlight()`. The latter also counts buffered batch records, which never flush during a
   /// drain (only on a size/age trigger or `BatchPipelineWrapper.close()` at teardown), so waiting
   /// on them would always burn the full `timeout`. Buffered batches are flushed + committed by the
@@ -505,13 +505,13 @@ public class KPipeConsumer implements AutoCloseable {
   /// @param timeout maximum time to wait
   /// @return `true` if active processing drained in time, else `false`
   public boolean waitForInFlightDrain(final Duration timeout) {
-    if (dispatcher.pendingCount() == 0) return true;
+    if (dispatcher.activeCount() == 0) return true;
     final var deadline = System.nanoTime() + timeout.toNanos();
     final var pollNanos = Math.min(timeout.toNanos() / 10, Duration.ofMillis(500).toNanos());
     final var pollMs = Math.max(1, pollNanos / 1_000_000);
     try {
       while (System.nanoTime() < deadline) {
-        if (dispatcher.pendingCount() == 0) return true;
+        if (dispatcher.activeCount() == 0) return true;
         //noinspection BusyWait — deadline-bounded drain poll, not a spin
         Thread.sleep(pollMs);
       }
@@ -519,7 +519,7 @@ public class KPipeConsumer implements AutoCloseable {
       Thread.currentThread().interrupt();
       return false;
     }
-    return dispatcher.pendingCount() == 0;
+    return dispatcher.activeCount() == 0;
   }
 
   /// Runs on the consumer thread, at the top of its `finally`, before any teardown. The poll
@@ -532,7 +532,7 @@ public class KPipeConsumer implements AutoCloseable {
   /// `processCommands()` flushes anything the last workers enqueued. Only the consumer thread may
   /// touch the Kafka consumer, so this must run here, not on the close() thread.
   ///
-  /// We wait on `dispatcher.pendingCount()`, NOT `totalInFlight()`: the latter also counts
+  /// We wait on `dispatcher.activeCount()`, NOT `totalInFlight()`: the latter also counts
   /// buffered batch records, which don't enqueue commands and won't flush on their own (size-only
   /// / long-maxAge policies). They're flushed by each `BatchPipelineWrapper.close()` in
   /// `releaseConstructedResources()` right after this returns — so waiting on them here would just
@@ -540,7 +540,7 @@ public class KPipeConsumer implements AutoCloseable {
   private void drainInFlightBeforeTeardown() {
     if (waitForMessagesTimeout.toMillis() > 0) {
       final var deadline = System.nanoTime() + waitForMessagesTimeout.toNanos();
-      while (dispatcher.pendingCount() > 0 && System.nanoTime() < deadline) {
+      while (dispatcher.activeCount() > 0 && System.nanoTime() < deadline) {
         processCommands();
         LockSupport.parkNanos(Duration.ofMillis(5).toNanos());
       }
@@ -957,8 +957,8 @@ public class KPipeConsumer implements AutoCloseable {
     stopMetricsReporterThread();
     commandQueue.offer(new ConsumerCommand.Close());
     dispatcher.signalShutdown();
-    if (waitForMessagesTimeout.toMillis() > 0 && dispatcher.pendingCount() > 0) {
-      LOGGER.log(Level.INFO, "Waiting for {0} in-flight messages to complete", dispatcher.pendingCount());
+    if (waitForMessagesTimeout.toMillis() > 0 && dispatcher.activeCount() > 0) {
+      LOGGER.log(Level.INFO, "Waiting for {0} in-flight messages to complete", dispatcher.activeCount());
       waitForInFlightDrain(waitForMessagesTimeout);
     }
   }
@@ -1109,7 +1109,7 @@ public class KPipeConsumer implements AutoCloseable {
   /// - `KeyOrderedDispatcher` enqueues records onto a per-key serial queue + virtual thread.
   ///
   /// The dispatcher also owns the in-flight counter (for non-sequential modes) and feeds
-  /// [#totalInFlight] via `dispatcher.pendingCount()`.
+  /// [#totalInFlight] via `dispatcher.activeCount()`.
   ///
   /// @param records the batch of records to process
   protected void processRecords(final ConsumerRecords<byte[], byte[]> records) {
@@ -1261,7 +1261,7 @@ public class KPipeConsumer implements AutoCloseable {
   /// finishes `processRecord` (which for batch is "the record was buffered"), so the buffer
   /// would otherwise be invisible to the watermark check.
   private long totalInFlight() {
-    var total = dispatcher.pendingCount();
+    var total = dispatcher.activeCount();
     for (final var wrapper : batchWrappers.values()) total += wrapper.bufferedCount();
     return total;
   }

--- a/lib/kpipe-consumer/src/main/java/io/github/eschizoid/kpipe/consumer/KeyOrderedDispatcher.java
+++ b/lib/kpipe-consumer/src/main/java/io/github/eschizoid/kpipe/consumer/KeyOrderedDispatcher.java
@@ -276,7 +276,7 @@ final class KeyOrderedDispatcher implements Dispatcher {
   }
 
   @Override
-  public long pendingCount() {
+  public long activeCount() {
     return pending.get();
   }
 

--- a/lib/kpipe-consumer/src/main/java/io/github/eschizoid/kpipe/consumer/ParallelDispatcher.java
+++ b/lib/kpipe-consumer/src/main/java/io/github/eschizoid/kpipe/consumer/ParallelDispatcher.java
@@ -15,7 +15,7 @@ import org.apache.kafka.clients.consumer.ConsumerRecord;
 /// `Executors.newVirtualThreadPerTaskExecutor()`. No ordering guarantees within or across
 /// keys; unbounded parallelism bounded only by Loom's carrier-thread capacity.
 ///
-/// Pairs with [BackpressureController#inFlightStrategy] in [KPipeConsumer] — `pendingCount()`
+/// Pairs with [BackpressureController#inFlightStrategy] in [KPipeConsumer] — `activeCount()`
 /// returns the number of records currently submitted but not yet finished.
 ///
 /// Owns its `ExecutorService` and shuts it down in [#close()] using the same `shutdown +
@@ -84,14 +84,14 @@ final class ParallelDispatcher implements Dispatcher {
   }
 
   @Override
-  public long pendingCount() {
+  public long activeCount() {
     return inFlight.get();
   }
 
   /// `shutdownNow()` doesn't strand `inFlight`: the VT-per-task executor has no work queue, so
   /// it returns an empty list and only interrupts running tasks — and interrupt doesn't skip a
   /// `finally`, so each task still decrements. A pooled executor WOULD strand queued tasks here;
-  /// `ParallelDispatcherTest.pendingCountDrainsToZeroWhenCloseInterruptsRunningTask` guards it.
+  /// `ParallelDispatcherTest.activeCountDrainsToZeroWhenCloseInterruptsRunningTask` guards it.
   @Override
   public void close() {
     try {

--- a/lib/kpipe-consumer/src/main/java/io/github/eschizoid/kpipe/consumer/SequentialDispatcher.java
+++ b/lib/kpipe-consumer/src/main/java/io/github/eschizoid/kpipe/consumer/SequentialDispatcher.java
@@ -9,7 +9,7 @@ import org.apache.kafka.clients.consumer.ConsumerRecord;
 ///
 /// Pairs with [BackpressureController#lagStrategy] in [KPipeConsumer] — when one record runs
 /// at a time, the only meaningful backlog metric is Kafka lag, not in-flight count. Lag-based
-/// backpressure does not consult `pendingCount()`.
+/// backpressure does not consult `activeCount()`.
 ///
 /// **Why we still track an in-flight count even though dispatch is inline.** The counter is
 /// reported as `inFlight` in [KPipeConsumer#getMetrics] (OTel + user-visible) and feeds the
@@ -20,7 +20,7 @@ import org.apache.kafka.clients.consumer.ConsumerRecord;
 ///
 /// Shutdown correctness is preserved by `KPipeConsumer.close()`'s `thread.join` on the
 /// consumer thread — the join waits for any in-flight `processTask.run()` to return regardless
-/// of `pendingCount()`. PARALLEL and KEY_ORDERED dispatch onto distinct virtual threads, so
+/// of `activeCount()`. PARALLEL and KEY_ORDERED dispatch onto distinct virtual threads, so
 /// they need a real counter to participate in `waitForInFlightDrain` too.
 final class SequentialDispatcher implements Dispatcher {
 
@@ -42,7 +42,7 @@ final class SequentialDispatcher implements Dispatcher {
   }
 
   @Override
-  public long pendingCount() {
+  public long activeCount() {
     return inFlight.get();
   }
 

--- a/lib/kpipe-consumer/src/test/java/io/github/eschizoid/kpipe/consumer/KPipeConsumerTest.java
+++ b/lib/kpipe-consumer/src/test/java/io/github/eschizoid/kpipe/consumer/KPipeConsumerTest.java
@@ -341,7 +341,7 @@ class KPipeConsumerTest {
   void closeDoesNotBurnTimeoutWaitingForBufferedBatchRecords() throws InterruptedException {
     // A size-only batch policy (maxSize=100) means a single buffered record never auto-flushes —
     // it's flushed by BatchPipelineWrapper.close() at teardown. So the in-flight drain must wait
-    // only on the dispatcher's active work (pendingCount), not totalInFlight (which counts the
+    // only on the dispatcher's active work (activeCount), not totalInFlight (which counts the
     // buffered record); otherwise close() burns the whole waitForMessagesTimeout while the
     // dispatcher is already idle. Probe: close() returns well under the timeout AND the buffered
     // record is still flushed + its offset marked at teardown.

--- a/lib/kpipe-consumer/src/test/java/io/github/eschizoid/kpipe/consumer/KeyOrderedDispatcherCorrectnessTest.java
+++ b/lib/kpipe-consumer/src/test/java/io/github/eschizoid/kpipe/consumer/KeyOrderedDispatcherCorrectnessTest.java
@@ -287,14 +287,14 @@ class KeyOrderedDispatcherCorrectnessTest {
         () -> "key " + key + " reordered under saturation hold: " + tracker.observed
       );
     }
-    // pendingCount is decremented in the worker's finally, which can run just after the per-record
+    // activeCount is decremented in the worker's finally, which can run just after the per-record
     // latch the producers awaited counts down — so poll for the drain rather than reading it the
     // instant the latch releases (an immediate read flaked on slow CI runners).
     final var drainDeadline = System.nanoTime() + Duration.ofSeconds(5).toNanos();
-    while (dispatcher.pendingCount() != 0 && System.nanoTime() < drainDeadline) {
+    while (dispatcher.activeCount() != 0 && System.nanoTime() < drainDeadline) {
       Thread.onSpinWait();
     }
-    assertEquals(0, dispatcher.pendingCount(), "no records may remain pending after saturation drains");
+    assertEquals(0, dispatcher.activeCount(), "no records may remain pending after saturation drains");
     dispatcher.close();
   }
 
@@ -431,20 +431,20 @@ class KeyOrderedDispatcherCorrectnessTest {
     for (final var p : producers) p.join(Duration.ofSeconds(5));
 
     assertTrue(snapshotErrors.isEmpty(), () -> "diagnostic snapshot errors under churn: " + snapshotErrors);
-    // pendingCount is decremented in the worker's finally, which can run just after the per-record
+    // activeCount is decremented in the worker's finally, which can run just after the per-record
     // latch the producers awaited counts down — so poll for the drain rather than reading it the
     // instant the latch releases (an immediate read flaked on slow CI runners).
     final var drainDeadline = System.nanoTime() + Duration.ofSeconds(5).toNanos();
-    while (dispatcher.pendingCount() != 0 && System.nanoTime() < drainDeadline) {
+    while (dispatcher.activeCount() != 0 && System.nanoTime() < drainDeadline) {
       Thread.onSpinWait();
     }
-    assertEquals(0, dispatcher.pendingCount(), "pending must drain to 0");
+    assertEquals(0, dispatcher.activeCount(), "pending must drain to 0");
     dispatcher.close();
   }
 
   @Test
   void concurrentDispatchAndCloseNeverLeavesPendingNegativeOrStuck() throws InterruptedException {
-    // Race a close() against in-flight dispatch. pendingCount() must never go negative (a
+    // Race a close() against in-flight dispatch. activeCount() must never go negative (a
     // double-decrement bug) and must settle. We don't assert all records ran — close() is allowed
     // to abandon stragglers — only that the counter is non-negative throughout and ends >= 0.
     final var dispatcher = new KeyOrderedDispatcher(16);
@@ -455,7 +455,7 @@ class KeyOrderedDispatcherCorrectnessTest {
 
     final var watcher = Thread.ofVirtual().start(() -> {
       while (!stopWatch.get()) {
-        if (dispatcher.pendingCount() < 0) negativeSeen.set(true);
+        if (dispatcher.activeCount() < 0) negativeSeen.set(true);
         Thread.onSpinWait();
       }
     });
@@ -487,8 +487,8 @@ class KeyOrderedDispatcherCorrectnessTest {
     stopWatch.set(true);
     watcher.join(Duration.ofSeconds(5));
 
-    assertFalse(negativeSeen.get(), "pendingCount() must never go negative under dispatch/close race");
-    assertTrue(dispatcher.pendingCount() >= 0, "pendingCount() must end non-negative");
+    assertFalse(negativeSeen.get(), "activeCount() must never go negative under dispatch/close race");
+    assertTrue(dispatcher.activeCount() >= 0, "activeCount() must end non-negative");
   }
 
   private static List<Long> expectedOrder(final int n) {

--- a/lib/kpipe-consumer/src/test/java/io/github/eschizoid/kpipe/consumer/KeyOrderedDispatcherTest.java
+++ b/lib/kpipe-consumer/src/test/java/io/github/eschizoid/kpipe/consumer/KeyOrderedDispatcherTest.java
@@ -128,7 +128,7 @@ class KeyOrderedDispatcherTest {
   }
 
   @Test
-  void pendingCountReflectsBufferedAndInFlight() throws InterruptedException {
+  void activeCountReflectsBufferedAndInFlight() throws InterruptedException {
     final var dispatcher = new KeyOrderedDispatcher(KeyOrderedDispatcher.DEFAULT_MAX_KEYS);
     final var allowFinish = new CountDownLatch(1);
     final var firstStarted = new CountDownLatch(1);
@@ -151,15 +151,15 @@ class KeyOrderedDispatcherTest {
     }
 
     assertTrue(firstStarted.await(2, TimeUnit.SECONDS));
-    assertEquals(3, dispatcher.pendingCount(), "all 3 records pending (1 in-flight + 2 queued)");
+    assertEquals(3, dispatcher.activeCount(), "all 3 records pending (1 in-flight + 2 queued)");
 
     allowFinish.countDown();
     // Wait for everything to drain
     final var deadline = System.nanoTime() + Duration.ofSeconds(5).toNanos();
-    while (dispatcher.pendingCount() > 0 && System.nanoTime() < deadline) {
+    while (dispatcher.activeCount() > 0 && System.nanoTime() < deadline) {
       Thread.sleep(10);
     }
-    assertEquals(0, dispatcher.pendingCount());
+    assertEquals(0, dispatcher.activeCount());
     dispatcher.close();
   }
 
@@ -702,7 +702,7 @@ class KeyOrderedDispatcherTest {
     final var pendingBeforeSignal = new AtomicInteger();
     Thread.ofVirtual().start(() -> {
       dispatcher.dispatch(recordWithKey("c", 0), () -> {}, () -> {});
-      pendingBeforeSignal.set((int) dispatcher.pendingCount());
+      pendingBeforeSignal.set((int) dispatcher.activeCount());
       thirdCompleted.countDown();
     });
 
@@ -845,7 +845,7 @@ class KeyOrderedDispatcherTest {
 
       // Wait for everything to drain so the second saturation round has empty queues to fill.
       final var deadline = System.nanoTime() + Duration.ofSeconds(2).toNanos();
-      while (dispatcher.pendingCount() > 0 && System.nanoTime() < deadline) Thread.sleep(5);
+      while (dispatcher.activeCount() > 0 && System.nanoTime() < deadline) Thread.sleep(5);
 
       // Saturation round 2: same scenario, fresh blocked workers.
       final var workerA2 = new CountDownLatch(1);
@@ -944,7 +944,7 @@ class KeyOrderedDispatcherTest {
     final var deadline = System.nanoTime() + Duration.ofSeconds(2).toNanos();
     while (firstWorker.isAlive() && System.nanoTime() < deadline) Thread.sleep(5);
     assertFalse(firstWorker.isAlive(), "first worker VT must exit after queue drains");
-    assertEquals(0, dispatcher.pendingCount(), "pending must be 0 between batches");
+    assertEquals(0, dispatcher.activeCount(), "pending must be 0 between batches");
 
     // Second dispatch on the same key — must spawn a fresh worker, not reuse the dead one.
     dispatcher.dispatch(

--- a/lib/kpipe-consumer/src/test/java/io/github/eschizoid/kpipe/consumer/ParallelDispatcherRaceTest.java
+++ b/lib/kpipe-consumer/src/test/java/io/github/eschizoid/kpipe/consumer/ParallelDispatcherRaceTest.java
@@ -43,7 +43,7 @@ class ParallelDispatcherRaceTest {
 
   private static void awaitInFlightZero(final ParallelDispatcher dispatcher) throws InterruptedException {
     final var deadline = System.nanoTime() + Duration.ofSeconds(5).toNanos();
-    while (dispatcher.pendingCount() > 0 && System.nanoTime() < deadline) Thread.sleep(5);
+    while (dispatcher.activeCount() > 0 && System.nanoTime() < deadline) Thread.sleep(5);
   }
 
   @Test
@@ -62,7 +62,7 @@ class ParallelDispatcherRaceTest {
       // Park until the throw-path onComplete unparks us, the way the consumer thread
       // waits for
       // the in-flight count to drop. A while-loop guards against spurious wakeups.
-      while (dispatcher.pendingCount() > 0) {
+      while (dispatcher.activeCount() > 0) {
         LockSupport.park();
       }
       waiterReleased.countDown();
@@ -83,7 +83,7 @@ class ParallelDispatcherRaceTest {
       "throw-path onComplete must unpark the waiter; a swallowed onComplete would strand it"
     );
     awaitInFlightZero(dispatcher);
-    assertEquals(0, dispatcher.pendingCount(), "in-flight must drain to 0 after the throwing record");
+    assertEquals(0, dispatcher.activeCount(), "in-flight must drain to 0 after the throwing record");
     assertEquals(0, rejectCount.get(), "a throwing task body is not a rejection");
     dispatcher.close();
   }
@@ -132,7 +132,7 @@ class ParallelDispatcherRaceTest {
     assertTrue(allCompleted.await(10, TimeUnit.SECONDS), "onComplete must fire for every record");
 
     awaitInFlightZero(dispatcher);
-    assertEquals(0, dispatcher.pendingCount(), "interleaved throws and successes must drain to 0");
+    assertEquals(0, dispatcher.activeCount(), "interleaved throws and successes must drain to 0");
     assertEquals(total, onCompleteCount.get(), "onComplete must fire exactly once per record");
     assertEquals(0, rejectCount.get(), "no dispatch was rejected before close");
     dispatcher.close();
@@ -140,7 +140,7 @@ class ParallelDispatcherRaceTest {
 
   @Test
   void backpressureRecoversAfterABurstOfThrows() throws InterruptedException {
-    // The consumer's totalInFlight() feeds the dispatcher's pendingCount() into the in-flight
+    // The consumer's totalInFlight() feeds the dispatcher's activeCount() into the in-flight
     // backpressure strategy. This test wires a real BackpressureController to the dispatcher's
     // count, the same way the consumer does, and then exercises the pause/resume transition
     // across a burst of records that all throw.
@@ -157,7 +157,7 @@ class ParallelDispatcherRaceTest {
     final var controller = new BackpressureController(
       8,
       4,
-      BackpressureController.inFlightStrategy(dispatcher::pendingCount)
+      BackpressureController.inFlightStrategy(dispatcher::activeCount)
     );
     final var total = 32;
     final var release = new CountDownLatch(1);
@@ -196,7 +196,7 @@ class ParallelDispatcherRaceTest {
     assertTrue(allCompleted.await(10, TimeUnit.SECONDS), "every throwing record must complete after release");
     awaitInFlightZero(dispatcher);
 
-    assertEquals(0, dispatcher.pendingCount(), "a burst of throws must leave no residual in-flight count");
+    assertEquals(0, dispatcher.activeCount(), "a burst of throws must leave no residual in-flight count");
     // A consumer that paused at the high watermark must now be told to RESUME — the throwing
     // burst did not corrupt the count, so the watermark recovers.
     assertEquals(
@@ -222,7 +222,7 @@ class ParallelDispatcherRaceTest {
 
     final var watcher = Thread.ofVirtual().start(() -> {
       while (stopWatching.getCount() > 0) {
-        final var current = dispatcher.pendingCount();
+        final var current = dispatcher.activeCount();
         minObserved.updateAndGet(prev -> Math.min(prev, current));
         Thread.onSpinWait();
       }
@@ -255,7 +255,7 @@ class ParallelDispatcherRaceTest {
     watcher.join(Duration.ofSeconds(2));
 
     assertTrue(minObserved.get() >= 0, "in-flight count must never go negative; saw " + minObserved.get());
-    assertEquals(0, dispatcher.pendingCount(), "in-flight must settle at exactly 0 after the throwing burst");
+    assertEquals(0, dispatcher.activeCount(), "in-flight must settle at exactly 0 after the throwing burst");
     dispatcher.close();
   }
 }

--- a/lib/kpipe-consumer/src/test/java/io/github/eschizoid/kpipe/consumer/ParallelDispatcherTest.java
+++ b/lib/kpipe-consumer/src/test/java/io/github/eschizoid/kpipe/consumer/ParallelDispatcherTest.java
@@ -115,8 +115,8 @@ class ParallelDispatcherTest {
         throw new IllegalStateException("onComplete boom");
       });
       assertTrue(ran.await(2, TimeUnit.SECONDS), "processTask must run");
-      awaitTrue(() -> dispatcher.pendingCount() == 0 && !capture.records().isEmpty());
-      assertEquals(0, dispatcher.pendingCount(), "a throwing onComplete must not strand in-flight");
+      awaitTrue(() -> dispatcher.activeCount() == 0 && !capture.records().isEmpty());
+      assertEquals(0, dispatcher.activeCount(), "a throwing onComplete must not strand in-flight");
       assertTrue(
         capture.records().stream().anyMatch(r -> r.getMessage().contains("onComplete callback threw")),
         "the throwing onComplete must be logged at WARNING"
@@ -139,7 +139,7 @@ class ParallelDispatcherTest {
 
     dispatcher.dispatch(record(0), () -> {}, () -> {});
     assertEquals(1, rejectCount.get(), "dispatch after close must be rejected (executor shut down)");
-    assertEquals(0, dispatcher.pendingCount(), "rejected dispatch must roll back the in-flight counter");
+    assertEquals(0, dispatcher.activeCount(), "rejected dispatch must roll back the in-flight counter");
   }
 
   @Test
@@ -154,17 +154,17 @@ class ParallelDispatcherTest {
     assertTrue(ran.await(2, TimeUnit.SECONDS), "task must run on a virtual thread");
     assertTrue(completed.await(2, TimeUnit.SECONDS), "onComplete must fire");
     final var deadline = System.nanoTime() + Duration.ofSeconds(2).toNanos();
-    while (dispatcher.pendingCount() > 0 && System.nanoTime() < deadline) Thread.sleep(5);
-    assertEquals(0, dispatcher.pendingCount(), "in-flight must drain to 0");
+    while (dispatcher.activeCount() > 0 && System.nanoTime() < deadline) Thread.sleep(5);
+    assertEquals(0, dispatcher.activeCount(), "in-flight must drain to 0");
     assertEquals(0, rejectCount.get(), "no rejection on the happy path");
     dispatcher.close();
   }
 
   @Test
-  void pendingCountDecrementedWhenTaskThrows() throws InterruptedException {
+  void activeCountDecrementedWhenTaskThrows() throws InterruptedException {
     // Guards the criticality-9 race in §20: ParallelDispatcher owns the in-flight counter that
     // drives PARALLEL-mode backpressure (§5). If the task body throws and the finally block did
-    // NOT decrement, pendingCount() would climb monotonically per failed record — the watermark
+    // NOT decrement, activeCount() would climb monotonically per failed record — the watermark
     // would latch at HIGH and the consumer would pause forever (deadlock). Conversely, double
     // decrement would underflow toward negative and the consumer would never pause (false-
     // negative backpressure). The production code wraps processTask.run() in try/finally so
@@ -183,17 +183,17 @@ class ParallelDispatcherTest {
 
     assertTrue(completed.await(2, TimeUnit.SECONDS), "onComplete must fire even when task throws");
     final var deadline = System.nanoTime() + Duration.ofSeconds(2).toNanos();
-    while (dispatcher.pendingCount() > 0 && System.nanoTime() < deadline) Thread.sleep(5);
-    assertEquals(0, dispatcher.pendingCount(), "throwing task's finally must still decrement in-flight");
+    while (dispatcher.activeCount() > 0 && System.nanoTime() < deadline) Thread.sleep(5);
+    assertEquals(0, dispatcher.activeCount(), "throwing task's finally must still decrement in-flight");
     assertEquals(0, rejectCount.get(), "a throwing task body is not a rejection");
     dispatcher.close();
   }
 
   @Test
-  void pendingCountDrainsWhenTaskThrowsError() throws InterruptedException {
-    // Sibling of pendingCountDecrementedWhenTaskThrows for `Error` (e.g. `AssertionError`),
+  void activeCountDrainsWhenTaskThrowsError() throws InterruptedException {
+    // Sibling of activeCountDecrementedWhenTaskThrows for `Error` (e.g. `AssertionError`),
     // which is a Throwable-not-Exception and would bypass any future narrowing of the production
-    // try/finally to `catch (Exception) { ... } finally { ... }` — pendingCount would silently
+    // try/finally to `catch (Exception) { ... } finally { ... }` — activeCount would silently
     // strand on every Error escape.
     final var rejectCount = new AtomicInteger(0);
     final var dispatcher = newDispatcher(rejectCount);
@@ -209,14 +209,14 @@ class ParallelDispatcherTest {
 
     assertTrue(completed.await(2, TimeUnit.SECONDS), "onComplete must fire even when task throws an Error");
     final var deadline = System.nanoTime() + Duration.ofSeconds(2).toNanos();
-    while (dispatcher.pendingCount() > 0 && System.nanoTime() < deadline) Thread.sleep(5);
-    assertEquals(0, dispatcher.pendingCount(), "Error-throwing task's finally must still decrement in-flight");
+    while (dispatcher.activeCount() > 0 && System.nanoTime() < deadline) Thread.sleep(5);
+    assertEquals(0, dispatcher.activeCount(), "Error-throwing task's finally must still decrement in-flight");
     dispatcher.close();
   }
 
   @Test
   void onCompleteFiresExactlyOnceWhenTaskThrows() throws InterruptedException {
-    // Pair test for pendingCountDecrementedWhenTaskThrows: the consumer's afterRecordComplete()
+    // Pair test for activeCountDecrementedWhenTaskThrows: the consumer's afterRecordComplete()
     // unparks the consumer thread when backpressure is held (§11 LockSupport park/unpark). If
     // onComplete fired twice on the throw path (e.g. once in a catch and once in finally), the
     // consumer would re-evaluate twice per failed record — wasteful but tolerable. If it fired
@@ -243,8 +243,8 @@ class ParallelDispatcherTest {
     Thread.sleep(100);
     assertEquals(1, completeCount.get(), "onComplete must fire exactly once when task throws");
     final var deadline = System.nanoTime() + Duration.ofSeconds(2).toNanos();
-    while (dispatcher.pendingCount() > 0 && System.nanoTime() < deadline) Thread.sleep(5);
-    assertEquals(0, dispatcher.pendingCount(), "in-flight must drain to 0 after throwing task");
+    while (dispatcher.activeCount() > 0 && System.nanoTime() < deadline) Thread.sleep(5);
+    assertEquals(0, dispatcher.activeCount(), "in-flight must drain to 0 after throwing task");
     dispatcher.close();
   }
 
@@ -252,7 +252,7 @@ class ParallelDispatcherTest {
   void dispatchAfterCloseHitsRejectHandler() throws InterruptedException {
     // Explicit pin for the post-close rejection path. closeShutsDownExecutorEvenWithNoDispatches
     // already exercises the reject handler via a never-dispatched dispatcher; this test adds the
-    // stronger contract: the task body itself MUST NOT execute on rejection, and pendingCount()
+    // stronger contract: the task body itself MUST NOT execute on rejection, and activeCount()
     // must roll back from the speculative increment in dispatch(). If the increment were not
     // rolled back, every shutdown-race rejection would leak a count, and shutdownGracefully()
     // would burn its full timeout waiting on a ghost.
@@ -272,7 +272,7 @@ class ParallelDispatcherTest {
       onCompleteRan.get(),
       "rejected dispatch must NOT invoke onComplete (the consumer takes the reject path instead)"
     );
-    assertEquals(0, dispatcher.pendingCount(), "rejected dispatch must roll back the speculative increment");
+    assertEquals(0, dispatcher.activeCount(), "rejected dispatch must roll back the speculative increment");
   }
 
   @Test
@@ -281,8 +281,8 @@ class ParallelDispatcherTest {
     // shut-down mid-flight while N dispatcher threads call dispatch() concurrently. Each
     // dispatch ends in one of two terminal accounting states — task started + finally drained,
     // OR rejected + counter rolled back. There is no third "leaked" state. The invariant: after
-    // all dispatcher threads return and close() has completed, pendingCount() must drain to 0,
-    // AND (started + rejected) must equal total. A leak shows up either as a non-zero pendingCount
+    // all dispatcher threads return and close() has completed, activeCount() must drain to 0,
+    // AND (started + rejected) must equal total. A leak shows up either as a non-zero activeCount
     // (decrement missing) or as a started + rejected != total mismatch (silent drop).
     final var rejectCount = new AtomicInteger(0);
     final var dispatcher = newDispatcher(rejectCount, Duration.ofSeconds(2));
@@ -322,8 +322,8 @@ class ParallelDispatcherTest {
     assertTrue(closeReturned.await(10, TimeUnit.SECONDS), "close() must return");
 
     final var deadline = System.nanoTime() + Duration.ofSeconds(5).toNanos();
-    while (dispatcher.pendingCount() > 0 && System.nanoTime() < deadline) Thread.sleep(10);
-    assertEquals(0, dispatcher.pendingCount(), "pendingCount must drain to 0 after concurrent dispatch+close");
+    while (dispatcher.activeCount() > 0 && System.nanoTime() < deadline) Thread.sleep(10);
+    assertEquals(0, dispatcher.activeCount(), "activeCount must drain to 0 after concurrent dispatch+close");
     assertEquals(
       totalDispatches,
       started.get() + rejectCount.get(),
@@ -332,7 +332,7 @@ class ParallelDispatcherTest {
   }
 
   @Test
-  void pendingCountDrainsToZeroWhenCloseInterruptsRunningTask() throws InterruptedException {
+  void activeCountDrainsToZeroWhenCloseInterruptsRunningTask() throws InterruptedException {
     // close() calls shutdownNow() when awaitTermination times out. The concern: an interrupted
     // task never runs its finally, leaving inFlight stuck > 0. That's a real risk for a POOLED
     // executor (shutdownNow returns queued-unstarted tasks), but ParallelDispatcher uses
@@ -358,12 +358,12 @@ class ParallelDispatcherTest {
       () -> {}
     );
     assertTrue(started.await(2, TimeUnit.SECONDS), "task must start");
-    assertEquals(1, dispatcher.pendingCount(), "one task in flight before close");
+    assertEquals(1, dispatcher.activeCount(), "one task in flight before close");
 
     dispatcher.close(); // awaitTermination(50ms) times out → shutdownNow() interrupts the sleep
 
     final var deadline = System.nanoTime() + Duration.ofSeconds(5).toNanos();
-    while (dispatcher.pendingCount() > 0 && System.nanoTime() < deadline) Thread.sleep(5);
-    assertEquals(0, dispatcher.pendingCount(), "interrupted task's finally must still decrement in-flight");
+    while (dispatcher.activeCount() > 0 && System.nanoTime() < deadline) Thread.sleep(5);
+    assertEquals(0, dispatcher.activeCount(), "interrupted task's finally must still decrement in-flight");
   }
 }

--- a/lib/kpipe-consumer/src/test/java/io/github/eschizoid/kpipe/consumer/SequentialDispatcherTest.java
+++ b/lib/kpipe-consumer/src/test/java/io/github/eschizoid/kpipe/consumer/SequentialDispatcherTest.java
@@ -20,21 +20,21 @@ class SequentialDispatcherTest {
   }
 
   @Test
-  void pendingCountIsZeroWhenIdle() {
+  void activeCountIsZeroWhenIdle() {
     final var dispatcher = new SequentialDispatcher();
-    assertEquals(0L, dispatcher.pendingCount());
+    assertEquals(0L, dispatcher.activeCount());
     dispatcher.close();
   }
 
   @Test
-  void pendingCountReadsOneWhileProcessingThenZero() throws InterruptedException {
+  void activeCountReadsOneWhileProcessingThenZero() throws InterruptedException {
     final var dispatcher = new SequentialDispatcher();
     final var insideTask = new CountDownLatch(1);
     final var allowFinish = new CountDownLatch(1);
     final var observed = new AtomicLong(-1);
 
     // SequentialDispatcher.dispatch is synchronous on the calling thread, so we have to run
-    // it on a separate thread to observe pendingCount mid-flight.
+    // it on a separate thread to observe activeCount mid-flight.
     final var worker = Thread.ofVirtual().start(() ->
       dispatcher.dispatch(
         record(0),
@@ -51,12 +51,12 @@ class SequentialDispatcherTest {
     );
 
     assertTrue(insideTask.await(2, TimeUnit.SECONDS), "task should start");
-    observed.set(dispatcher.pendingCount());
+    observed.set(dispatcher.activeCount());
     allowFinish.countDown();
     worker.join(2_000);
 
-    assertEquals(1L, observed.get(), "pendingCount must report 1 while processing");
-    assertEquals(0L, dispatcher.pendingCount(), "pendingCount must drop to 0 after task returns");
+    assertEquals(1L, observed.get(), "activeCount must report 1 while processing");
+    assertEquals(0L, dispatcher.activeCount(), "activeCount must drop to 0 after task returns");
     dispatcher.close();
   }
 
@@ -78,7 +78,7 @@ class SequentialDispatcherTest {
     }
 
     assertEquals(1L, completed.get(), "onComplete must fire even when task throws");
-    assertEquals(0L, dispatcher.pendingCount(), "pendingCount must drop to 0 even when task throws");
+    assertEquals(0L, dispatcher.activeCount(), "activeCount must drop to 0 even when task throws");
     dispatcher.close();
   }
 
@@ -109,6 +109,6 @@ class SequentialDispatcherTest {
 
     assertEquals(1L, ran.get(), "processTask must still run inline after close()");
     assertEquals(1L, completed.get(), "onComplete must still fire after close()");
-    assertEquals(0L, dispatcher.pendingCount(), "in-flight must drain to 0 after the inline run");
+    assertEquals(0L, dispatcher.activeCount(), "in-flight must drain to 0 after the inline run");
   }
 }

--- a/lib/kpipe-consumer/src/test/java/io/github/eschizoid/kpipe/consumer/WatermarkHysteresisTest.java
+++ b/lib/kpipe-consumer/src/test/java/io/github/eschizoid/kpipe/consumer/WatermarkHysteresisTest.java
@@ -292,7 +292,7 @@ class WatermarkHysteresisTest {
   @Nested
   class InFlightIncludesBufferedBatchRecords {
 
-    /// The consumer composes its in-flight metric as `dispatcher.pendingCount() + Σ buffered
+    /// The consumer composes its in-flight metric as `dispatcher.activeCount() + Σ buffered
     /// batch records`. A controller wired to that composite supplier must see buffered records
     /// as real pressure: a dispatcher that has drained to zero can still keep the consumer
     /// paused if enough records are sitting in batch buffers. This models that composite supplier


### PR DESCRIPTION
The optional clarity item from the pass-2 backlog. "Pending" overloaded two concepts: the dispatcher's count of records **actively running/queued in a worker** (what `waitForInFlightDrain` waits on) vs the offset-side "pending" (`PendingOffsetSet`, `PartitionState.pendingCount`, `CommitCoordinator.pendingCount` — offsets/commits not yet resolved).

Renames the **Dispatcher family only**: sealed interface + 3 impls + KPipeConsumer call sites/docs + dispatcher-focused tests (incl. method names) + the jcstress class (`DispatcherPendingCountJCStressTest` → `DispatcherActiveCountJCStressTest`). The offset-side names are deliberately untouched — they correctly mean "pending". `totalInFlight() = dispatcher.activeCount() + Σ bufferedCount()` now reads unambiguously.

Internal-only (`Dispatcher` is package-private sealed) — §16 n/a. Dispatcher/Watermark suites green; two `ContainerLaunchException` failures in the full local run are local-Docker exhaustion, unrelated (CI validates).