### PR TITLE
refactor(consumer): extract RecordProcessor; batch routes now honor withRetry

### DIFF
--- a/lib/kpipe-consumer/src/main/java/io/github/eschizoid/kpipe/consumer/KPipeConsumer.java
+++ b/lib/kpipe-consumer/src/main/java/io/github/eschizoid/kpipe/consumer/KPipeConsumer.java
@@ -1,15 +1,12 @@
 package io.github.eschizoid.kpipe.consumer;
 
 import io.github.eschizoid.kpipe.metrics.ConsumerMetricKeys;
-import io.github.eschizoid.kpipe.metrics.ConsumerMetrics;
 import io.github.eschizoid.kpipe.metrics.KPipeMetricsReporter;
 import io.github.eschizoid.kpipe.producer.KPipeProducer;
 import io.github.eschizoid.kpipe.producer.tracing.Tracer;
 import io.github.eschizoid.kpipe.registry.MessagePipeline;
-import io.github.eschizoid.kpipe.registry.Result;
 import java.lang.System.Logger;
 import java.lang.System.Logger.Level;
-import java.nio.channels.ClosedByInterruptException;
 import java.time.Duration;
 import java.util.*;
 import java.util.concurrent.*;
@@ -92,16 +89,12 @@ public class KPipeConsumer implements AutoCloseable {
   private final Queue<ConsumerCommand> commandQueue;
   private final Consumer<byte[], byte[]> kafkaConsumer;
   private final Set<String> topics;
-  private final Map<String, MessagePipeline<?>> pipelines;
   private final Duration pollTimeout;
   private final AtomicReference<Thread> consumerThread = new AtomicReference<>();
   private final Duration waitForMessagesTimeout;
   private final Duration threadTerminationTimeout;
   private final OffsetManager offsetManager;
   private final ConsumerRebalanceListener rebalanceListener;
-  private final ErrorHandler errorHandler;
-  private final int maxRetries;
-  private final Duration retryBackoff;
   private final AtomicReference<ConsumerState> state = new AtomicReference<>(ConsumerState.CREATED);
   /// Guards [#releaseConstructedResources] so it runs exactly once no matter which path ends
   /// the consumer: external `close()`, the never-started fast path, or the consumer thread
@@ -112,8 +105,6 @@ public class KPipeConsumer implements AutoCloseable {
   private final AtomicBoolean resourcesReleased = new AtomicBoolean(false);
   private final ProcessingMode processingMode;
   private final Map<String, AtomicLong> metrics = new ConcurrentHashMap<>();
-  private final ConsumerMetrics otelMetrics;
-  private final Tracer tracer;
   /// Owns the per-mode dispatch strategy and the in-flight counter for non-sequential modes.
   /// Constructed once in the consumer constructor from [#processingMode]; closed in `close()`
   /// before `offsetManager.close()` so any in-flight records get their offsets marked before
@@ -127,8 +118,12 @@ public class KPipeConsumer implements AutoCloseable {
   /// `internalResume`, and metric events through a HealthMetricsObserver bound to the counters.
   private final ConsumerHealthController health;
 
-  private final String deadLetterTopic;
   private final KPipeProducer<byte[], byte[]> kpipeProducer;
+
+  /// Per-record processing engine: deserialize → operators → sink → mark/DLQ, including the
+  /// retry loop, span handling, and the batch-route buffering. The consumer only tracks,
+  /// dispatches, and delegates; see [RecordProcessor] for the per-record semantics.
+  private final RecordProcessor recordProcessor;
 
   private final Map<String, BatchPipelineWrapper<?>> batchWrappers;
 
@@ -193,19 +188,17 @@ public class KPipeConsumer implements AutoCloseable {
       // `build()` sets `topics` to the UNION of regular + batch routes for Kafka subscription, so
       // the homogeneous branch must filter out batch-route topics to avoid replicating the regular
       // pipeline onto a topic that's owned by a batch wrapper.
+      final Map<String, MessagePipeline<?>> pipelines;
       if (builder.pipelinesPerTopic != null) {
-        this.pipelines = builder.pipelinesPerTopic;
+        pipelines = builder.pipelinesPerTopic;
       } else if (builder.pipeline != null) {
         final var map = new LinkedHashMap<String, MessagePipeline<?>>(builder.topics.size());
         for (final var t : builder.topics) if (!builder.batchSpecs.containsKey(t)) map.put(t, builder.pipeline);
-        this.pipelines = Map.copyOf(map);
+        pipelines = Map.copyOf(map);
       } else {
-        this.pipelines = Map.of();
+        pipelines = Map.of();
       }
       this.pollTimeout = Objects.requireNonNull(builder.pollTimeout);
-      this.errorHandler = builder.errorHandler;
-      this.maxRetries = builder.maxRetries;
-      this.retryBackoff = builder.retryBackoff;
       this.processingMode = builder.processingMode;
       this.waitForMessagesTimeout = builder.waitForMessagesTimeout;
       this.threadTerminationTimeout = builder.threadTerminationTimeout;
@@ -240,14 +233,14 @@ public class KPipeConsumer implements AutoCloseable {
           : BackpressureController.inFlightStrategy(this::totalInFlight)
       );
 
-      this.tracer = builder.tracer != null ? builder.tracer : Tracer.noop();
+      final var tracer = builder.tracer != null ? builder.tracer : Tracer.noop();
 
-      this.deadLetterTopic = builder.deadLetterTopic;
+      final var deadLetterTopic = builder.deadLetterTopic;
       this.kpipeProducer =
         builder.kpipeProducer != null
           ? builder.kpipeProducer
-          : this.deadLetterTopic != null
-            ? KPipeProducer.<byte[], byte[]>builder().withProperties(builder.kafkaProps).withTracer(this.tracer).build()
+          : deadLetterTopic != null
+            ? KPipeProducer.<byte[], byte[]>builder().withProperties(builder.kafkaProps).withTracer(tracer).build()
             : null;
 
       final var needScheduler = !builder.batchSpecs.isEmpty() || builder.circuitBreakerController != null;
@@ -259,16 +252,6 @@ public class KPipeConsumer implements AutoCloseable {
         });
       } else {
         this.scheduler = null;
-      }
-
-      if (!builder.batchSpecs.isEmpty()) {
-        final var wrappers = new LinkedHashMap<String, BatchPipelineWrapper<?>>(builder.batchSpecs.size());
-        for (final var entry : builder.batchSpecs.entrySet()) {
-          wrappers.put(entry.getKey(), createBatchWrapper(entry.getValue()));
-        }
-        this.batchWrappers = Map.copyOf(wrappers);
-      } else {
-        this.batchWrappers = Map.of();
       }
 
       this.metricsReporters = List.copyOf(builder.metricsReporters);
@@ -307,7 +290,7 @@ public class KPipeConsumer implements AutoCloseable {
 
       // Guarded once at the source: a throwing user metrics implementation must never crash a
       // worker, abort a batch-flush callback loop, or alter an error-path outcome.
-      this.otelMetrics = GuardedConsumerMetrics.guard(builder.consumerMetrics);
+      final var otelMetrics = GuardedConsumerMetrics.guard(builder.consumerMetrics);
 
       this.health = new ConsumerHealthController(
         bp,
@@ -355,6 +338,28 @@ public class KPipeConsumer implements AutoCloseable {
           }
         }
       );
+
+      // The processing engine owns the per-record unit (retries, span handling, DLQ-or-mark,
+      // batch buffering) and creates the batch wrappers so their flush callbacks live next to
+      // the per-record error path they mirror. The consumer keeps the wrapper map for
+      // start/drain/in-flight bookkeeping.
+      this.recordProcessor = new RecordProcessor(
+        pipelines,
+        builder.batchSpecs.values(),
+        this.scheduler,
+        this.offsetManager,
+        this.health,
+        otelMetrics,
+        this.metrics,
+        builder.errorHandler,
+        deadLetterTopic,
+        this.kpipeProducer,
+        tracer,
+        builder.maxRetries,
+        builder.retryBackoff,
+        this::isRunning
+      );
+      this.batchWrappers = recordProcessor.batchWrappers();
     } catch (final Throwable t) {
       closePartiallyConstructed(t);
       throw t;
@@ -423,70 +428,6 @@ public class KPipeConsumer implements AutoCloseable {
         original.addSuppressed(e);
       }
     }
-  }
-
-  private <T> BatchPipelineWrapper<T> createBatchWrapper(final KPipeConsumerBuilder.BatchSpec<T> spec) {
-    // Batch flushes call the OffsetManager directly rather than going through commandQueue. The
-    // queue exists to serialize Kafka-consumer calls (pause/resume/commitSync) on the consumer
-    // thread; OffsetManager.markOffsetProcessed is already thread-safe and avoiding the queue
-    // means the shutdown drain works even after the consumer thread has exited.
-    final var callbacks = new BatchPipelineWrapper.BatchCallbacks() {
-      @Override
-      public void markProcessed(final ConsumerRecord<byte[], byte[]> record) {
-        metrics.get(METRIC_MESSAGES_PROCESSED).incrementAndGet();
-        otelMetrics.recordMessageProcessed(record.topic());
-        // Feed the circuit breaker / health window so batch outcomes count toward the failure
-        // rate, exactly like the per-record path. Both branches must report, or the rolling
-        // window would see only failures and trip spuriously.
-        health.recordOutcome(true);
-        if (offsetManager != null) offsetManager.markOffsetProcessed(record);
-      }
-
-      @Override
-      public void onBatchFailure(final ConsumerRecord<byte[], byte[]> record, final Exception cause) {
-        metrics.get(METRIC_PROCESSING_ERRORS).incrementAndGet();
-        otelMetrics.recordProcessingError(record.topic());
-        health.recordOutcome(false);
-        LOGGER.log(Level.WARNING, () -> "Batch failure for record at offset " + record.offset(), cause);
-        // LOCKSTEP: mirror of the per-record path's DLQ-or-mark block in handleProcessingError
-        // —
-        // mark the offset only after a successful DLQ send; a failed send leaves it pending so
-        // the record is reprocessed, never dropped. Deliberately duplicated (the paths differ
-        // on
-        // span handling, retry counts, and circuit-breaker ordering — recordOutcome runs BEFORE
-        // this block here, AFTER it on the per-record path). Any change here must be mirrored
-        // there; DlqTerminalContractTest asserts both paths cell-for-cell and fails on drift.
-        if (deadLetterTopic != null && kpipeProducer != null) {
-          if (kpipeProducer.sendToDlq(deadLetterTopic, record, record.topic(), cause)) {
-            metrics.get(METRIC_DLQ_SENT).incrementAndGet();
-            if (offsetManager != null) offsetManager.markOffsetProcessed(record);
-          } else {
-            metrics.get(METRIC_DLQ_FAILED).incrementAndGet();
-            LOGGER.log(
-              Level.ERROR,
-              () ->
-                "DLQ delivery failed for batch record at offset " +
-                record.offset() +
-                "; offset NOT committed, record will be reprocessed on restart/rebalance"
-            );
-          }
-        } else if (offsetManager != null) {
-          offsetManager.markOffsetProcessed(record);
-        }
-        try {
-          errorHandler.accept(new ProcessingError(record, cause, 0));
-        } catch (final Exception ex) {
-          LOGGER.log(
-            Level.ERROR,
-            "Error handler threw on batch failure at offset {0}: {1}",
-            record.offset(),
-            ex.getMessage(),
-            ex
-          );
-        }
-      }
-    };
-    return new BatchPipelineWrapper<>(spec.topic(), spec.pipeline(), spec.sink(), spec.policy(), scheduler, callbacks);
   }
 
   /// Blocks until the dispatcher's in-flight records finish processing, or `timeout` elapses, or
@@ -1129,24 +1070,13 @@ public class KPipeConsumer implements AutoCloseable {
   }
 
   /// Surfaces a rejection from `ParallelDispatcher`'s executor (typically during shutdown)
-  /// back to the consumer's error path. Mirrors the prior inline behavior in `processRecords`.
+  /// back to the processing engine's error path. Kept as an instance method so the dispatcher
+  /// can be constructed (with a method reference) before the engine field is assigned.
   private void handleParallelRejection(
     final ConsumerRecord<byte[], byte[]> record,
     final RejectedExecutionException e
   ) {
-    if (!isRunning()) return;
-    LOGGER.log(Level.WARNING, "Task submission rejected during shutdown", e);
-    metrics.get(METRIC_PROCESSING_ERRORS).incrementAndGet();
-    otelMetrics.recordProcessingError(record.topic());
-    try {
-      errorHandler.accept(new ProcessingError(record, e, 0));
-    } catch (final Exception ex) {
-      LOGGER.log(
-        Level.ERROR,
-        () -> "Error handler threw while handling rejected task at offset " + record.offset(),
-        ex
-      );
-    }
+    recordProcessor.handleParallelRejection(record, e);
   }
 
   /// Runs after every record finishes (on whichever thread executed it). Unparks the consumer
@@ -1165,102 +1095,15 @@ public class KPipeConsumer implements AutoCloseable {
     }
   }
 
-  /// Processes a single Kafka consumer record using the topic's configured pipeline. Runs in the
-  /// current virtual thread; retries on exception according to `maxRetries` + `retryBackoff`. On
-  /// success the per-record outcome feeds the circuit-breaker window; on retry-exhausted failure
-  /// the record is routed to the DLQ (when configured) and the error handler is invoked.
-  ///
-  /// Metrics tracked during processing:
-  ///
-  /// * `messagesReceived` — incremented on entry
-  /// * `messagesProcessed` — incremented on success
-  /// * `processingDurationTotalMs` — incremented on success by the wall-clock duration
-  /// * `retries` — incremented per retry attempt (not the initial attempt)
-  /// * `processingErrors` — incremented when processing fails after all retries
+  /// Processes a single Kafka consumer record by delegating to the [RecordProcessor] engine:
+  /// the full deserialize → operators → sink → mark/DLQ unit, including retries per
+  /// `withRetry(maxRetries, backoff)` and tracing-span handling. Runs in the current
+  /// virtual thread. Kept on the consumer (and `protected`) as the per-record entry point for
+  /// the dispatcher and for tests that drive a single record without a poll loop.
   ///
   /// @param record the Kafka consumer record to process
   protected void processRecord(final ConsumerRecord<byte[], byte[]> record) {
-    metrics.get(METRIC_MESSAGES_RECEIVED).incrementAndGet();
-    otelMetrics.recordMessageReceived(record.topic());
-
-    Tracer.SpanScope span;
-    try {
-      span = tracer.startConsumerSpan(record);
-    } catch (final Exception traceEx) {
-      LOGGER.log(Level.WARNING, "Tracer.startConsumerSpan threw", traceEx);
-      span = Tracer.SpanScope.noop();
-    }
-
-    final long startTime = System.currentTimeMillis();
-    try {
-      final var result = tryProcessRecord(record, span);
-      if (result) {
-        final var durationMs = System.currentTimeMillis() - startTime;
-        metrics.get(METRIC_MESSAGES_PROCESSED).incrementAndGet();
-        metrics.get(METRIC_PROCESSING_DURATION_TOTAL_MS).addAndGet(durationMs);
-        otelMetrics.recordMessageProcessed(record.topic());
-        otelMetrics.recordProcessingDuration(record.topic(), durationMs);
-      }
-    } finally {
-      try {
-        span.close();
-      } catch (final Exception traceEx) {
-        LOGGER.log(Level.WARNING, "Tracer.SpanScope.close threw", traceEx);
-      }
-      // In-flight count + backpressure-unpark handled by the dispatcher's `onComplete`
-      // callback (`afterRecordComplete`). See `processRecords`.
-    }
-  }
-
-  private boolean tryProcessRecord(final ConsumerRecord<byte[], byte[]> record, final Tracer.SpanScope span) {
-    final var batchWrapper = batchWrappers.get(record.topic());
-    if (batchWrapper != null) return tryEnqueueBatchRecord(record, batchWrapper, span);
-    final var pipeline = pipelines.get(record.topic());
-    if (pipeline == null) {
-      LOGGER.log(
-        Level.WARNING,
-        "No pipeline registered for topic {0}; dropping record at offset {1}",
-        record.topic(),
-        record.offset()
-      );
-      markOffsetProcessed(record);
-      return false;
-    }
-    for (int attempt = 0; attempt <= maxRetries; attempt++) {
-      if (attempt > 0) {
-        metrics.get(METRIC_RETRIES).incrementAndGet();
-        LOGGER.log(
-          Level.DEBUG,
-          "Retrying message at offset {0} (attempt {1} of {2})",
-          record.offset(),
-          attempt,
-          maxRetries
-        );
-        try {
-          Thread.sleep(retryBackoff.toMillis());
-        } catch (final InterruptedException ie) {
-          Thread.currentThread().interrupt();
-          return false;
-        }
-      }
-
-      try {
-        driveSinkedPipeline(pipeline, record.value());
-        markOffsetProcessed(record);
-        health.recordOutcome(true);
-        return true;
-      } catch (final Exception e) {
-        if (isInterruptionRelated(e)) {
-          Thread.currentThread().interrupt();
-          return false;
-        }
-        if (attempt == maxRetries) {
-          handleProcessingError(record, e, attempt, span);
-          return false;
-        }
-      }
-    }
-    return false;
+    recordProcessor.process(record);
   }
 
   /// Returns the total number of records currently being tracked for backpressure: whatever
@@ -1273,140 +1116,6 @@ public class KPipeConsumer implements AutoCloseable {
     var total = dispatcher.activeCount();
     for (final var wrapper : batchWrappers.values()) total += wrapper.bufferedCount();
     return total;
-  }
-
-  private <T> boolean tryEnqueueBatchRecord(
-    final ConsumerRecord<byte[], byte[]> record,
-    final BatchPipelineWrapper<T> wrapper,
-    final Tracer.SpanScope span
-  ) {
-    try {
-      final var pipeline = wrapper.pipeline();
-      final var deserialized = pipeline.deserializeOrFail(record.value());
-      switch (pipeline.process(deserialized)) {
-        case Result.Passed<T> p -> {
-          wrapper.enqueue(record, p.value());
-          // Buffered: messagesProcessed will be incremented in the flush callback when the batch
-          // is committed to the user sink.
-          return false;
-        }
-        case Result.Filtered<T> _ -> {
-          // Intentional filter — mark processed immediately; nothing to buffer.
-          markOffsetProcessed(record);
-          return true;
-        }
-        case Result.Failed<T> f -> throw rethrowResultCause(f.cause());
-      }
-    } catch (final Exception e) {
-      if (isInterruptionRelated(e)) {
-        Thread.currentThread().interrupt();
-        return false;
-      }
-      handleProcessingError(record, e, 0, span);
-      return false;
-    }
-  }
-
-  /// Drive a pipeline (with erased element type) from raw bytes to its terminal sink. Throws if
-  /// the pipeline reports `Failed` so the calling retry/error path handles it the same way it
-  /// always did. Returns normally on `Passed` (after the sink runs) and on `Filtered`.
-  private static <T> void driveSinkedPipeline(final MessagePipeline<T> pipeline, final byte[] data) {
-    final var deserialized = pipeline.deserializeOrFail(data);
-    switch (pipeline.process(deserialized)) {
-      case Result.Passed<T> p -> {
-        final var sink = pipeline.getSink();
-        if (sink != null) sink.accept(p.value());
-      }
-      case Result.Filtered<T> _ -> {
-        /* intentional filter — no sink invocation */
-      }
-      case Result.Failed<T> f -> throw rethrowResultCause(f.cause());
-    }
-  }
-
-  /// Re-throw a captured `Result.Failed` cause as an unchecked exception so the retry/error path
-  /// can catch it. Mirrors the legacy MessagePipeline byte-level entry point behavior — it just
-  /// lives here now, where the catching happens, rather than buried in three duplicated unwrap
-  /// blocks inside MessagePipeline.
-  private static RuntimeException rethrowResultCause(final Throwable cause) {
-    if (cause instanceof RuntimeException re) return re;
-    if (cause instanceof Error err) throw err;
-    return new RuntimeException(cause);
-  }
-
-  private void markOffsetProcessed(final ConsumerRecord<byte[], byte[]> record) {
-    if (offsetManager != null) offsetManager.markOffsetProcessed(record);
-  }
-
-  private void handleProcessingError(
-    final ConsumerRecord<byte[], byte[]> record,
-    final Exception e,
-    final int retryCount,
-    final Tracer.SpanScope span
-  ) {
-    metrics.get(METRIC_PROCESSING_ERRORS).incrementAndGet();
-    otelMetrics.recordProcessingError(record.topic());
-    // Mark the span as errored. Guarded — a misbehaving tracer must never crash the consumer
-    // thread, leak in-flight counts, or skip offset marking.
-    try {
-      span.recordException(e);
-    } catch (final Exception traceEx) {
-      LOGGER.log(Level.WARNING, "Tracer.SpanScope.recordException threw", traceEx);
-    }
-    LOGGER.log(
-      Level.WARNING,
-      () -> "Failed to process message at offset " + record.offset() + " after " + (retryCount + 1) + " attempt(s)",
-      e
-    );
-    if (deadLetterTopic != null && kpipeProducer != null) {
-      // The offset advances only once the record reaches a durable terminal state: either the sink
-      // processed it (handled elsewhere) or it is safely parked in the DLQ. If the DLQ send fails
-      // the record is in neither place, so leave the offset pending — the commit point holds and
-      // the record is re-fetched (and the DLQ retried) on the next restart or partition
-      // reassignment. A down DLQ stalls the commit point rather than silently dropping data
-      // (the fetch position races ahead in-memory; this is a commit stall, not a pause).
-      //
-      // LOCKSTEP: this DLQ-or-mark block is deliberately duplicated in the batch wrapper's
-      // onBatchFailure callback — the two paths differ on span handling, retry counts, and
-      // circuit-breaker ordering (recordOutcome runs AFTER this block here, BEFORE it on the
-      // batch path), so a shared helper would blur those. Any change here must be mirrored
-      // there; DlqTerminalContractTest asserts both paths cell-for-cell and fails on drift.
-      if (kpipeProducer.sendToDlq(deadLetterTopic, record, record.topic(), e)) {
-        metrics.get(METRIC_DLQ_SENT).incrementAndGet();
-        markOffsetProcessed(record);
-      } else {
-        metrics.get(METRIC_DLQ_FAILED).incrementAndGet();
-        LOGGER.log(
-          Level.ERROR,
-          () ->
-            "DLQ delivery failed for record at offset " +
-            record.offset() +
-            "; offset NOT committed, record will be reprocessed on restart/rebalance"
-        );
-      }
-    } else {
-      // No DLQ configured: the caller opted into log-and-advance. Mark processed and move on.
-      markOffsetProcessed(record);
-    }
-    health.recordOutcome(false);
-    try {
-      errorHandler.accept(new ProcessingError(record, e, retryCount));
-    } catch (final Exception ex) {
-      LOGGER.log(
-        Level.ERROR,
-        "Error handler threw while handling failure at offset {0}: {1}",
-        record.offset(),
-        ex.getMessage(),
-        ex
-      );
-    }
-  }
-
-  private static boolean isInterruptionRelated(final Throwable error) {
-    for (Throwable current = error; current != null; current = current.getCause()) {
-      if (current instanceof InterruptedException || current instanceof ClosedByInterruptException) return true;
-    }
-    return false;
   }
 
   private ConsumerRecords<byte[], byte[]> pollRecords() {

--- a/lib/kpipe-consumer/src/main/java/io/github/eschizoid/kpipe/consumer/KPipeConsumerBuilder.java
+++ b/lib/kpipe-consumer/src/main/java/io/github/eschizoid/kpipe/consumer/KPipeConsumerBuilder.java
@@ -163,6 +163,12 @@ public final class KPipeConsumerBuilder {
   /// buffered records participate in the in-flight backpressure metric so a slow sink cannot
   /// let the buffer grow unbounded.
   ///
+  /// Retry interplay: [#withRetry] covers each record's deserialize + operator step before it
+  /// is buffered — a transiently failing operator gets the configured attempts, and only
+  /// retry-exhausted records go to the DLQ / error handler. The batch sink flush itself is
+  /// never retried; a flush failure is handled through the per-record
+  /// [io.github.eschizoid.kpipe.sink.BatchResult] outcomes and the DLQ path described above.
+  ///
   /// @param topic the Kafka topic
   /// @param pipeline the typed pipeline to deserialize+process raw bytes into `T`
   /// @param sink the batch sink invoked on each flush
@@ -205,7 +211,14 @@ public final class KPipeConsumerBuilder {
     return this;
   }
 
-  /// Configures retry behavior for failed message processing.
+  /// Configures retry behavior for failed message processing. The backoff is fixed (the same
+  /// delay before every retry); an interruption during processing or backoff aborts without
+  /// further attempts.
+  ///
+  /// On regular routes the retried unit is the record's full deserialize → operators → sink
+  /// pass. On batch routes ([#withBatchPipeline]) the retried unit is the record's
+  /// deserialize + operator step before buffering; the batch sink flush is not retried — a
+  /// flush failure is handled through the `BatchResult` / DLQ path, not this policy.
   ///
   /// @param maxRetries Maximum number of retry attempts
   /// @param backoff Duration to wait between retry attempts

--- a/lib/kpipe-consumer/src/main/java/io/github/eschizoid/kpipe/consumer/RecordProcessor.java
+++ b/lib/kpipe-consumer/src/main/java/io/github/eschizoid/kpipe/consumer/RecordProcessor.java
@@ -1,0 +1,476 @@
+package io.github.eschizoid.kpipe.consumer;
+
+import io.github.eschizoid.kpipe.metrics.ConsumerMetricKeys;
+import io.github.eschizoid.kpipe.metrics.ConsumerMetrics;
+import io.github.eschizoid.kpipe.producer.KPipeProducer;
+import io.github.eschizoid.kpipe.producer.tracing.Tracer;
+import io.github.eschizoid.kpipe.registry.MessagePipeline;
+import io.github.eschizoid.kpipe.registry.Result;
+import java.lang.System.Logger;
+import java.lang.System.Logger.Level;
+import java.nio.channels.ClosedByInterruptException;
+import java.time.Duration;
+import java.util.Collection;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.BooleanSupplier;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+
+/// Per-record processing engine extracted from [KPipeConsumer]: everything that happens to one
+/// record once a [Dispatcher] hands it a worker thread. Owns the full
+/// deserialize → operators → sink → mark/DLQ unit including the retry loop, tracing-span
+/// handling, the error/DLQ terminal paths, and the batch-route buffer plus its flush-callback
+/// wiring. The consumer keeps lifecycle, threads, the poll loop, the command pump, dispatch,
+/// and close orchestration.
+///
+/// The class holds no mutable state of its own — all fields are shared collaborators owned by
+/// the consumer (the metrics map, the offset manager, the health controller, the DLQ producer)
+/// — so [#process] is safe to invoke from any dispatcher worker thread.
+///
+/// Retry semantics are uniform across route shapes: both the regular per-record path and the
+/// batch route drive their deserialize + operator step through the same attempt loop
+/// ([#runWithRetries]). On the batch route only the pre-buffer step is retried; a successful
+/// attempt buffers the value exactly once, and the batch sink flush itself is never retried
+/// (flush failures take the `BatchResult` / DLQ path in the flush callbacks).
+final class RecordProcessor {
+
+  private static final Logger LOGGER = System.getLogger(RecordProcessor.class.getName());
+
+  // Aliases of the shared public key set (ConsumerMetricKeys) — the single source of truth also
+  // read by ConsumerMetricsReporter and the kpipe-test quiescence check. Never re-declare the
+  // literals here; aliasing keeps every call site short while making drift impossible.
+  private static final String METRIC_MESSAGES_RECEIVED = ConsumerMetricKeys.MESSAGES_RECEIVED;
+  private static final String METRIC_MESSAGES_PROCESSED = ConsumerMetricKeys.MESSAGES_PROCESSED;
+  private static final String METRIC_PROCESSING_ERRORS = ConsumerMetricKeys.PROCESSING_ERRORS;
+  private static final String METRIC_PROCESSING_DURATION_TOTAL_MS = ConsumerMetricKeys.PROCESSING_DURATION_TOTAL_MS;
+  private static final String METRIC_RETRIES = ConsumerMetricKeys.RETRIES;
+  private static final String METRIC_DLQ_SENT = ConsumerMetricKeys.DLQ_SENT;
+  private static final String METRIC_DLQ_FAILED = ConsumerMetricKeys.DLQ_FAILED;
+
+  private final Map<String, MessagePipeline<?>> pipelines;
+  private final Map<String, BatchPipelineWrapper<?>> batchWrappers;
+  private final OffsetManager offsetManager;
+  private final ConsumerHealthController health;
+  private final ConsumerMetrics otelMetrics;
+  private final Map<String, AtomicLong> metrics;
+  private final KPipeConsumer.ErrorHandler errorHandler;
+  private final String deadLetterTopic;
+  private final KPipeProducer<byte[], byte[]> kpipeProducer;
+  private final Tracer tracer;
+  private final int maxRetries;
+  private final Duration retryBackoff;
+  /// Snapshot of the owning consumer's running state, used only by [#handleParallelRejection]
+  /// to stay silent on rejections that are part of an orderly shutdown.
+  private final BooleanSupplier consumerActive;
+
+  /// One deserialize + process attempt for a record. Returns the record's terminal-success flag
+  /// (the same meaning as [#tryProcessRecord]'s return value); throws to request another
+  /// attempt from the surrounding retry loop.
+  @FunctionalInterface
+  private interface RecordAttempt {
+    boolean run(int attempt) throws Exception;
+  }
+
+  RecordProcessor(
+    final Map<String, MessagePipeline<?>> pipelines,
+    final Collection<KPipeConsumerBuilder.BatchSpec<?>> batchSpecs,
+    final ScheduledExecutorService scheduler,
+    final OffsetManager offsetManager,
+    final ConsumerHealthController health,
+    final ConsumerMetrics otelMetrics,
+    final Map<String, AtomicLong> metrics,
+    final KPipeConsumer.ErrorHandler errorHandler,
+    final String deadLetterTopic,
+    final KPipeProducer<byte[], byte[]> kpipeProducer,
+    final Tracer tracer,
+    final int maxRetries,
+    final Duration retryBackoff,
+    final BooleanSupplier consumerActive
+  ) {
+    this.pipelines = pipelines;
+    this.offsetManager = offsetManager;
+    this.health = health;
+    this.otelMetrics = otelMetrics;
+    this.metrics = metrics;
+    this.errorHandler = errorHandler;
+    this.deadLetterTopic = deadLetterTopic;
+    this.kpipeProducer = kpipeProducer;
+    this.tracer = tracer;
+    this.maxRetries = maxRetries;
+    this.retryBackoff = retryBackoff;
+    this.consumerActive = consumerActive;
+    if (batchSpecs.isEmpty()) {
+      this.batchWrappers = Map.of();
+    } else {
+      final var wrappers = new LinkedHashMap<String, BatchPipelineWrapper<?>>(batchSpecs.size());
+      for (final var spec : batchSpecs) wrappers.put(spec.topic(), createBatchWrapper(spec, scheduler));
+      this.batchWrappers = Map.copyOf(wrappers);
+    }
+  }
+
+  /// The per-topic batch wrappers this processor created from the builder's batch specs. The
+  /// owning consumer starts them in `start()`, drains them at teardown, and sums their
+  /// `bufferedCount()` into its in-flight total; the processor itself routes records into them
+  /// from [#tryEnqueueBatchRecord].
+  Map<String, BatchPipelineWrapper<?>> batchWrappers() {
+    return batchWrappers;
+  }
+
+  private <T> BatchPipelineWrapper<T> createBatchWrapper(
+    final KPipeConsumerBuilder.BatchSpec<T> spec,
+    final ScheduledExecutorService scheduler
+  ) {
+    // Batch flushes call the OffsetManager directly rather than going through commandQueue. The
+    // queue exists to serialize Kafka-consumer calls (pause/resume/commitSync) on the consumer
+    // thread; OffsetManager.markOffsetProcessed is already thread-safe and avoiding the queue
+    // means the shutdown drain works even after the consumer thread has exited.
+    final var callbacks = new BatchPipelineWrapper.BatchCallbacks() {
+      @Override
+      public void markProcessed(final ConsumerRecord<byte[], byte[]> record) {
+        metrics.get(METRIC_MESSAGES_PROCESSED).incrementAndGet();
+        otelMetrics.recordMessageProcessed(record.topic());
+        // Feed the circuit breaker / health window so batch outcomes count toward the failure
+        // rate, exactly like the per-record path. Both branches must report, or the rolling
+        // window would see only failures and trip spuriously.
+        health.recordOutcome(true);
+        if (offsetManager != null) offsetManager.markOffsetProcessed(record);
+      }
+
+      @Override
+      public void onBatchFailure(final ConsumerRecord<byte[], byte[]> record, final Exception cause) {
+        metrics.get(METRIC_PROCESSING_ERRORS).incrementAndGet();
+        otelMetrics.recordProcessingError(record.topic());
+        health.recordOutcome(false);
+        LOGGER.log(Level.WARNING, () -> "Batch failure for record at offset " + record.offset(), cause);
+        // LOCKSTEP: mirror of the per-record path's DLQ-or-mark block in handleProcessingError
+        // —
+        // mark the offset only after a successful DLQ send; a failed send leaves it pending so
+        // the record is reprocessed, never dropped. Deliberately duplicated (the paths differ
+        // on
+        // span handling, retry counts, and circuit-breaker ordering — recordOutcome runs BEFORE
+        // this block here, AFTER it on the per-record path). Any change here must be mirrored
+        // there; DlqTerminalContractTest asserts both paths cell-for-cell and fails on drift.
+        if (deadLetterTopic != null && kpipeProducer != null) {
+          if (kpipeProducer.sendToDlq(deadLetterTopic, record, record.topic(), cause)) {
+            metrics.get(METRIC_DLQ_SENT).incrementAndGet();
+            if (offsetManager != null) offsetManager.markOffsetProcessed(record);
+          } else {
+            metrics.get(METRIC_DLQ_FAILED).incrementAndGet();
+            LOGGER.log(
+              Level.ERROR,
+              () ->
+                "DLQ delivery failed for batch record at offset " +
+                record.offset() +
+                "; offset NOT committed, record will be reprocessed on restart/rebalance"
+            );
+          }
+        } else if (offsetManager != null) {
+          offsetManager.markOffsetProcessed(record);
+        }
+        try {
+          errorHandler.accept(new KPipeConsumer.ProcessingError(record, cause, 0));
+        } catch (final Exception ex) {
+          LOGGER.log(
+            Level.ERROR,
+            "Error handler threw on batch failure at offset {0}: {1}",
+            record.offset(),
+            ex.getMessage(),
+            ex
+          );
+        }
+      }
+    };
+    return new BatchPipelineWrapper<>(spec.topic(), spec.pipeline(), spec.sink(), spec.policy(), scheduler, callbacks);
+  }
+
+  /// Processes a single Kafka consumer record using the topic's configured pipeline. Runs in the
+  /// current virtual thread; retries on exception according to `maxRetries` + `retryBackoff`. On
+  /// success the per-record outcome feeds the circuit-breaker window; on retry-exhausted failure
+  /// the record is routed to the DLQ (when configured) and the error handler is invoked.
+  ///
+  /// Metrics tracked during processing:
+  ///
+  /// * `messagesReceived` — incremented on entry
+  /// * `messagesProcessed` — incremented on success
+  /// * `processingDurationTotalMs` — incremented on success by the wall-clock duration
+  /// * `retries` — incremented per retry attempt (not the initial attempt)
+  /// * `processingErrors` — incremented when processing fails after all retries
+  ///
+  /// @param record the Kafka consumer record to process
+  void process(final ConsumerRecord<byte[], byte[]> record) {
+    metrics.get(METRIC_MESSAGES_RECEIVED).incrementAndGet();
+    otelMetrics.recordMessageReceived(record.topic());
+
+    Tracer.SpanScope span;
+    try {
+      span = tracer.startConsumerSpan(record);
+    } catch (final Exception traceEx) {
+      LOGGER.log(Level.WARNING, "Tracer.startConsumerSpan threw", traceEx);
+      span = Tracer.SpanScope.noop();
+    }
+
+    final long startTime = System.currentTimeMillis();
+    try {
+      final var result = tryProcessRecord(record, span);
+      if (result) {
+        final var durationMs = System.currentTimeMillis() - startTime;
+        metrics.get(METRIC_MESSAGES_PROCESSED).incrementAndGet();
+        metrics.get(METRIC_PROCESSING_DURATION_TOTAL_MS).addAndGet(durationMs);
+        otelMetrics.recordMessageProcessed(record.topic());
+        otelMetrics.recordProcessingDuration(record.topic(), durationMs);
+      }
+    } finally {
+      try {
+        span.close();
+      } catch (final Exception traceEx) {
+        LOGGER.log(Level.WARNING, "Tracer.SpanScope.close threw", traceEx);
+      }
+      // In-flight count + backpressure-unpark handled by the dispatcher's `onComplete`
+      // callback (`afterRecordComplete`). See `KPipeConsumer.processRecords`.
+    }
+  }
+
+  private boolean tryProcessRecord(final ConsumerRecord<byte[], byte[]> record, final Tracer.SpanScope span) {
+    final var batchWrapper = batchWrappers.get(record.topic());
+    if (batchWrapper != null) return tryEnqueueBatchRecord(record, batchWrapper, span);
+    final var pipeline = pipelines.get(record.topic());
+    if (pipeline == null) {
+      LOGGER.log(
+        Level.WARNING,
+        "No pipeline registered for topic {0}; dropping record at offset {1}",
+        record.topic(),
+        record.offset()
+      );
+      markOffsetProcessed(record);
+      return false;
+    }
+    return runWithRetries(record, span, _ -> {
+      driveSinkedPipeline(pipeline, record.value());
+      markOffsetProcessed(record);
+      health.recordOutcome(true);
+      return true;
+    });
+  }
+
+  /// The shared attempt loop behind both route shapes: run `attempt`, and on a thrown exception
+  /// back off and re-run up to `maxRetries` times. Interruption (of the backoff sleep, or an
+  /// interruption-related failure from the attempt itself) restores the flag and aborts without
+  /// retrying and without invoking the error path — teardown recovery is re-fetch on restart.
+  /// Once attempts are exhausted the failure goes terminal through [#handleProcessingError]
+  /// with `retryCount` equal to the retries actually performed.
+  private boolean runWithRetries(
+    final ConsumerRecord<byte[], byte[]> record,
+    final Tracer.SpanScope span,
+    final RecordAttempt attemptBody
+  ) {
+    for (int attempt = 0; attempt <= maxRetries; attempt++) {
+      if (attempt > 0) {
+        metrics.get(METRIC_RETRIES).incrementAndGet();
+        LOGGER.log(
+          Level.DEBUG,
+          "Retrying message at offset {0} (attempt {1} of {2})",
+          record.offset(),
+          attempt,
+          maxRetries
+        );
+        try {
+          Thread.sleep(retryBackoff.toMillis());
+        } catch (final InterruptedException ie) {
+          Thread.currentThread().interrupt();
+          return false;
+        }
+      }
+
+      try {
+        return attemptBody.run(attempt);
+      } catch (final Exception e) {
+        if (isInterruptionRelated(e)) {
+          Thread.currentThread().interrupt();
+          return false;
+        }
+        if (attempt == maxRetries) {
+          handleProcessingError(record, e, attempt, span);
+          return false;
+        }
+      }
+    }
+    return false;
+  }
+
+  /// Batch route: drive the record's deserialize + operator step through the same retry loop as
+  /// the per-record path, then buffer the `Passed` value. Only the pre-buffer step is retried —
+  /// a record that passes is enqueued exactly once via [#enqueueBuffered], outside the retried
+  /// region, so a slow or failing flush can never cause a duplicate buffer entry. Pipeline
+  /// `Failed` results rethrow so a transient operator failure gets its configured attempts
+  /// before going terminal (DLQ / error handler) with the real retry count.
+  private <T> boolean tryEnqueueBatchRecord(
+    final ConsumerRecord<byte[], byte[]> record,
+    final BatchPipelineWrapper<T> wrapper,
+    final Tracer.SpanScope span
+  ) {
+    final var pipeline = wrapper.pipeline();
+    return runWithRetries(record, span, attempt -> {
+      final var deserialized = pipeline.deserializeOrFail(record.value());
+      return switch (pipeline.process(deserialized)) {
+        case Result.Passed<T> p -> enqueueBuffered(record, wrapper, p.value(), attempt, span);
+        case Result.Filtered<T> _ -> {
+          // Intentional filter — mark processed immediately; nothing to buffer.
+          markOffsetProcessed(record);
+          yield true;
+        }
+        case Result.Failed<T> f -> throw rethrowResultCause(f.cause());
+      };
+    });
+  }
+
+  /// Buffers a `Passed` value into the batch wrapper exactly once. Called from inside the retry
+  /// loop but handles its own failures so the loop can never observe an enqueue throw — retrying
+  /// an enqueue would re-run deserialize + process and buffer a duplicate. An enqueue failure
+  /// (e.g. an inline size-triggered flush path throwing) is terminal for the record: it takes
+  /// the standard error path with the retry count accumulated so far. Returns `false` because a
+  /// buffered record is not yet processed — `messagesProcessed` is incremented by the flush
+  /// callback when the batch is committed to the user sink.
+  private <T> boolean enqueueBuffered(
+    final ConsumerRecord<byte[], byte[]> record,
+    final BatchPipelineWrapper<T> wrapper,
+    final T value,
+    final int attempt,
+    final Tracer.SpanScope span
+  ) {
+    try {
+      wrapper.enqueue(record, value);
+    } catch (final Exception e) {
+      if (isInterruptionRelated(e)) {
+        Thread.currentThread().interrupt();
+        return false;
+      }
+      handleProcessingError(record, e, attempt, span);
+    }
+    return false;
+  }
+
+  /// Drive a pipeline (with erased element type) from raw bytes to its terminal sink. Throws if
+  /// the pipeline reports `Failed` so the calling retry/error path handles it the same way it
+  /// always did. Returns normally on `Passed` (after the sink runs) and on `Filtered`.
+  private static <T> void driveSinkedPipeline(final MessagePipeline<T> pipeline, final byte[] data) {
+    final var deserialized = pipeline.deserializeOrFail(data);
+    switch (pipeline.process(deserialized)) {
+      case Result.Passed<T> p -> {
+        final var sink = pipeline.getSink();
+        if (sink != null) sink.accept(p.value());
+      }
+      case Result.Filtered<T> _ -> {
+        /* intentional filter — no sink invocation */
+      }
+      case Result.Failed<T> f -> throw rethrowResultCause(f.cause());
+    }
+  }
+
+  /// Re-throw a captured `Result.Failed` cause as an unchecked exception so the retry/error path
+  /// can catch it. Mirrors the legacy MessagePipeline byte-level entry point behavior — it just
+  /// lives here now, where the catching happens, rather than buried in three duplicated unwrap
+  /// blocks inside MessagePipeline.
+  private static RuntimeException rethrowResultCause(final Throwable cause) {
+    if (cause instanceof RuntimeException re) return re;
+    if (cause instanceof Error err) throw err;
+    return new RuntimeException(cause);
+  }
+
+  private void markOffsetProcessed(final ConsumerRecord<byte[], byte[]> record) {
+    if (offsetManager != null) offsetManager.markOffsetProcessed(record);
+  }
+
+  private void handleProcessingError(
+    final ConsumerRecord<byte[], byte[]> record,
+    final Exception e,
+    final int retryCount,
+    final Tracer.SpanScope span
+  ) {
+    metrics.get(METRIC_PROCESSING_ERRORS).incrementAndGet();
+    otelMetrics.recordProcessingError(record.topic());
+    // Mark the span as errored. Guarded — a misbehaving tracer must never crash the consumer
+    // thread, leak in-flight counts, or skip offset marking.
+    try {
+      span.recordException(e);
+    } catch (final Exception traceEx) {
+      LOGGER.log(Level.WARNING, "Tracer.SpanScope.recordException threw", traceEx);
+    }
+    LOGGER.log(
+      Level.WARNING,
+      () -> "Failed to process message at offset " + record.offset() + " after " + (retryCount + 1) + " attempt(s)",
+      e
+    );
+    if (deadLetterTopic != null && kpipeProducer != null) {
+      // The offset advances only once the record reaches a durable terminal state: either the sink
+      // processed it (handled elsewhere) or it is safely parked in the DLQ. If the DLQ send fails
+      // the record is in neither place, so leave the offset pending — the commit point holds and
+      // the record is re-fetched (and the DLQ retried) on the next restart or partition
+      // reassignment. A down DLQ stalls the commit point rather than silently dropping data
+      // (the fetch position races ahead in-memory; this is a commit stall, not a pause).
+      //
+      // LOCKSTEP: this DLQ-or-mark block is deliberately duplicated in the batch wrapper's
+      // onBatchFailure callback — the two paths differ on span handling, retry counts, and
+      // circuit-breaker ordering (recordOutcome runs AFTER this block here, BEFORE it on the
+      // batch path), so a shared helper would blur those. Any change here must be mirrored
+      // there; DlqTerminalContractTest asserts both paths cell-for-cell and fails on drift.
+      if (kpipeProducer.sendToDlq(deadLetterTopic, record, record.topic(), e)) {
+        metrics.get(METRIC_DLQ_SENT).incrementAndGet();
+        markOffsetProcessed(record);
+      } else {
+        metrics.get(METRIC_DLQ_FAILED).incrementAndGet();
+        LOGGER.log(
+          Level.ERROR,
+          () ->
+            "DLQ delivery failed for record at offset " +
+            record.offset() +
+            "; offset NOT committed, record will be reprocessed on restart/rebalance"
+        );
+      }
+    } else {
+      // No DLQ configured: the caller opted into log-and-advance. Mark processed and move on.
+      markOffsetProcessed(record);
+    }
+    health.recordOutcome(false);
+    try {
+      errorHandler.accept(new KPipeConsumer.ProcessingError(record, e, retryCount));
+    } catch (final Exception ex) {
+      LOGGER.log(
+        Level.ERROR,
+        "Error handler threw while handling failure at offset {0}: {1}",
+        record.offset(),
+        ex.getMessage(),
+        ex
+      );
+    }
+  }
+
+  /// Surfaces a rejection from `ParallelDispatcher`'s executor (typically during shutdown)
+  /// back to the consumer's error path. The record never started processing, so it is neither
+  /// marked processed nor DLQ'd — at shutdown, re-fetch on restart is the right recovery, not a
+  /// poisoned mark.
+  void handleParallelRejection(final ConsumerRecord<byte[], byte[]> record, final RejectedExecutionException e) {
+    if (!consumerActive.getAsBoolean()) return;
+    LOGGER.log(Level.WARNING, "Task submission rejected during shutdown", e);
+    metrics.get(METRIC_PROCESSING_ERRORS).incrementAndGet();
+    otelMetrics.recordProcessingError(record.topic());
+    try {
+      errorHandler.accept(new KPipeConsumer.ProcessingError(record, e, 0));
+    } catch (final Exception ex) {
+      LOGGER.log(
+        Level.ERROR,
+        () -> "Error handler threw while handling rejected task at offset " + record.offset(),
+        ex
+      );
+    }
+  }
+
+  private static boolean isInterruptionRelated(final Throwable error) {
+    for (Throwable current = error; current != null; current = current.getCause()) {
+      if (current instanceof InterruptedException || current instanceof ClosedByInterruptException) return true;
+    }
+    return false;
+  }
+}

--- a/lib/kpipe-consumer/src/test/java/io/github/eschizoid/kpipe/consumer/BatchRetryIntegrationTest.java
+++ b/lib/kpipe-consumer/src/test/java/io/github/eschizoid/kpipe/consumer/BatchRetryIntegrationTest.java
@@ -1,0 +1,179 @@
+package io.github.eschizoid.kpipe.consumer;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.github.eschizoid.kpipe.sink.BatchPolicy;
+import io.github.eschizoid.kpipe.sink.BatchSink;
+import java.time.Duration;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.BooleanSupplier;
+import org.apache.kafka.clients.consumer.ConsumerRebalanceListener;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.clients.consumer.MockConsumer;
+import org.apache.kafka.clients.producer.Producer;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.clients.producer.RecordMetadata;
+import org.apache.kafka.common.TopicPartition;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+/// Pins the honor-retries contract on batch routes: `withRetry(n)` applies to a batch-route
+/// record's deserialize + operator step before buffering, exactly as it does on the regular
+/// per-record path. Historically the batch enqueue path ran a single attempt with a hardcoded
+/// retry count of 0 — `withRetry(3)` + `withBatchPipeline` silently applied zero retries and
+/// reported `retryCount=0` to the error handler. These tests fail on that regression.
+///
+/// The batch sink flush itself is deliberately NOT retried (its failure handling is the
+/// `BatchResult` / DLQ path, pinned by `DlqTerminalContractTest` and the batch matrix); only
+/// the pre-buffer step gains attempts, which is what both cells below exercise.
+class BatchRetryIntegrationTest {
+
+  private static final String TOPIC = "batch-retry-topic";
+  private static final String DLQ_TOPIC = "batch-retry-dlq";
+  private static final long OFFSET = 0L;
+
+  private static Properties props() {
+    final var p = new Properties();
+    p.put("bootstrap.servers", "localhost:9092");
+    p.put("group.id", "batch-retry-group");
+    p.put("key.deserializer", "org.apache.kafka.common.serialization.ByteArrayDeserializer");
+    p.put("value.deserializer", "org.apache.kafka.common.serialization.ByteArrayDeserializer");
+    p.put("enable.auto.commit", "false");
+    return p;
+  }
+
+  private static MockConsumer<byte[], byte[]> seededSingleRecord() {
+    final var mock = new MockConsumer<byte[], byte[]>("earliest") {
+      @Override
+      public synchronized void subscribe(final Collection<String> topics) {}
+
+      @Override
+      public synchronized void subscribe(final Collection<String> topics, final ConsumerRebalanceListener cb) {}
+    };
+    final var tp = new TopicPartition(TOPIC, 0);
+    mock.assign(List.of(tp));
+    mock.updateBeginningOffsets(Map.of(tp, 0L));
+    mock.addRecord(new ConsumerRecord<>(TOPIC, 0, OFFSET, "k".getBytes(UTF_8), "v".getBytes(UTF_8)));
+    return mock;
+  }
+
+  @SuppressWarnings("unchecked")
+  private static Producer<byte[], byte[]> recordingDlqProducer(final List<Long> dlqOffsets) {
+    final Producer<byte[], byte[]> producer = Mockito.mock(Producer.class);
+    Mockito.lenient()
+      .when(producer.send(Mockito.any(ProducerRecord.class)))
+      .thenAnswer(_ -> {
+        dlqOffsets.add(OFFSET);
+        return CompletableFuture.completedFuture(Mockito.mock(RecordMetadata.class));
+      });
+    return producer;
+  }
+
+  private static void awaitCondition(final BooleanSupplier cond, final long timeoutMs) throws InterruptedException {
+    final var deadline = System.currentTimeMillis() + timeoutMs;
+    while (!cond.getAsBoolean()) {
+      if (System.currentTimeMillis() >= deadline) throw new AssertionError(
+        "awaitCondition timed out after " + timeoutMs + "ms"
+      );
+      Thread.sleep(10);
+    }
+  }
+
+  /// Cell (a): withRetry(2) + a pipeline that fails twice then succeeds. The record must end up
+  /// buffered and flushed to the batch sink — zero DLQ traffic, zero terminal errors, no error
+  /// handler invocation — and the retries counter must show exactly the two real retries.
+  @Test
+  void batchRouteHonorsRetriesAndRecoversWithoutDlq() throws Exception {
+    final var attempts = new AtomicInteger();
+    final var flushed = new CopyOnWriteArrayList<byte[]>();
+    final var dlqOffsets = new CopyOnWriteArrayList<Long>();
+    final var errors = new CopyOnWriteArrayList<KPipeConsumer.ProcessingError>();
+
+    final var consumer = KPipeConsumer.builder()
+      .withProperties(props())
+      .withBatchPipeline(
+        TOPIC,
+        TestPipelines.sideEffect(v -> {
+          if (attempts.incrementAndGet() <= 2) throw new RuntimeException("transient, recovers on attempt 3");
+          return v;
+        }),
+        BatchSink.ofVoid(flushed::addAll),
+        BatchPolicy.ofSize(1)
+      )
+      .withRetry(2, Duration.ofMillis(1))
+      .withDeadLetterTopic(DLQ_TOPIC)
+      .withKafkaProducer(recordingDlqProducer(dlqOffsets))
+      .withErrorHandler(errors::add)
+      .withConsumer(BatchRetryIntegrationTest::seededSingleRecord)
+      .withPollTimeout(Duration.ofMillis(5))
+      .build();
+
+    try {
+      consumer.start();
+      awaitCondition(() -> !flushed.isEmpty(), 10_000);
+
+      assertEquals(3, attempts.get(), "the pipeline must be driven once per attempt (1 initial + 2 retries)");
+      assertEquals(2L, consumer.getMetrics().get("retries"), "retries metric must count the two real retries");
+      assertEquals(1, flushed.size(), "the recovered record must reach the batch sink exactly once");
+      assertTrue(dlqOffsets.isEmpty(), "a record that recovers on retry must never touch the DLQ");
+      assertEquals(0L, consumer.getMetrics().get("processingErrors"), "no terminal error for a recovered record");
+      assertTrue(errors.isEmpty(), "the error handler must not fire for a recovered record");
+    } finally {
+      consumer.close();
+    }
+  }
+
+  /// Cell (b): withRetry(1) + a persistently failing pipeline. The record must reach the error
+  /// handler with `retryCount=1` (the retries actually performed, not the historical hardcoded
+  /// 0) and park in the DLQ; the batch sink must never see it.
+  @Test
+  void batchRouteExhaustedRetriesReportRealCountAndDlq() throws Exception {
+    final var attempts = new AtomicInteger();
+    final var flushed = new CopyOnWriteArrayList<byte[]>();
+    final var dlqOffsets = new CopyOnWriteArrayList<Long>();
+    final var errors = new CopyOnWriteArrayList<KPipeConsumer.ProcessingError>();
+
+    final var consumer = KPipeConsumer.builder()
+      .withProperties(props())
+      .withBatchPipeline(
+        TOPIC,
+        TestPipelines.sideEffect(v -> {
+          attempts.incrementAndGet();
+          throw new RuntimeException("permanent failure");
+        }),
+        BatchSink.ofVoid(flushed::addAll),
+        BatchPolicy.ofSize(1)
+      )
+      .withRetry(1, Duration.ofMillis(1))
+      .withDeadLetterTopic(DLQ_TOPIC)
+      .withKafkaProducer(recordingDlqProducer(dlqOffsets))
+      .withErrorHandler(errors::add)
+      .withConsumer(BatchRetryIntegrationTest::seededSingleRecord)
+      .withPollTimeout(Duration.ofMillis(5))
+      .build();
+
+    try {
+      consumer.start();
+      awaitCondition(() -> !errors.isEmpty() && !dlqOffsets.isEmpty(), 10_000);
+
+      assertEquals(2, attempts.get(), "the pipeline must be driven twice (1 initial + 1 retry)");
+      assertEquals(1L, consumer.getMetrics().get("retries"), "retries metric must count the single real retry");
+      assertEquals(1, errors.size(), "the error handler must observe the exhausted failure exactly once");
+      assertEquals(1, errors.getFirst().retryCount(), "retryCount must reflect the retries actually performed");
+      assertEquals(List.of(OFFSET), dlqOffsets, "the exhausted record must park in the DLQ");
+      assertTrue(flushed.isEmpty(), "a never-passing record must not reach the batch sink");
+      assertEquals(1L, consumer.getMetrics().get("processingErrors"), "exactly one terminal error");
+      assertEquals(1L, consumer.getMetrics().get("dlqSent"), "exactly one DLQ send");
+    } finally {
+      consumer.close();
+    }
+  }
+}

--- a/lib/kpipe-consumer/src/test/java/io/github/eschizoid/kpipe/consumer/MultiTopicUnroutedPolicyTest.java
+++ b/lib/kpipe-consumer/src/test/java/io/github/eschizoid/kpipe/consumer/MultiTopicUnroutedPolicyTest.java
@@ -183,8 +183,9 @@ class MultiTopicUnroutedPolicyTest {
     end.put(unroutedTp, 1L);
     mock.updateEndOffsets(end);
 
-    // Capture WARNING logs emitted by KPipeConsumer (System.Logger → JUL by default).
-    final var julLogger = Logger.getLogger(KPipeConsumer.class.getName());
+    // Capture WARNING logs emitted by the per-record engine (System.Logger → JUL by default);
+    // the unrouted-topic drop is logged by RecordProcessor, where the routing decision lives.
+    final var julLogger = Logger.getLogger(RecordProcessor.class.getName());
     final var captured = new CopyOnWriteArrayList<LogRecord>();
     final var handler = new Handler() {
       @Override


### PR DESCRIPTION
Architecture-pass items #5 + #2 (the last open bug).

**Extraction:** the ~315-line per-record engine leaves the 1,450-line `KPipeConsumer` as package-private `RecordProcessor` (fixed collaborator set; directly unit-testable without the poll thread). Consumer keeps lifecycle/threads/commands/close. Behavior-identical: `DlqTerminalContractTest` passes **unchanged**, as do the CB integration, batch matrix, and the full consumer suite (427/427) + api (86/86).

**Bug fix:** `withRetry(n)` + `withBatchPipeline` silently applied zero retries (single attempt, retryCount hardcoded 0). The batch deserialize+process step now shares the per-record attempt loop; flush failures stay non-retried (BatchResult/DLQ path). Documented on both builder methods. New `BatchRetryIntegrationTest` pins transient-recovers and persistent-DLQs-with-real-retryCount.