### PR TITLE
docs(readme): KEY_ORDERED metrics prose reflects the v2 dispatcher + broker verify

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,10 +56,14 @@ than extrapolated.
 
 For the same per-key-FIFO guarantee, KPipe `KEY_ORDERED` runs **4× Confluent PC `KEY` at 10ms and 5.4× at 100ms**,
 reproduced on both machines. In the sub-millisecond regime that comparison is box-dependent and we say so: 1.42× on
-the 4-vCPU CI runner, 0.83× on the 12-thread local box, where lock contention in the key-ordered dispatcher becomes
-visible (striped-lock experiment on the backlog). KPipe `PARALLEL` at 1ms holds the lead on both boxes (8.1× CPC
-`UNORDERED` locally, ~2× on CI). Full tables, error bars, and every caveat:
-[`benchmarks/results/2026-07-21.md`](benchmarks/results/2026-07-21.md), captured per the
+the 4-vCPU CI runner, 0.86× on the 12-thread local box. The dispatcher's global lock was the prime suspect and has
+since been eliminated (v2: `ConcurrentHashMap` + per-queue monitors — **+122% at high key cardinality** in the
+isolated dispatch benchmark, and the dispatcher now scales up with cores instead of down), but the broker-level
+sub-ms cell didn't move: at 1ms of real work the budget is dominated by fetch, deserialization, and offset tracking,
+not dispatch — measured and recorded in
+[`benchmarks/results/2026-07-21-keyordered-dispatch-ab.md`](benchmarks/results/2026-07-21-keyordered-dispatch-ab.md).
+KPipe `PARALLEL` at 1ms holds the lead on both boxes (8.1× CPC `UNORDERED` locally, ~2× on CI). Full tables, error
+bars, and every caveat: [`benchmarks/results/2026-07-21.md`](benchmarks/results/2026-07-21.md), captured per the
 [methodology](benchmarks/METHODOLOGY.md).
 
 The only faster arm in the capture is the hand-rolled `KafkaConsumer` + virtual-threads loop (458k at 10ms) — and it

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -59,7 +59,7 @@ ingest tens of thousands of externally-measured timestamp pairs. Producer stamps
 | Bench                        | Arm / `@Benchmark` | `@Param` sweep                                                | What it isolates                                                                                            |
 | ---------------------------- | ------------------ | ------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------- |
 | `BatchSinkLatencyBenchmark`  | `run`              | `sinkLatencyMicros ∈ {10,100,1000}`, `batchSize ∈ {1,10,100}` | The `Stream.toBatch(...)` amortisation when the destination has a per-call cost (`batchSize=1` is the control). |
-| `KeyOrderedDispatchBenchmark`| `dispatch`         | `mode ∈ {PARALLEL, KEY_ORDERED}`, key cardinality `{1,100,10000}` | The single-`ReentrantLock` cost of the `KEY_ORDERED` dispatcher vs `PARALLEL` (the striped-locking baseline). |
+| `KeyOrderedDispatchBenchmark`| `dispatch`         | `mode ∈ {PARALLEL, KEY_ORDERED}`, key cardinality `{1,100,10000}` | Dispatcher overhead of `KEY_ORDERED` vs `PARALLEL`. Arbitrated the v2 rewrite (CHM + per-queue monitors, +122% at 10k keys — `results/2026-07-21-keyordered-dispatch-ab.md`); stays the gate for future dispatcher work. |
 | `OffsetManagerBoxingBenchmark`| `trackAndMark`    | partitions `{8}`                                              | Allocation/boxing cost on the offset-tracking hot path.                                                     |
 
 ## Running benchmarks


### PR DESCRIPTION
Docs-only. The main README's sub-ms caveat still attributed the 12-thread-box deficit to dispatcher lock contention and promised a "striped-lock experiment on the backlog" — that experiment has since run (#278, #279): the lock is gone, the isolated dispatch bench improved +122%, and the broker-level sub-ms cell measured flat (0.83×→0.86×, within noise). Both READMEs now state the measured outcome and link `results/2026-07-21-keyordered-dispatch-ab.md` instead of promising completed work. The benchmarks README's bench-table row similarly described the bench as measuring "the single-ReentrantLock cost" — updated to the v2 framing.