### PR TITLE
docs+core: observer-thread javadoc fix, BatchResult overlap contract, README when-to-use

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,12 +7,12 @@
 [![JVM 25+](https://img.shields.io/badge/JVM-25%2B-brightgreen.svg?&logo=openjdk)](https://openjdk.org/projects/jdk/25/)
 [![Build](https://github.com/eschizoid/kpipe/actions/workflows/ci.yaml/badge.svg)](https://github.com/eschizoid/kpipe/actions/workflows/ci.yaml)
 [![Codecov](https://codecov.io/gh/eschizoid/kpipe/graph/badge.svg?token=X50GBU4X7J)](https://codecov.io/gh/eschizoid/kpipe)
-[![Maven Central](https://img.shields.io/maven-central/v/io.github.eschizoid/kpipe-consumer.svg?label=Maven%20Central)](https://central.sonatype.com/artifact/io.github.eschizoid/kpipe-consumer)
+[![Maven Central](https://img.shields.io/maven-central/v/io.github.eschizoid/kpipe-api.svg?label=Maven%20Central)](https://central.sonatype.com/artifact/io.github.eschizoid/kpipe-api)
 [![Javadoc](https://javadoc.io/badge2/io.github.eschizoid/kpipe-api/javadoc.svg?color=purple)](https://javadoc.io/doc/io.github.eschizoid/kpipe-api)
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 
-A Kafka consumer library for Java 25+: one virtual thread per record, a typed pipeline API, and at-least-once
-delivery with parallel processing.
+KPipe is a plain-JVM Kafka consumer runtime for Java 25+: one virtual thread per record, a typed pipeline API, and
+at-least-once delivery that still holds while records run in parallel.
 
 KPipe replaces the hand-rolled `Consumer.poll` loop that most Kafka services grow around their business logic. You
 declare a pipeline — deserialize, transform, sink — and KPipe runs it with:
@@ -31,6 +31,10 @@ declare a pipeline — deserialize, transform, sink — and KPipe runs it with:
   "intentionally skipped" and "broken" cannot be confused, in code or in metrics.
 - **The operational stack as configuration.** Retries, dead-letter routing, backpressure, a circuit breaker, metrics,
   and W3C trace propagation are fluent calls, not code you write.
+
+Use it when you are building a transform, enrich, validate, route, or write-to-database consumer and the hard part is
+coordinating parallel I/O with commits. Reach for Kafka Streams instead when you need joins, windows, state stores, or
+exactly-once processing.
 
 ## Thirty-second example
 

--- a/lib/kpipe-api/src/main/java/io/github/eschizoid/kpipe/Stream.java
+++ b/lib/kpipe-api/src/main/java/io/github/eschizoid/kpipe/Stream.java
@@ -190,10 +190,11 @@ public interface Stream<T> {
   /// [#withDeadLetterTopic] for real failure routing; this is purely a hook for logging and
   /// metrics.
   ///
-  /// Runs on the consumer thread immediately after the pipeline returns `Filtered`. If the
-  /// observer throws, the exception is logged at WARNING and swallowed so observer bugs cannot
-  /// crash the pipeline. Calling this method more than once replaces the previous observer —
-  /// for fan-out, compose externally.
+  /// Runs on the same thread that processes the record: the consumer thread in `SEQUENTIAL`
+  /// mode, or a virtual worker thread in `PARALLEL` / `KEY_ORDERED` mode. If the observer
+  /// throws, the exception is logged at WARNING and swallowed so observer bugs cannot crash the
+  /// pipeline. Calling this method more than once replaces the previous observer — for fan-out,
+  /// compose externally.
   ///
   /// @param observer a side-effect invoked when a record is filtered (must not be null)
   /// @return a new stream with the observer attached
@@ -208,9 +209,10 @@ public interface Stream<T> {
   /// that exhausts `withRetry(2, ...)` invokes this observer three times. For exactly one callback
   /// per record after retries are exhausted, use `withErrorHandler(...)` instead.
   ///
-  /// Runs on the consumer thread immediately after the pipeline returns `Failed`. If the
-  /// observer throws, the exception is logged at WARNING and swallowed. Calling this method more
-  /// than once replaces the previous observer.
+  /// Runs on the same thread that processes the record: the consumer thread in `SEQUENTIAL`
+  /// mode, or a virtual worker thread in `PARALLEL` / `KEY_ORDERED` mode. If the observer
+  /// throws, the exception is logged at WARNING and swallowed. Calling this method more than
+  /// once replaces the previous observer.
   ///
   /// **Use this when "processed" counters look healthy but the sink is starved.** If
   /// `messagesProcessed` keeps rising while `sinkInvocationCount` stays at 0, the pipeline is
@@ -227,9 +229,10 @@ public interface Stream<T> {
   /// `Passed`, `Filtered`, or `Failed`. The lowest-level observer hook; use this for full
   /// pattern-matching diagnostic taps. Does **not** affect pipeline flow.
   ///
-  /// Runs on the consumer thread before any downstream sink invocation. If the observer throws,
-  /// the exception is logged at WARNING and swallowed. Calling this method more than once
-  /// replaces the previous observer.
+  /// Runs on the same thread that processes the record, before any downstream sink invocation:
+  /// the consumer thread in `SEQUENTIAL` mode, or a virtual worker thread in `PARALLEL` /
+  /// `KEY_ORDERED` mode. If the observer throws, the exception is logged at WARNING and
+  /// swallowed. Calling this method more than once replaces the previous observer.
   ///
   /// @param observer a side-effect invoked with every pipeline outcome (must not be null)
   /// @return a new stream with the observer attached

--- a/lib/kpipe-consumer/src/main/java/io/github/eschizoid/kpipe/consumer/BatchPipelineWrapper.java
+++ b/lib/kpipe-consumer/src/main/java/io/github/eschizoid/kpipe/consumer/BatchPipelineWrapper.java
@@ -192,7 +192,8 @@ final class BatchPipelineWrapper<T> implements AutoCloseable {
       if (i != null && i >= 0 && i < size) succeeded.set(i);
       else logOutOfRange("succeeded", i, size);
     }
-    for (final var i : result.failedByIndex().keySet()) {
+    final var failedByIndex = result.failedByIndex();
+    for (final var i : failedByIndex.keySet()) {
       if (i == null || i < 0 || i >= size) logOutOfRange("failed", i, size);
     }
 
@@ -201,12 +202,12 @@ final class BatchPipelineWrapper<T> implements AutoCloseable {
     // contract-violation path (rare); the common success path stays allocation-free.
     var missingCount = 0;
     for (int i = 0; i < size; i++) {
-      if (!succeeded.get(i) && !result.failedByIndex().containsKey(i)) missingCount++;
+      if (!succeeded.get(i) && !failedByIndex.containsKey(i)) missingCount++;
     }
     if (missingCount > 0) {
       final var missing = new ArrayList<Integer>(missingCount);
       for (int i = 0; i < size; i++) {
-        if (!succeeded.get(i) && !result.failedByIndex().containsKey(i)) missing.add(i);
+        if (!succeeded.get(i) && !failedByIndex.containsKey(i)) missing.add(i);
       }
       coverageViolation = new IllegalStateException(
         "BatchSink for topic " +
@@ -232,7 +233,7 @@ final class BatchPipelineWrapper<T> implements AutoCloseable {
           callbacks.markProcessed(record);
           continue;
         }
-        final var perRecordCause = result.failedByIndex().get(i);
+        final var perRecordCause = failedByIndex.get(i);
         callbacks.onBatchFailure(
           record,
           perRecordCause != null

--- a/lib/kpipe-consumer/src/test/java/io/github/eschizoid/kpipe/consumer/BatchCoverageContractInvariantTest.java
+++ b/lib/kpipe-consumer/src/test/java/io/github/eschizoid/kpipe/consumer/BatchCoverageContractInvariantTest.java
@@ -217,10 +217,10 @@ class BatchCoverageContractInvariantTest {
   }
 
   /// **Overlap precedence.** Index 1 appears in BOTH the succeeded list and the failure map. The
-  /// `BatchResult` Javadoc declares overlap "undefined," but the wrapper's behavior is
-  /// deterministic and worth pinning so a refactor can't silently flip it: the succeeded check is
-  /// consulted first, so an overlapping index is marked processed and its failure-map entry is
-  /// ignored. Coverage is still complete (no missing indexes), so no record hits the DLQ.
+  /// `BatchResult` defines overlap as success-wins. The wrapper's behavior is deterministic and
+  /// worth pinning so a refactor can't silently flip it: the succeeded check is consulted first, so
+  /// an overlapping index is marked processed and its failure-map entry is ignored. Coverage is
+  /// still complete (no missing indexes), so no record hits the DLQ.
   @Test
   void overlappingIndexIsMarkedProcessedSucceededWins() {
     final var topic = "inv-overlap";

--- a/lib/kpipe-core/src/main/java/io/github/eschizoid/kpipe/sink/BatchResult.java
+++ b/lib/kpipe-core/src/main/java/io/github/eschizoid/kpipe/sink/BatchResult.java
@@ -15,7 +15,9 @@ import java.util.Objects;
 /// position in the input batch (i.e. their disjoint union must be exactly `[0, batchSize)`). The
 /// `BatchPipelineWrapper` in `kpipe-consumer` enforces this — any indexes left unaccounted for
 /// are treated as failures and routed to the configured DLQ. Implementations should not return
-/// overlapping entries (an index appearing in both lists); behavior in that case is undefined.
+/// overlapping entries (an index appearing in both lists). If an overlap is returned, success
+/// wins and the failure entry for that index is ignored; callers should still avoid overlaps
+/// because they usually indicate ambiguous sink accounting.
 ///
 /// **Sentinel factories.** Use [#allSucceeded] and [#allFailed] for the trivial all-or-nothing
 /// outcomes — these are the natural results when a downstream system either confirms the whole


### PR DESCRIPTION
User-authored polish, verified and shipped:
- **Stream.java observer javadoc was factually wrong** — said observers run on the consumer thread; they run on the record's processing thread (worker VT in PARALLEL/KEY_ORDERED). Public-API doc fix.
- **BatchResult overlap: 'undefined' → documented success-wins contract** (the `overlappingIndexIsMarkedProcessedSucceededWins` invariant test already pins this behavior); wrapper hoists repeated `failedByIndex()` calls.
- README: Maven Central badge artifact now matches its link (kpipe-api); tighter tagline; when-to-use paragraph on the first screen.

check-docs green; invariant test + api/core compile green locally.