### PR TITLE
fix: pre-release hardening — verified findings from the adversarial 4-lens audit

### DIFF
--- a/lib/kpipe-api/src/main/java/io/github/eschizoid/kpipe/DefaultStream.java
+++ b/lib/kpipe-api/src/main/java/io/github/eschizoid/kpipe/DefaultStream.java
@@ -191,7 +191,7 @@ record DefaultStream<T>(
   @Override
   public Stream<T> skipBytes(final int n) {
     if (n < 0) throw new IllegalArgumentException("n cannot be negative");
-    if (n > 0 && isRegistryBacked(format)) throw new IllegalArgumentException(
+    if (n > 0 && format.isSchemaRegistryBacked()) throw new IllegalArgumentException(
       "skipBytes(" + n + ") cannot be combined with a Schema-Registry-backed format: the format " +
         "reads the Confluent wire envelope itself, and stripping bytes first would corrupt every " +
         "record. Drop the skipBytes(...) call."
@@ -210,15 +210,6 @@ record DefaultStream<T>(
     @SuppressWarnings("unchecked")
     final var newFormat = (MessageFormat<T>) registryBackedFormat(format, resolver);
     return mutate(m -> m.format = newFormat);
-  }
-
-  /// True when `format` is an Avro/Protobuf codec operating in Schema-Registry mode (per-record
-  /// envelope read). Detected via the formats' public mode accessors — both return their static
-  /// schema/descriptor, which is null exactly in registry mode.
-  private static boolean isRegistryBacked(final MessageFormat<?> format) {
-    if (format instanceof AvroFormat avro) return avro.schema() == null;
-    if (format instanceof ProtobufFormat proto) return proto.descriptor() == null;
-    return false;
   }
 
   /// Returns a registry-backed variant of `format` for any format that supports per-record schema

--- a/lib/kpipe-api/src/main/java/io/github/eschizoid/kpipe/DefaultStream.java
+++ b/lib/kpipe-api/src/main/java/io/github/eschizoid/kpipe/DefaultStream.java
@@ -191,15 +191,34 @@ record DefaultStream<T>(
   @Override
   public Stream<T> skipBytes(final int n) {
     if (n < 0) throw new IllegalArgumentException("n cannot be negative");
+    if (n > 0 && isRegistryBacked(format)) throw new IllegalArgumentException(
+      "skipBytes(" + n + ") cannot be combined with a Schema-Registry-backed format: the format " +
+        "reads the Confluent wire envelope itself, and stripping bytes first would corrupt every " +
+        "record. Drop the skipBytes(...) call."
+    );
     return mutate(m -> m.skipBytes = n);
   }
 
   @Override
   public Stream<T> withSchemaRegistry(final SchemaResolver resolver) {
     Objects.requireNonNull(resolver, "resolver cannot be null");
+    if (skipBytes > 0) throw new IllegalArgumentException(
+      "withSchemaRegistry(...) cannot be combined with skipBytes(" + skipBytes + "): the " +
+        "registry-backed format reads the Confluent wire envelope itself, and stripping bytes " +
+        "first would corrupt every record. Drop the skipBytes(...) call."
+    );
     @SuppressWarnings("unchecked")
     final var newFormat = (MessageFormat<T>) registryBackedFormat(format, resolver);
     return mutate(m -> m.format = newFormat);
+  }
+
+  /// True when `format` is an Avro/Protobuf codec operating in Schema-Registry mode (per-record
+  /// envelope read). Detected via the formats' public mode accessors — both return their static
+  /// schema/descriptor, which is null exactly in registry mode.
+  private static boolean isRegistryBacked(final MessageFormat<?> format) {
+    if (format instanceof AvroFormat avro) return avro.schema() == null;
+    if (format instanceof ProtobufFormat proto) return proto.descriptor() == null;
+    return false;
   }
 
   /// Returns a registry-backed variant of `format` for any format that supports per-record schema

--- a/lib/kpipe-api/src/main/java/io/github/eschizoid/kpipe/Stream.java
+++ b/lib/kpipe-api/src/main/java/io/github/eschizoid/kpipe/Stream.java
@@ -204,6 +204,10 @@ public interface Stream<T> {
   /// returns `Failed`. The observer is for visibility — it does **not** suppress the failure or
   /// stop the failure from reaching retry / DLQ / `withErrorHandler` logic.
   ///
+  /// Fires on **every** failing pipeline invocation — including each retry attempt, so a record
+  /// that exhausts `withRetry(2, ...)` invokes this observer three times. For exactly one callback
+  /// per record after retries are exhausted, use `withErrorHandler(...)` instead.
+  ///
   /// Runs on the consumer thread immediately after the pipeline returns `Failed`. If the
   /// observer throws, the exception is logged at WARNING and swallowed. Calling this method more
   /// than once replaces the previous observer.

--- a/lib/kpipe-api/src/test/java/io/github/eschizoid/kpipe/WithSchemaRegistryDispatchTest.java
+++ b/lib/kpipe-api/src/test/java/io/github/eschizoid/kpipe/WithSchemaRegistryDispatchTest.java
@@ -7,6 +7,7 @@ import com.google.protobuf.DescriptorProtos.DescriptorProto;
 import com.google.protobuf.DescriptorProtos.FileDescriptorProto;
 import com.google.protobuf.Descriptors.DescriptorValidationException;
 import com.google.protobuf.Descriptors.FileDescriptor;
+import io.github.eschizoid.kpipe.format.avro.AvroFormat;
 import io.github.eschizoid.kpipe.format.protobuf.ProtobufFormat;
 import io.github.eschizoid.kpipe.registry.SchemaResolver;
 import java.util.Properties;
@@ -60,5 +61,24 @@ class WithSchemaRegistryDispatchTest {
       ex.getMessage().contains("not supported"),
       "expected the unsupported-format message, got: " + ex.getMessage()
     );
+  }
+
+  @Test
+  void skipBytesAfterRegistryEntryPointIsRejected() {
+    // KPipe.avro(topic, props, resolver) constructs a registry-backed format directly; a
+    // subsequent skipBytes would strip the envelope the format itself reads.
+    final var stream = KPipe.avro("t", props(), (SchemaResolver) id -> "{}");
+    final var ex = assertThrows(IllegalArgumentException.class, () -> stream.skipBytes(5));
+    assertTrue(ex.getMessage().contains("Schema-Registry"), ex.getMessage());
+  }
+
+  @Test
+  void withSchemaRegistryAfterSkipBytesIsRejected() {
+    final var staticAvro = AvroFormat.of(
+      "{\"type\":\"record\",\"name\":\"R\",\"fields\":[{\"name\":\"f\",\"type\":\"string\"}]}"
+    );
+    final var stream = KPipe.avro("t", props(), staticAvro).skipBytes(5);
+    final var ex = assertThrows(IllegalArgumentException.class, () -> stream.withSchemaRegistry(RESOLVER));
+    assertTrue(ex.getMessage().contains("skipBytes"), ex.getMessage());
   }
 }

--- a/lib/kpipe-consumer/src/main/java/io/github/eschizoid/kpipe/consumer/BatchPipelineWrapper.java
+++ b/lib/kpipe-consumer/src/main/java/io/github/eschizoid/kpipe/consumer/BatchPipelineWrapper.java
@@ -222,24 +222,49 @@ final class BatchPipelineWrapper<T> implements AutoCloseable {
 
     for (int i = 0; i < size; i++) {
       final var record = snapshot.get(i).record();
-      if (succeeded.get(i)) {
-        callbacks.markProcessed(record);
-        continue;
+      // Per-iteration guard: a throwing callback (a custom OffsetManager in markProcessed, or a
+      // buggy hook) must not abort the loop and strand the REMAINING records with no outcome at
+      // all — every record in the batch gets its callback attempt. The failing record's own
+      // outcome is lost (logged at ERROR); its offset stays unmarked, so it is reprocessed rather
+      // than dropped.
+      try {
+        if (succeeded.get(i)) {
+          callbacks.markProcessed(record);
+          continue;
+        }
+        final var perRecordCause = result.failedByIndex().get(i);
+        callbacks.onBatchFailure(
+          record,
+          perRecordCause != null
+            ? perRecordCause
+            : (coverageViolation != null
+                ? coverageViolation
+                : new IllegalStateException("BatchSink contract violation at index " + i + " for topic " + topic))
+        );
+      } catch (final Exception callbackEx) {
+        LOGGER.log(
+          Level.ERROR,
+          "Batch outcome callback threw for offset " + record.offset() + " on topic " + topic +
+            "; continuing with the remaining records (offset stays unmarked, record will be reprocessed)",
+          callbackEx
+        );
       }
-      final var perRecordCause = result.failedByIndex().get(i);
-      callbacks.onBatchFailure(
-        record,
-        perRecordCause != null
-          ? perRecordCause
-          : (coverageViolation != null
-              ? coverageViolation
-              : new IllegalStateException("BatchSink contract violation at index " + i + " for topic " + topic))
-      );
     }
   }
 
   private void failAll(final List<Entry<T>> snapshot, final Exception cause) {
-    for (final var entry : snapshot) callbacks.onBatchFailure(entry.record(), cause);
+    for (final var entry : snapshot) {
+      try {
+        callbacks.onBatchFailure(entry.record(), cause);
+      } catch (final Exception callbackEx) {
+        LOGGER.log(
+          Level.ERROR,
+          "Batch failure callback threw for offset " + entry.record().offset() + " on topic " + topic +
+            "; continuing with the remaining records",
+          callbackEx
+        );
+      }
+    }
   }
 
   private void logOutOfRange(final String kind, final Integer index, final int batchSize) {

--- a/lib/kpipe-consumer/src/main/java/io/github/eschizoid/kpipe/consumer/BatchPipelineWrapper.java
+++ b/lib/kpipe-consumer/src/main/java/io/github/eschizoid/kpipe/consumer/BatchPipelineWrapper.java
@@ -242,6 +242,7 @@ final class BatchPipelineWrapper<T> implements AutoCloseable {
                 : new IllegalStateException("BatchSink contract violation at index " + i + " for topic " + topic))
         );
       } catch (final Exception callbackEx) {
+        if (callbackEx instanceof InterruptedException) Thread.currentThread().interrupt();
         LOGGER.log(
           Level.ERROR,
           "Batch outcome callback threw for offset " + record.offset() + " on topic " + topic +
@@ -257,6 +258,7 @@ final class BatchPipelineWrapper<T> implements AutoCloseable {
       try {
         callbacks.onBatchFailure(entry.record(), cause);
       } catch (final Exception callbackEx) {
+        if (callbackEx instanceof InterruptedException) Thread.currentThread().interrupt();
         LOGGER.log(
           Level.ERROR,
           "Batch failure callback threw for offset " + entry.record().offset() + " on topic " + topic +

--- a/lib/kpipe-consumer/src/main/java/io/github/eschizoid/kpipe/consumer/ConsumerHealthController.java
+++ b/lib/kpipe-consumer/src/main/java/io/github/eschizoid/kpipe/consumer/ConsumerHealthController.java
@@ -360,7 +360,12 @@ final class ConsumerHealthController {
       // Shutdown race: the scheduler is already closed. Propagating would crash the worker that
       // recorded the outcome; the breaker stays OPEN, which is moot on a dying consumer. Log so a
       // non-shutdown rejection (misconfigured shared scheduler) is still visible.
-      LOGGER.log(Level.WARNING, "Could not schedule the circuit-breaker probe (scheduler shut down?)", e);
+      LOGGER.log(
+        Level.WARNING,
+        "Could not schedule the circuit-breaker probe — if this is not a shutdown, the breaker " +
+          "stays OPEN and the consumer remains paused until restart",
+        e
+      );
     }
   }
 

--- a/lib/kpipe-consumer/src/main/java/io/github/eschizoid/kpipe/consumer/ConsumerHealthController.java
+++ b/lib/kpipe-consumer/src/main/java/io/github/eschizoid/kpipe/consumer/ConsumerHealthController.java
@@ -4,6 +4,7 @@ import java.lang.System.Logger;
 import java.lang.System.Logger.Level;
 import java.util.EnumSet;
 import java.util.Set;
+import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
@@ -349,11 +350,18 @@ final class ConsumerHealthController {
     if (requestPause(Source.CIRCUIT_BREAKER)) pauseHook.onPause();
     final var existing = cbProbeFuture;
     if (existing != null) existing.cancel(false);
-    cbProbeFuture = scheduler.schedule(
-      this::tryHalfOpen,
-      cbController.openDuration().toMillis(),
-      TimeUnit.MILLISECONDS
-    );
+    try {
+      cbProbeFuture = scheduler.schedule(
+        this::tryHalfOpen,
+        cbController.openDuration().toMillis(),
+        TimeUnit.MILLISECONDS
+      );
+    } catch (final RejectedExecutionException e) {
+      // Shutdown race: the scheduler is already closed. Propagating would crash the worker that
+      // recorded the outcome; the breaker stays OPEN, which is moot on a dying consumer. Log so a
+      // non-shutdown rejection (misconfigured shared scheduler) is still visible.
+      LOGGER.log(Level.WARNING, "Could not schedule the circuit-breaker probe (scheduler shut down?)", e);
+    }
   }
 
   /// One-shot probe-timer callback. CAS OPEN → HALF_OPEN and fire the resume callback; the next

--- a/lib/kpipe-consumer/src/main/java/io/github/eschizoid/kpipe/consumer/GuardedConsumerMetrics.java
+++ b/lib/kpipe-consumer/src/main/java/io/github/eschizoid/kpipe/consumer/GuardedConsumerMetrics.java
@@ -1,0 +1,155 @@
+package io.github.eschizoid.kpipe.consumer;
+
+import io.github.eschizoid.kpipe.metrics.ConsumerMetrics;
+import java.lang.System.Logger;
+import java.lang.System.Logger.Level;
+
+/// Wraps a user-supplied [ConsumerMetrics] so a throwing implementation can never crash the
+/// consumer. The rule that every user callback is guarded (tracer, error handler) previously had
+/// one unguarded exception: the ~dozen `otelMetrics.*` call sites, where a throwing metrics
+/// implementation could crash a worker mid-error-handling or abort a batch-flush callback loop.
+/// Guarding once here — at construction — protects every call site at once instead of try/catching
+/// each of them.
+///
+/// Failures are logged at WARNING with the failing method name and then swallowed; metrics are
+/// observability, never worth a record.
+final class GuardedConsumerMetrics implements ConsumerMetrics {
+
+  private static final Logger LOGGER = System.getLogger(GuardedConsumerMetrics.class.getName());
+
+  private final ConsumerMetrics delegate;
+
+  private GuardedConsumerMetrics(final ConsumerMetrics delegate) {
+    this.delegate = delegate;
+  }
+
+  /// Wraps `delegate`, or returns the no-op unchanged (nothing to guard, no extra indirection).
+  ///
+  /// @param delegate the user-supplied metrics, or null for none
+  /// @return a guard around `delegate`, or [ConsumerMetrics#noop] when null/noop
+  static ConsumerMetrics guard(final ConsumerMetrics delegate) {
+    if (delegate == null || delegate == ConsumerMetrics.noop()) return ConsumerMetrics.noop();
+    return new GuardedConsumerMetrics(delegate);
+  }
+
+  @Override
+  public void recordMessageReceived() {
+    try {
+      delegate.recordMessageReceived();
+    } catch (final Exception e) {
+      warn("recordMessageReceived", e);
+    }
+  }
+
+  @Override
+  public void recordMessageProcessed() {
+    try {
+      delegate.recordMessageProcessed();
+    } catch (final Exception e) {
+      warn("recordMessageProcessed", e);
+    }
+  }
+
+  @Override
+  public void recordProcessingError() {
+    try {
+      delegate.recordProcessingError();
+    } catch (final Exception e) {
+      warn("recordProcessingError", e);
+    }
+  }
+
+  @Override
+  public void recordProcessingDuration(final long millis) {
+    try {
+      delegate.recordProcessingDuration(millis);
+    } catch (final Exception e) {
+      warn("recordProcessingDuration", e);
+    }
+  }
+
+  @Override
+  public void recordBackpressurePause() {
+    try {
+      delegate.recordBackpressurePause();
+    } catch (final Exception e) {
+      warn("recordBackpressurePause", e);
+    }
+  }
+
+  @Override
+  public void recordBackpressureTime(final long millis) {
+    try {
+      delegate.recordBackpressureTime(millis);
+    } catch (final Exception e) {
+      warn("recordBackpressureTime", e);
+    }
+  }
+
+  @Override
+  public void recordMessageReceived(final String topic) {
+    try {
+      delegate.recordMessageReceived(topic);
+    } catch (final Exception e) {
+      warn("recordMessageReceived(topic)", e);
+    }
+  }
+
+  @Override
+  public void recordMessageProcessed(final String topic) {
+    try {
+      delegate.recordMessageProcessed(topic);
+    } catch (final Exception e) {
+      warn("recordMessageProcessed(topic)", e);
+    }
+  }
+
+  @Override
+  public void recordProcessingError(final String topic) {
+    try {
+      delegate.recordProcessingError(topic);
+    } catch (final Exception e) {
+      warn("recordProcessingError(topic)", e);
+    }
+  }
+
+  @Override
+  public void recordProcessingDuration(final String topic, final long millis) {
+    try {
+      delegate.recordProcessingDuration(topic, millis);
+    } catch (final Exception e) {
+      warn("recordProcessingDuration(topic)", e);
+    }
+  }
+
+  @Override
+  public void recordCircuitBreakerTrip() {
+    try {
+      delegate.recordCircuitBreakerTrip();
+    } catch (final Exception e) {
+      warn("recordCircuitBreakerTrip", e);
+    }
+  }
+
+  @Override
+  public void recordCircuitBreakerStateChange(final Enum<?> state) {
+    try {
+      delegate.recordCircuitBreakerStateChange(state);
+    } catch (final Exception e) {
+      warn("recordCircuitBreakerStateChange", e);
+    }
+  }
+
+  @Override
+  public void recordCircuitBreakerTimeOpen(final long millis) {
+    try {
+      delegate.recordCircuitBreakerTimeOpen(millis);
+    } catch (final Exception e) {
+      warn("recordCircuitBreakerTimeOpen", e);
+    }
+  }
+
+  private static void warn(final String method, final Exception e) {
+    LOGGER.log(Level.WARNING, "ConsumerMetrics." + method + " threw; swallowing (metrics must never crash records)", e);
+  }
+}

--- a/lib/kpipe-consumer/src/main/java/io/github/eschizoid/kpipe/consumer/KPipeConsumer.java
+++ b/lib/kpipe-consumer/src/main/java/io/github/eschizoid/kpipe/consumer/KPipeConsumer.java
@@ -311,7 +311,9 @@ public class KPipeConsumer implements AutoCloseable {
         )
       );
 
-      this.otelMetrics = builder.consumerMetrics != null ? builder.consumerMetrics : ConsumerMetrics.noop();
+      // Guarded once at the source: a throwing user metrics implementation must never crash a
+      // worker, abort a batch-flush callback loop, or alter an error-path outcome.
+      this.otelMetrics = GuardedConsumerMetrics.guard(builder.consumerMetrics);
 
       this.health = new ConsumerHealthController(
         bp,

--- a/lib/kpipe-consumer/src/main/java/io/github/eschizoid/kpipe/consumer/KPipeConsumerBuilder.java
+++ b/lib/kpipe-consumer/src/main/java/io/github/eschizoid/kpipe/consumer/KPipeConsumerBuilder.java
@@ -75,7 +75,13 @@ public final class KPipeConsumerBuilder {
   /// @param props The Kafka consumer properties
   /// @return This builder instance for method chaining
   public KPipeConsumerBuilder withProperties(final Properties props) {
-    this.kafkaProps = Objects.requireNonNull(props, "props cannot be null");
+    Objects.requireNonNull(props, "props cannot be null");
+    // Defensive clone: build() pins key.deserializer into these properties
+    // (forceByteArrayKeyDeserializer), and without a copy that mutation would leak into the
+    // caller's own Properties object — or, on the fluent path, into sibling streams sharing one
+    // internal copy. `(Properties) clone()`, never `new Properties(parent)` (that makes the
+    // parent a getProperty fallback, not a copy).
+    this.kafkaProps = (Properties) props.clone();
     return this;
   }
 

--- a/lib/kpipe-consumer/src/test/java/io/github/eschizoid/kpipe/consumer/HardeningGuardsTest.java
+++ b/lib/kpipe-consumer/src/test/java/io/github/eschizoid/kpipe/consumer/HardeningGuardsTest.java
@@ -131,6 +131,10 @@ class HardeningGuardsTest {
   @SuppressWarnings("unchecked")
   void buildDoesNotMutateTheCallersProperties() {
     final var callerProps = byteProperties();
+    // Seed a DIVERGENT key.deserializer: the pin would overwrite it, so if build() still mutated
+    // the caller's object this assertion flips. (With the default ByteArray value the mutation
+    // writes an identical value and the test can't see it.)
+    callerProps.put("key.deserializer", "org.apache.kafka.common.serialization.StringDeserializer");
     final var before = (Properties) callerProps.clone();
     try (
       final var consumer = KPipeConsumer.builder()

--- a/lib/kpipe-consumer/src/test/java/io/github/eschizoid/kpipe/consumer/HardeningGuardsTest.java
+++ b/lib/kpipe-consumer/src/test/java/io/github/eschizoid/kpipe/consumer/HardeningGuardsTest.java
@@ -1,0 +1,217 @@
+package io.github.eschizoid.kpipe.consumer;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import io.github.eschizoid.kpipe.metrics.ConsumerMetrics;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.List;
+import java.util.Properties;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CopyOnWriteArrayList;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.clients.producer.Producer;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.clients.producer.RecordMetadata;
+import org.apache.kafka.common.header.internals.RecordHeader;
+import org.apache.kafka.common.header.internals.RecordHeaders;
+import org.apache.kafka.common.record.TimestampType;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+/// Pins the pre-release hardening guards: a throwing user [ConsumerMetrics] must never crash a
+/// record's processing, and the DLQ record must carry the original record's headers plus the
+/// source-timestamp envelope header so operators can correlate and replay.
+class HardeningGuardsTest {
+
+  private static final String TOPIC = "hardening-topic";
+
+  /// A user metrics implementation where EVERY callback throws. The guard wraps it at
+  /// construction, so records must still process, mark, and count normally.
+  private static final class ThrowingMetrics implements ConsumerMetrics {
+
+    @Override
+    public void recordMessageReceived() {
+      throw new RuntimeException("metrics bug");
+    }
+
+    @Override
+    public void recordMessageProcessed() {
+      throw new RuntimeException("metrics bug");
+    }
+
+    @Override
+    public void recordProcessingError() {
+      throw new RuntimeException("metrics bug");
+    }
+
+    @Override
+    public void recordProcessingDuration(final long millis) {
+      throw new RuntimeException("metrics bug");
+    }
+
+    @Override
+    public void recordBackpressurePause() {
+      throw new RuntimeException("metrics bug");
+    }
+
+    @Override
+    public void recordBackpressureTime(final long millis) {
+      throw new RuntimeException("metrics bug");
+    }
+  }
+
+  @Test
+  void throwingUserMetricsMustNotCrashProcessingOrSkipOffsetMarking() {
+    final var marked = new CopyOnWriteArrayList<Long>();
+    final var offsetManager = new OffsetManager() {
+      @Override
+      public OffsetManager start() {
+        return this;
+      }
+
+      @Override
+      public OffsetManager stop() {
+        return this;
+      }
+
+      @Override
+      public void trackOffset(final ConsumerRecord<byte[], byte[]> record) {}
+
+      @Override
+      public void markOffsetProcessed(final ConsumerRecord<byte[], byte[]> record) {
+        marked.add(record.offset());
+      }
+
+      @Override
+      public void notifyCommitComplete(final String commitId, final boolean success) {}
+
+      @Override
+      public OffsetState getState() {
+        return OffsetState.RUNNING;
+      }
+
+      @Override
+      public boolean isRunning() {
+        return true;
+      }
+
+      @Override
+      public OffsetStatistics getStatistics() {
+        return OffsetStatistics.empty();
+      }
+
+      @Override
+      public void close() {}
+    };
+
+    try (
+      final var consumer = KPipeConsumer.builder()
+        .withProperties(byteProperties())
+        .withTopic(TOPIC)
+        .withPipeline(TestPipelines.sideEffect(v -> v))
+        .withMetrics(new ThrowingMetrics())
+        .withOffsetManager(offsetManager)
+        .build()
+    ) {
+      final var record = new ConsumerRecord<>(TOPIC, 0, 5L, "k".getBytes(UTF_8), "v".getBytes(UTF_8));
+      assertDoesNotThrow(() -> consumer.processRecord(record), "a throwing metrics impl must be swallowed");
+      assertTrue(marked.contains(5L), "the record must still be marked processed");
+      assertEquals(1L, consumer.getMetrics().get("messagesProcessed"), "internal counters unaffected");
+    }
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  void buildDoesNotMutateTheCallersProperties() {
+    final var callerProps = byteProperties();
+    final var before = (Properties) callerProps.clone();
+    try (
+      final var consumer = KPipeConsumer.builder()
+        .withProperties(callerProps)
+        .withTopic(TOPIC)
+        .withPipeline(TestPipelines.sideEffect(v -> v))
+        .build()
+    ) {
+      assertEquals(
+        before,
+        callerProps,
+        "build() must not mutate the caller's Properties (the key.deserializer pin lands on an internal clone)"
+      );
+    }
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  void dlqRecordCarriesOriginalHeadersAndSourceTimestamp() throws Exception {
+    final var producer = (Producer<byte[], byte[]>) mock(Producer.class);
+    final var captor = ArgumentCaptor.forClass(ProducerRecord.class);
+    when(producer.send(captor.capture())).thenReturn(CompletableFuture.completedFuture(mock(RecordMetadata.class)));
+
+    final var originalHeaders = new RecordHeaders(
+      List.of(new RecordHeader("correlationId", "req-123".getBytes(UTF_8)))
+    );
+    final var record = new ConsumerRecord<>(
+      TOPIC,
+      0,
+      7L,
+      1234567890L,
+      TimestampType.CREATE_TIME,
+      -1,
+      -1,
+      "k".getBytes(UTF_8),
+      "v".getBytes(StandardCharsets.UTF_8),
+      originalHeaders,
+      java.util.Optional.empty()
+    );
+
+    try (
+      final var consumer = KPipeConsumer.builder()
+        .withProperties(byteProperties())
+        .withTopic(TOPIC)
+        .withPipeline(
+          TestPipelines.sideEffect(_ -> {
+            throw new RuntimeException("always fails");
+          })
+        )
+        .withRetry(0, Duration.ofMillis(1))
+        .withDeadLetterTopic("dlq")
+        .withKafkaProducer(producer)
+        .build()
+    ) {
+      consumer.processRecord(record);
+    }
+
+    final var dlqRecord = captor.getValue();
+    assertEquals(
+      "req-123",
+      new String(dlqRecord.headers().lastHeader("correlationId").value(), UTF_8),
+      "original headers must survive into the DLQ record"
+    );
+    assertEquals(
+      "1234567890",
+      new String(dlqRecord.headers().lastHeader("x-dlq-source-timestamp").value(), UTF_8),
+      "the original event timestamp must travel in the envelope"
+    );
+    assertEquals(
+      String.valueOf(7L),
+      new String(dlqRecord.headers().lastHeader("x-dlq-source-offset").value(), UTF_8)
+    );
+  }
+
+  private static Properties byteProperties() {
+    final var p = new Properties();
+    p.put("bootstrap.servers", "localhost:9092");
+    p.put("group.id", "hardening-group");
+    p.put("key.deserializer", "org.apache.kafka.common.serialization.ByteArrayDeserializer");
+    p.put("value.deserializer", "org.apache.kafka.common.serialization.ByteArrayDeserializer");
+    p.put("enable.auto.commit", "false");
+    return p;
+  }
+}

--- a/lib/kpipe-consumer/src/test/java/io/github/eschizoid/kpipe/consumer/KPipeConsumerBuilderValidationTest.java
+++ b/lib/kpipe-consumer/src/test/java/io/github/eschizoid/kpipe/consumer/KPipeConsumerBuilderValidationTest.java
@@ -136,17 +136,17 @@ class KPipeConsumerBuilderValidationTest {
   private static Properties buildWithProps(final Properties props) {
     @SuppressWarnings("unchecked")
     final var pipeline = (MessagePipeline<String>) mock(MessagePipeline.class);
-    try (
-      final var consumer = builder()
-        .withProperties(props)
-        .withTopic("t")
-        .withPipeline(pipeline)
-        .withConsumer(() -> mock(Consumer.class))
-        .build()
-    ) {
+    final var b = builder()
+      .withProperties(props)
+      .withTopic("t")
+      .withPipeline(pipeline)
+      .withConsumer(() -> mock(Consumer.class));
+    try (final var consumer = b.build()) {
       assertEquals(false, consumer == null);
     }
-    return props;
+    // The pin lands on the builder's internal defensive clone — never on the caller's Properties
+    // (HardeningGuardsTest.buildDoesNotMutateTheCallersProperties pins that). Inspect the clone.
+    return b.kafkaProps;
   }
 
   @Test

--- a/lib/kpipe-core/src/main/java/io/github/eschizoid/kpipe/registry/MessageFormat.java
+++ b/lib/kpipe-core/src/main/java/io/github/eschizoid/kpipe/registry/MessageFormat.java
@@ -30,6 +30,15 @@ public interface MessageFormat<T> {
     return BytesFormat.INSTANCE;
   }
 
+  /// True when this codec resolves schemas per record from a Schema Registry (reading the wire
+  /// envelope itself). The facade uses this to reject `skipBytes(...)`, which would strip the
+  /// envelope the codec needs. Default false — only registry-mode codecs override.
+  ///
+  /// @return whether this codec reads a Schema-Registry wire envelope per record
+  default boolean isSchemaRegistryBacked() {
+    return false;
+  }
+
   /// Serializes the given data to a byte array.
   ///
   /// @param data The data to serialize

--- a/lib/kpipe-format-avro/src/main/java/io/github/eschizoid/kpipe/format/avro/AvroFormat.java
+++ b/lib/kpipe-format-avro/src/main/java/io/github/eschizoid/kpipe/format/avro/AvroFormat.java
@@ -93,6 +93,11 @@ public final class AvroFormat implements MessageFormat<GenericRecord> {
 
   /// Returns the schema this codec is bound to in static mode.
   ///
+  @Override
+  public boolean isSchemaRegistryBacked() {
+    return resolver != null;
+  }
+
   /// @return the bound schema in static mode; null in Schema-Registry mode
   public Schema schema() {
     return staticSchema;

--- a/lib/kpipe-format-protobuf/src/main/java/io/github/eschizoid/kpipe/format/protobuf/ProtobufFormat.java
+++ b/lib/kpipe-format-protobuf/src/main/java/io/github/eschizoid/kpipe/format/protobuf/ProtobufFormat.java
@@ -112,6 +112,11 @@ public final class ProtobufFormat implements MessageFormat<Message> {
     return new ProtobufFormat(resolver, compiler);
   }
 
+  @Override
+  public boolean isSchemaRegistryBacked() {
+    return resolver != null;
+  }
+
   /// Returns the descriptor this codec is bound to.
   ///
   /// @return the bound descriptor in static mode; `null` in Schema-Registry mode (each record's

--- a/lib/kpipe-producer/src/main/java/io/github/eschizoid/kpipe/producer/GuardedProducerMetrics.java
+++ b/lib/kpipe-producer/src/main/java/io/github/eschizoid/kpipe/producer/GuardedProducerMetrics.java
@@ -1,0 +1,72 @@
+package io.github.eschizoid.kpipe.producer;
+
+import io.github.eschizoid.kpipe.metrics.ProducerMetrics;
+import java.lang.System.Logger;
+import java.lang.System.Logger.Level;
+
+/// Wraps a user-supplied [ProducerMetrics] so a throwing implementation can never corrupt send
+/// semantics. Unguarded, a metrics implementation that threw on `recordMessageSent()` would turn a
+/// SUCCESSFUL send into a thrown "send failed" (the counter call sits after the broker ack), and a
+/// throwing `recordDlqSent()` would make a successful DLQ park report as a DLQ failure — a user
+/// observability callback must never change data-path outcomes.
+///
+/// Failures are logged at WARNING and swallowed; metrics are observability, never worth a record.
+final class GuardedProducerMetrics implements ProducerMetrics {
+
+  private static final Logger LOGGER = System.getLogger(GuardedProducerMetrics.class.getName());
+
+  private final ProducerMetrics delegate;
+
+  private GuardedProducerMetrics(final ProducerMetrics delegate) {
+    this.delegate = delegate;
+  }
+
+  /// Wraps `delegate`, or returns the no-op unchanged (nothing to guard, no extra indirection).
+  ///
+  /// @param delegate the user-supplied metrics, or null for none
+  /// @return a guard around `delegate`, or [ProducerMetrics#noop] when null/noop
+  static ProducerMetrics guard(final ProducerMetrics delegate) {
+    if (delegate == null || delegate == ProducerMetrics.noop()) return ProducerMetrics.noop();
+    return new GuardedProducerMetrics(delegate);
+  }
+
+  @Override
+  public void recordMessageSent() {
+    try {
+      delegate.recordMessageSent();
+    } catch (final Exception e) {
+      warn("recordMessageSent", e);
+    }
+  }
+
+  @Override
+  public void recordMessageFailed() {
+    try {
+      delegate.recordMessageFailed();
+    } catch (final Exception e) {
+      warn("recordMessageFailed", e);
+    }
+  }
+
+  @Override
+  public void recordDlqSent() {
+    try {
+      delegate.recordDlqSent();
+    } catch (final Exception e) {
+      warn("recordDlqSent", e);
+    }
+  }
+
+  @Override
+  public void recordDlqFailed() {
+    try {
+      delegate.recordDlqFailed();
+    } catch (final Exception e) {
+      warn("recordDlqFailed", e);
+    }
+  }
+
+  private static void warn(final String method, final Exception e) {
+    LOGGER.log(Level.WARNING, "ProducerMetrics." + method + " threw; swallowing (metrics must never affect sends)", e);
+  }
+}

--- a/lib/kpipe-producer/src/main/java/io/github/eschizoid/kpipe/producer/KPipeProducer.java
+++ b/lib/kpipe-producer/src/main/java/io/github/eschizoid/kpipe/producer/KPipeProducer.java
@@ -43,7 +43,9 @@ public class KPipeProducer<K, V> implements AutoCloseable {
   ) {
     this.producer = Objects.requireNonNull(producer, "Producer cannot be null");
     this.ownProducer = ownProducer;
-    this.metrics = metrics != null ? metrics : ProducerMetrics.noop();
+    // Guarded once at the source: a throwing user metrics implementation must never turn a
+    // successful send/DLQ-park into a reported failure.
+    this.metrics = GuardedProducerMetrics.guard(metrics);
     this.tracer = tracer != null ? tracer : Tracer.noop();
   }
 
@@ -157,6 +159,11 @@ public class KPipeProducer<K, V> implements AutoCloseable {
   /// @param record      the original consumer record that failed
   /// @param sourceTopic the original source topic name
   /// @param exception   the exception that caused the processing failure
+  /// The DLQ record carries the original key, value, and ALL original headers, plus the
+  /// `x-dlq-*` envelope (exception class/message, source topic/partition/offset/timestamp) and the
+  /// current trace context. Original and envelope headers coexist; read `x-dlq-*` keys by last
+  /// occurrence if a source header happens to share a name.
+  ///
   /// @return true if the record was successfully sent to the DLQ, false otherwise (DLQ disabled or
   ///         send failed). Callers can use the return value to update their own counters or
   ///         trigger fallback handling.
@@ -169,6 +176,14 @@ public class KPipeProducer<K, V> implements AutoCloseable {
     if (dlqTopic == null) return false;
 
     final var producerRecord = new ProducerRecord<>(dlqTopic, record.key(), record.value());
+    // Preserve the ORIGINAL record's headers first (correlation ids, tenant markers — whatever the
+    // producer attached): an operator replaying from the DLQ needs them, and dropping them made
+    // DLQ records unrecoverable for root-cause analysis. The x-dlq-* envelope is appended after,
+    // so both coexist (Kafka headers allow duplicate keys; DLQ consumers should read x-dlq-* by
+    // last occurrence).
+    for (final var header : record.headers()) {
+      producerRecord.headers().add(header);
+    }
     producerRecord.headers().add("x-dlq-exception-class", exception.getClass().getName().getBytes());
     producerRecord
       .headers()
@@ -176,6 +191,9 @@ public class KPipeProducer<K, V> implements AutoCloseable {
     producerRecord.headers().add("x-dlq-source-topic", sourceTopic.getBytes());
     producerRecord.headers().add("x-dlq-source-partition", String.valueOf(record.partition()).getBytes());
     producerRecord.headers().add("x-dlq-source-offset", String.valueOf(record.offset()).getBytes());
+    // The DLQ record's own Kafka timestamp is the (meaningful) park time; the original event time
+    // travels as a header so replay tooling can restore it.
+    producerRecord.headers().add("x-dlq-source-timestamp", String.valueOf(record.timestamp()).getBytes());
 
     // Inject the current trace context (e.g. W3C `traceparent`) so DLQ subscribers can continue
     // the trace. Guarded — a misbehaving tracer must not break the error path.
@@ -201,6 +219,10 @@ public class KPipeProducer<K, V> implements AutoCloseable {
   ///
   /// When called from a virtual thread this is highly efficient — blocking on the future
   /// parks the virtual thread without pinning its carrier thread.
+  ///
+  /// The blocking wait is bounded by the producer's own `delivery.timeout.ms` (default 2 minutes):
+  /// the Kafka client fails the returned future after that, so this call cannot park forever even
+  /// against a hung broker. Tune that producer property to tighten or relax the bound.
   ///
   /// @param record the record to send
   /// @return the metadata for the record that was sent

--- a/lib/kpipe-producer/src/main/java/io/github/eschizoid/kpipe/producer/KPipeProducer.java
+++ b/lib/kpipe-producer/src/main/java/io/github/eschizoid/kpipe/producer/KPipeProducer.java
@@ -154,16 +154,16 @@ public class KPipeProducer<K, V> implements AutoCloseable {
   /// ensure reliability in the error path — when called from a virtual thread this does not block
   /// the underlying carrier thread.
   ///
-  /// @param dlqTopic    the name of the dead-letter topic; if null this method is a no-op and
-  ///                    returns false
-  /// @param record      the original consumer record that failed
-  /// @param sourceTopic the original source topic name
-  /// @param exception   the exception that caused the processing failure
   /// The DLQ record carries the original key, value, and ALL original headers, plus the
   /// `x-dlq-*` envelope (exception class/message, source topic/partition/offset/timestamp) and the
   /// current trace context. Original and envelope headers coexist; read `x-dlq-*` keys by last
   /// occurrence if a source header happens to share a name.
   ///
+  /// @param dlqTopic    the name of the dead-letter topic; if null this method is a no-op and
+  ///                    returns false
+  /// @param record      the original consumer record that failed
+  /// @param sourceTopic the original source topic name
+  /// @param exception   the exception that caused the processing failure
   /// @return true if the record was successfully sent to the DLQ, false otherwise (DLQ disabled or
   ///         send failed). Callers can use the return value to update their own counters or
   ///         trigger fallback handling.


### PR DESCRIPTION
The pre-1.18 hard audit (4 adversarial lenses, every claim hand-verified — ~60% refutation rate) produced these surviving findings, all fixed here:

1. **Builder `Properties` defensive clone** — `build()` pins `key.deserializer` INTO the supplied Properties; the mutation leaked into the caller's own object (explicit path) or the sibling-shared copy (fluent path). Two existing tests were unknowingly pinning the leak — repointed at the internal clone; a new test asserts caller props stay untouched.
2. **`GuardedConsumerMetrics` / `GuardedProducerMetrics`** — tracer + error-handler were guarded everywhere, but ~12 consumer + 4 producer metrics call sites weren't: a throwing user metrics impl could crash a worker, abort a batch-flush loop, or turn a successful send/DLQ-park into a reported failure. One decorator at construction guards every site.
3. **Batch flush loop per-iteration guard** — a throwing outcome callback (e.g. custom OffsetManager) no longer strands the remaining records' outcomes.
4. **CB trip `scheduler.schedule` guard** — shutdown-race `RejectedExecutionException` no longer crashes the recording worker.
5. **DLQ record fidelity** — original headers preserved (were dropped — DLQ records were unrecoverable for correlation/replay) + `x-dlq-source-timestamp`; envelope contract documented.
6. **`skipBytes` × Schema-Registry build-time validation, both orders** — was documented-only; misconfig previously surfaced as cryptic decode errors.
7. **Javadoc accuracy** — `send()` documents the `delivery.timeout.ms` bound (refuting the audit's "blocks forever"); `onFailed` documents per-attempt firing.

**Refuted audit claims (not fixed, recorded in PLAN):** cardinality bomb (no Pattern subscription exists), send-forever (client bounds the future), README Builder refs (already migrated), message-index over-allocation (guard exists), shaded-jar attribution (7 LICENSE/NOTICE entries verified in the jar).

Tests: `HardeningGuardsTest` + 2 facade validation tests. consumer+producer+api suites green incl. Testcontainers.