### PR TITLE
docs: README refactor follow-up — review-round hardening (#283)

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ implementation("io.github.eschizoid:kpipe-api")
 implementation("io.github.eschizoid:kpipe-format-json")   // or -avro / -protobuf — formats are opt-in
 ```
 
-`kpipe-api` brings the consumer, producer, and core modules transitively; its only external runtime dependency is
+`kpipe-api` brings the consumer, producer, core, and metrics modules transitively; its only external runtime dependency is
 `kafka-clients`. Maven snippets, the full module catalog, `platform` vs `enforcedPlatform`, and JPMS
 (`module-info.java`) guidance: [docs/MODULES.md](docs/MODULES.md).
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -2,7 +2,7 @@
 
 The fluent surface, grouped by the type each method actually lives on. Chain shape:
 `KPipe.<format>(...)` → `Stream<T>` (build the pipeline) → terminal → `Sink<T>` → `start()` → `Handle` (lifecycle).
-This catalog is verified against the source of `kpipe-api` 1.18.0; the
+This catalog is verified against the `kpipe-api` source; the
 [Javadoc](https://javadoc.io/doc/io.github.eschizoid/kpipe-api) is the normative reference.
 
 Code snippets on this page use placeholder values (`kafkaProps`, `enrich`, `mySink`, ...) — they show shape, not a

--- a/docs/GUARANTEES.md
+++ b/docs/GUARANTEES.md
@@ -1,7 +1,7 @@
 # Delivery and ordering guarantees
 
 What KPipe guarantees, the exact boundary of each guarantee, and the failure matrix. Everything on this page is
-verified against `kpipe-consumer` 1.18.0 source; the machine-checkable invariants (jcstress + property suites) are
+verified against the `kpipe-consumer` source; the machine-checkable invariants (jcstress + property suites) are
 written down in [OFFSET-INVARIANTS.md](OFFSET-INVARIANTS.md).
 
 ## The headline guarantee

--- a/docs/MODULES.md
+++ b/docs/MODULES.md
@@ -77,7 +77,7 @@ kpipe-core, kpipe-metrics          — roots, no kpipe dependencies
 kpipe-producer                     → core, metrics
 kpipe-consumer                     → core, producer (metrics transitively)
 kpipe-format-{json,avro,protobuf}  → core
-kpipe-api                          → consumer + producer; format modules are compile-only (requires static)
+kpipe-api                          → core, consumer, producer; format modules are compile-only (requires static)
 kpipe-metrics-otel                 → metrics
 kpipe-tracing-otel                 → producer
 kpipe-schema-registry-confluent    → core

--- a/scripts/check-docs.sh
+++ b/scripts/check-docs.sh
@@ -30,8 +30,10 @@ for f in README.md docs/*.md benchmarks/README.md; do
 done
 
 # --- 2. one version string everywhere ------------------------------------------------------
-versions=$(grep -rhoE 'io\.github\.eschizoid:kpipe[a-z-]*:[0-9]+\.[0-9]+\.[0-9]+' README.md docs/MODULES.md \
-  | sed -E 's/.*:([0-9]+\.[0-9]+\.[0-9]+)$/\1/' | sort -u)
+versions=$( (grep -rhoE 'io\.github\.eschizoid:kpipe[a-z-]*:[0-9]+\.[0-9]+\.[0-9]+' README.md docs/MODULES.md \
+  | sed -E 's/.*:([0-9]+\.[0-9]+\.[0-9]+)$/\1/'; \
+  grep -rhoE '<version>[0-9]+\.[0-9]+\.[0-9]+</version>' README.md docs/MODULES.md \
+  | sed -E 's/<\/?version>//g') | sort -u)
 count=$(echo "$versions" | grep -c . || true)
 if [ "$count" -gt 1 ]; then
   echo "VERSION DRIFT: multiple kpipe versions referenced in docs: $(echo "$versions" | tr '\n' ' ')"
@@ -45,6 +47,7 @@ if [ -z "$snippet" ]; then
   echo "QUICKSTART CHECK: no java block found in README.md"
   fail=1
 else
+  # README -> class: every README code line must exist in the compiled class
   while IFS= read -r line; do
     trimmed=$(echo "$line" | sed -E 's/^[[:space:]]+//; s/[[:space:]]+$//')
     [ -z "$trimmed" ] && continue
@@ -53,6 +56,20 @@ else
       fail=1
     fi
   done <<< "$snippet"
+  # class -> README: every code line of the class (minus /// docs and the private ctor)
+  # must appear in the README block, so the class cannot silently gain behavior the
+  # README does not show
+  while IFS= read -r line; do
+    trimmed=$(echo "$line" | sed -E 's/^[[:space:]]+//; s/[[:space:]]+$//')
+    [ -z "$trimmed" ] && continue
+    case "$trimmed" in
+      ///*|"private ReadmeQuickstart"*) continue ;;
+    esac
+    if ! printf '%s\n' "$snippet" | grep -qF "$trimmed"; then
+      echo "QUICKSTART DRIFT: $quickstart line not in README: $trimmed"
+      fail=1
+    fi
+  done < "$quickstart"
 fi
 
 if [ "$fail" -ne 0 ]; then


### PR DESCRIPTION
Closing commit of the #283 refactor: the post-merge consistency review found **no blockers** (all 7 docs cross-check, every anchor resolves, numbers agree) plus two guard gaps and two nits, all fixed here:

- **check-docs.sh quickstart check is now bidirectional** — the compiled class gaining lines the README lacks now fails CI (negative-tested in this PR's development), matching the README's "cannot drift" promise.
- **Version check covers the Maven `<version>` tag form**; the hardcoded version in API.md/GUARANTEES.md prose is removed outright — fewer places to half-bump.
- **MODULES.md diagram**: `kpipe-api` arrow gains `core` (matches `module-info`); README/MODULES transitive-wording harmonized.