### PR TITLE
refactor: drainableCount/backpressureLoad split, SchemaResolver.lookupRequired, SR Collection overloads

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -15,9 +15,9 @@ runnable program. For a complete runnable example see
 | --- | --- | --- |
 | `json(topic, props)` | `Stream<Map<String, Object>>` | also `json(Collection<String>, props)` for many topics, one pipeline |
 | `avro(topic, props, AvroFormat)` | `Stream<GenericRecord>` | static single-schema mode; `Collection` overload exists |
-| `avro(topic, props, SchemaResolver)` | `Stream<GenericRecord>` | Confluent SR per-record lookup; no `Collection` overload; `toConsole()` unsupported in this mode |
+| `avro(topic, props, SchemaResolver)` | `Stream<GenericRecord>` | Confluent SR per-record lookup; `Collection` overload exists; `toConsole()` unsupported in this mode |
 | `protobuf(topic, props, ProtobufFormat)` | `Stream<Message>` | static descriptor mode; `Collection` overload exists |
-| `protobuf(topic, props, SchemaResolver)` | `Stream<Message>` | SR mode; requires `kpipe-format-protobuf-confluent` at runtime; no `Collection` overload; `toConsole()` unsupported |
+| `protobuf(topic, props, SchemaResolver)` | `Stream<Message>` | SR mode; requires `kpipe-format-protobuf-confluent` at runtime; `Collection` overload exists; `toConsole()` unsupported |
 | `bytes(topic, props)` | `Stream<byte[]>` | passthrough; `Collection` overload exists |
 | `custom(topic, props, MessageFormat<T>)` | `Stream<T>` | your own format; `Collection` overload exists |
 | `multi(props)` | `MultiBuilder` | heterogeneous per-topic routes on one consumer |

--- a/lib/kpipe-api/src/main/java/io/github/eschizoid/kpipe/KPipe.java
+++ b/lib/kpipe-api/src/main/java/io/github/eschizoid/kpipe/KPipe.java
@@ -105,6 +105,24 @@ public final class KPipe {
     return new DefaultStream<>(topic, kafkaProps, format, KPipe::registryModeConsoleSinkUnsupported);
   }
 
+  /// Avro-typed stream wired for per-record Confluent Schema Registry lookup across multiple
+  /// homogeneous topics through a single shared pipeline. See
+  /// [#avro(String, Properties, SchemaResolver)] — the same envelope and `.skipBytes(5)` rules
+  /// apply.
+  ///
+  /// @param topics the Kafka topics to consume (must be non-empty)
+  /// @param kafkaProps the Kafka consumer properties
+  /// @param resolver the schema resolver (must be non-null; typically a `CachedSchemaResolver`)
+  /// @return a fluent [Stream] configured for Avro with per-record schema lookup
+  public static Stream<GenericRecord> avro(
+    final Collection<String> topics,
+    final Properties kafkaProps,
+    final SchemaResolver resolver
+  ) {
+    final var format = AvroFormat.withRegistry(resolver);
+    return new DefaultStream<>(topics, kafkaProps, format, KPipe::registryModeConsoleSinkUnsupported);
+  }
+
   static MessageSink<GenericRecord> registryModeConsoleSinkUnsupported() {
     throw new IllegalStateException(
       "toConsole() requires a fixed schema; an AvroFormat in Schema-Registry mode has none. " +
@@ -158,6 +176,24 @@ public final class KPipe {
   ) {
     final var format = ProtobufFormat.withRegistry(resolver);
     return new DefaultStream<>(topic, kafkaProps, format, KPipe::registryModeProtobufConsoleSinkUnsupported);
+  }
+
+  /// Protobuf-typed stream wired for per-record Confluent Schema Registry lookup across multiple
+  /// homogeneous topics through a single shared pipeline. See
+  /// [#protobuf(String, Properties, SchemaResolver)] — the same `kpipe-format-protobuf-confluent`
+  /// requirement, envelope handling, and `.skipBytes(6)` rules apply.
+  ///
+  /// @param topics the Kafka topics to consume (must be non-empty)
+  /// @param kafkaProps the Kafka consumer properties
+  /// @param resolver the schema resolver (must be non-null; typically a `CachedSchemaResolver`)
+  /// @return a fluent [Stream] configured for Protobuf with per-record schema lookup
+  public static Stream<Message> protobuf(
+    final Collection<String> topics,
+    final Properties kafkaProps,
+    final SchemaResolver resolver
+  ) {
+    final var format = ProtobufFormat.withRegistry(resolver);
+    return new DefaultStream<>(topics, kafkaProps, format, KPipe::registryModeProtobufConsoleSinkUnsupported);
   }
 
   static MessageSink<Message> registryModeProtobufConsoleSinkUnsupported() {

--- a/lib/kpipe-api/src/test/java/io/github/eschizoid/kpipe/KPipeFacadeBuildTest.java
+++ b/lib/kpipe-api/src/test/java/io/github/eschizoid/kpipe/KPipeFacadeBuildTest.java
@@ -8,9 +8,11 @@ import io.github.eschizoid.kpipe.consumer.ProcessingMode;
 import io.github.eschizoid.kpipe.format.json.JsonFormat;
 import io.github.eschizoid.kpipe.metrics.ConsumerMetrics;
 import io.github.eschizoid.kpipe.producer.tracing.Tracer;
+import io.github.eschizoid.kpipe.registry.SchemaResolver;
 import io.github.eschizoid.kpipe.sink.BatchPolicy;
 import io.github.eschizoid.kpipe.sink.BatchSink;
 import java.time.Duration;
+import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 import java.util.concurrent.atomic.AtomicReference;
@@ -353,6 +355,36 @@ class KPipeFacadeBuildTest {
         .withCircuitBreaker(breaker)
         .json("topic-a", s -> s.toCustom(_ -> {}))
         .json("topic-b", s -> s.toCustom(_ -> {}))
+    );
+  }
+
+  @Test
+  void avroCollectionResolverOverloadBuildsAndRejectsConsoleSink() {
+    final SchemaResolver resolver = schemaId -> "{}";
+    final var stream = KPipe.avro(List.of("topic-a", "topic-b"), props(), resolver);
+    assertNotNull(stream, "the Collection resolver overload must build a stream");
+
+    // Registry mode has no fixed schema, so the console sink is the dedicated "unsupported" one.
+    final var ex = assertThrows(IllegalStateException.class, stream::toConsole);
+    assertTrue(
+      ex.getMessage().contains("toConsole()"),
+      () -> "expected the registry-mode console-sink rejection, got: " + ex.getMessage()
+    );
+  }
+
+  @Test
+  void protobufCollectionResolverOverloadRoutesToTheRegistryFormat() {
+    // kpipe-api's test path has no kpipe-format-protobuf-confluent, so
+    // ProtobufFormat.withRegistry fails ServiceLoader lookup with a "ProtobufDescriptorCompiler"
+    // message — reachable ONLY if the overload delegated to the registry-mode factory. With the
+    // compiler on the path the overload builds a stream whose toConsole() throws, mirroring Avro.
+    final SchemaResolver resolver = schemaId -> "syntax = \"proto3\";";
+    final var ex = assertThrows(IllegalStateException.class, () ->
+      KPipe.protobuf(List.of("topic-a", "topic-b"), props(), resolver)
+    );
+    assertTrue(
+      ex.getMessage().contains("ProtobufDescriptorCompiler"),
+      () -> "expected the registry branch's ServiceLoader error, got: " + ex.getMessage()
     );
   }
 }

--- a/lib/kpipe-consumer/src/jcstress/java/io/github/eschizoid/kpipe/consumer/DispatcherDrainableCountJCStressTest.java
+++ b/lib/kpipe-consumer/src/jcstress/java/io/github/eschizoid/kpipe/consumer/DispatcherDrainableCountJCStressTest.java
@@ -32,7 +32,7 @@ import org.openjdk.jcstress.infra.results.JJJ_Result;
 /// Awaiting that latch establishes a happens-before edge: by the time an actor returns, its
 /// own record's decrement is visible. One actor dispatches a record whose task returns
 /// normally; the other dispatches a record whose task throws, exercising the throw-path
-/// finally. Each actor reads `activeCount()` after its own completion and records it; the
+/// finally. Each actor reads `drainableCount()` after its own completion and records it; the
 /// arbiter reads the final settled count once both actors finish.
 ///
 /// jcstress runs the two actors against fresh state under every interleaving its scheduler
@@ -66,7 +66,7 @@ import org.openjdk.jcstress.infra.results.JJJ_Result;
   desc = "A negative observation or non-zero final count: an increment or decrement was lost."
 )
 @State
-public class DispatcherActiveCountJCStressTest {
+public class DispatcherDrainableCountJCStressTest {
 
   private static final String TOPIC = "jcstress-topic";
 
@@ -96,7 +96,7 @@ public class DispatcherActiveCountJCStressTest {
   public void observe(final JJJ_Result r) {
     awaitQuietly(normalDone);
     awaitQuietly(throwDone);
-    r.r3 = dispatcher.activeCount();
+    r.r3 = dispatcher.drainableCount();
   }
 
   /// Blocks until this record's completion fires, then snapshots the live count. A snapshot
@@ -105,7 +105,7 @@ public class DispatcherActiveCountJCStressTest {
   /// without a matching increment.
   private long awaitThenObserve(final CountDownLatch done) {
     awaitQuietly(done);
-    return dispatcher.activeCount();
+    return dispatcher.drainableCount();
   }
 
   private static void awaitQuietly(final CountDownLatch done) {

--- a/lib/kpipe-consumer/src/jcstress/java/io/github/eschizoid/kpipe/consumer/KeyOrderedWorkerHandoffJCStressTest.java
+++ b/lib/kpipe-consumer/src/jcstress/java/io/github/eschizoid/kpipe/consumer/KeyOrderedWorkerHandoffJCStressTest.java
@@ -36,7 +36,7 @@ import org.openjdk.jcstress.infra.results.I_Result;
 /// Scenario. Both actors dispatch a record for the same key. Each dispatched task increments
 /// a shared counter once; the dispatcher's per-task `onComplete` then counts down a latch the
 /// arbiter awaits. Awaiting the latch establishes a happens-before edge that BOTH tasks have
-/// fully run before the counter is read — closing the early-exit window a `activeCount()` spin
+/// fully run before the counter is read — closing the early-exit window a `drainableCount()` spin
 /// had (the count can momentarily read zero between an enqueue and the task body executing). The
 /// only acceptable outcome is 2: both tasks ran exactly once. A lost enqueue means a task never
 /// runs, the latch never reaches zero, the await times out, and the run reports the forbidden -1.
@@ -68,7 +68,8 @@ public class KeyOrderedWorkerHandoffJCStressTest {
   public void observe(final I_Result r) {
     // Await both tasks' onComplete (fired per task by the dispatcher after task.run()). The await
     // is the happens-before edge guaranteeing both task bodies fully ran before tasksRun is read,
-    // so a momentary activeCount==0 between enqueue and execution can't make the read fire early.
+    // so a momentary drainableCount==0 between enqueue and execution can't make the read fire
+    // early.
     // A lost enqueue leaves the latch above zero; the await times out and the run reports -1.
     try {
       if (!done.await(5, TimeUnit.SECONDS)) {

--- a/lib/kpipe-consumer/src/main/java/io/github/eschizoid/kpipe/consumer/Dispatcher.java
+++ b/lib/kpipe-consumer/src/main/java/io/github/eschizoid/kpipe/consumer/Dispatcher.java
@@ -44,14 +44,9 @@ sealed interface Dispatcher
   ///                     (typically an unpark of the consumer thread if backpressure-held)
   void dispatch(ConsumerRecord<byte[], byte[]> record, Runnable processTask, Runnable onComplete);
 
-  /// Returns the number of records currently dispatched but not yet finished. Fed into
-  /// `KPipeConsumer.totalInFlight()` so the in-flight backpressure strategy sees the
-  /// dispatcher's buffered + active records.
-  ///
-  /// Sequential mode returns 0 or 1 (one inline record at a time). Lag-based backpressure
-  /// doesn't consult this value, but it's still tracked so `inFlight` metrics and
-  /// `shutdownGracefully(timeout)` drain reporting are accurate.
-  long activeCount();
+  /// Returns the number of records dispatched but not yet finished — the count shutdown
+  /// drain waits on. Sequential mode returns 0 or 1 (one inline record at a time).
+  long drainableCount();
 
   /// Snapshot of the top-`n` keys by current queue depth, ordered deepest-first. Intended for
   /// ad-hoc diagnostics (heap-dump replacement, REPL/JMX inspection) — not for continuous

--- a/lib/kpipe-consumer/src/main/java/io/github/eschizoid/kpipe/consumer/KPipeConsumer.java
+++ b/lib/kpipe-consumer/src/main/java/io/github/eschizoid/kpipe/consumer/KPipeConsumer.java
@@ -230,7 +230,7 @@ public class KPipeConsumer implements AutoCloseable {
       ).withStrategy(
         this.processingMode == ProcessingMode.SEQUENTIAL
           ? BackpressureController.lagStrategy()
-          : BackpressureController.inFlightStrategy(this::totalInFlight)
+          : BackpressureController.inFlightStrategy(this::backpressureLoad)
       );
 
       final var tracer = builder.tracer != null ? builder.tracer : Tracer.noop();
@@ -430,27 +430,20 @@ public class KPipeConsumer implements AutoCloseable {
     }
   }
 
-  /// Blocks until the dispatcher's in-flight records finish processing, or `timeout` elapses, or
-  /// the calling thread is interrupted. Replaces the former standalone
-  /// `MessageTracker.waitForCompletion(...)`.
-  ///
-  /// Waits on `dispatcher.activeCount()` — records a worker is actively processing — NOT
-  /// `totalInFlight()`. The latter also counts buffered batch records, which never flush during a
-  /// drain (only on a size/age trigger or `BatchPipelineWrapper.close()` at teardown), so waiting
-  /// on them would always burn the full `timeout`. Buffered batches are flushed + committed by the
-  /// teardown that follows, so a `true` return here means "active processing is done, safe to tear
-  /// down."
+  /// Blocks until `dispatcher.drainableCount()` reaches zero, or `timeout` elapses, or the
+  /// calling thread is interrupted. A `true` return means "active processing is done, safe to
+  /// tear down" — buffered batches are flushed + committed by the teardown that follows.
   ///
   /// @param timeout maximum time to wait
   /// @return `true` if active processing drained in time, else `false`
   public boolean waitForInFlightDrain(final Duration timeout) {
-    if (dispatcher.activeCount() == 0) return true;
+    if (dispatcher.drainableCount() == 0) return true;
     final var deadline = System.nanoTime() + timeout.toNanos();
     final var pollNanos = Math.min(timeout.toNanos() / 10, Duration.ofMillis(500).toNanos());
     final var pollMs = Math.max(1, pollNanos / 1_000_000);
     try {
       while (System.nanoTime() < deadline) {
-        if (dispatcher.activeCount() == 0) return true;
+        if (dispatcher.drainableCount() == 0) return true;
         //noinspection BusyWait — deadline-bounded drain poll, not a spin
         Thread.sleep(pollMs);
       }
@@ -458,7 +451,7 @@ public class KPipeConsumer implements AutoCloseable {
       Thread.currentThread().interrupt();
       return false;
     }
-    return dispatcher.activeCount() == 0;
+    return dispatcher.drainableCount() == 0;
   }
 
   /// Runs on the consumer thread, at the top of its `finally`, before any teardown. The poll
@@ -469,17 +462,13 @@ public class KPipeConsumer implements AutoCloseable {
   /// by `waitForMessagesTimeout`. Finishing workers mark their offsets directly on the
   /// thread-safe `OffsetManager`, so those don't need the command queue. A final
   /// `processCommands()` flushes anything the last workers enqueued. Only the consumer thread may
-  /// touch the Kafka consumer, so this must run here, not on the close() thread.
-  ///
-  /// We wait on `dispatcher.activeCount()`, NOT `totalInFlight()`: the latter also counts
-  /// buffered batch records, which don't enqueue commands and won't flush on their own (size-only
-  /// / long-maxAge policies). They're flushed by each `BatchPipelineWrapper.close()` in
-  /// `releaseConstructedResources()` right after this returns — so waiting on them here would just
-  /// burn the whole timeout while the dispatcher is already idle.
+  /// touch the Kafka consumer, so this must run here, not on the close() thread. Waits on
+  /// `dispatcher.drainableCount()`; buffered batch records are flushed by each
+  /// `BatchPipelineWrapper.close()` in `releaseConstructedResources()` right after this returns.
   private void drainInFlightBeforeTeardown() {
     if (waitForMessagesTimeout.toMillis() > 0) {
       final var deadline = System.nanoTime() + waitForMessagesTimeout.toNanos();
-      while (dispatcher.activeCount() > 0 && System.nanoTime() < deadline) {
+      while (dispatcher.drainableCount() > 0 && System.nanoTime() < deadline) {
         processCommands();
         LockSupport.parkNanos(Duration.ofMillis(5).toNanos());
       }
@@ -529,7 +518,7 @@ public class KPipeConsumer implements AutoCloseable {
     // they observed rather than calling pause()/close() on an already-shutting consumer.
     final var snapshot = state.get();
     if (snapshot == ConsumerState.CLOSED) return true;
-    if (snapshot == ConsumerState.CLOSING) return awaitShutdown(timeout) && totalInFlight() == 0;
+    if (snapshot == ConsumerState.CLOSING) return awaitShutdown(timeout) && backpressureLoad() == 0;
     pause();
     final var drained = waitForInFlightDrain(timeout);
     close();
@@ -781,7 +770,7 @@ public class KPipeConsumer implements AutoCloseable {
       .entrySet()
       .stream()
       .collect(Collectors.toMap(Map.Entry::getKey, e -> e.getValue().get(), (a, _) -> a, HashMap::new));
-    snapshot.put(ConsumerMetricKeys.IN_FLIGHT, totalInFlight());
+    snapshot.put(ConsumerMetricKeys.IN_FLIGHT, backpressureLoad());
     return Collections.unmodifiableMap(snapshot);
   }
 
@@ -821,7 +810,13 @@ public class KPipeConsumer implements AutoCloseable {
   /// @return an immutable snapshot of this consumer's health
   public HealthSnapshot health() {
     final var sources = health.currentSources().stream().map(Enum::name).collect(Collectors.toUnmodifiableSet());
-    return new HealthSnapshot(isRunning(), health.isPaused(), sources, health.circuitBreakerState(), totalInFlight());
+    return new HealthSnapshot(
+      isRunning(),
+      health.isPaused(),
+      sources,
+      health.circuitBreakerState(),
+      backpressureLoad()
+    );
   }
 
   /// Atomically transitions from any active state (RUNNING or PAUSED) to CLOSING.
@@ -907,8 +902,8 @@ public class KPipeConsumer implements AutoCloseable {
     stopMetricsReporterThread();
     commandQueue.offer(new ConsumerCommand.Close());
     dispatcher.signalShutdown();
-    if (waitForMessagesTimeout.toMillis() > 0 && dispatcher.activeCount() > 0) {
-      LOGGER.log(Level.INFO, "Waiting for {0} in-flight messages to complete", dispatcher.activeCount());
+    if (waitForMessagesTimeout.toMillis() > 0 && dispatcher.drainableCount() > 0) {
+      LOGGER.log(Level.INFO, "Waiting for {0} in-flight messages to complete", dispatcher.drainableCount());
       waitForInFlightDrain(waitForMessagesTimeout);
     }
   }
@@ -1059,7 +1054,7 @@ public class KPipeConsumer implements AutoCloseable {
   /// - `KeyOrderedDispatcher` enqueues records onto a per-key serial queue + virtual thread.
   ///
   /// The dispatcher also owns the in-flight counter (for non-sequential modes) and feeds
-  /// [#totalInFlight] via `dispatcher.activeCount()`.
+  /// [#backpressureLoad] via `dispatcher.drainableCount()`.
   ///
   /// @param records the batch of records to process
   protected void processRecords(final ConsumerRecords<byte[], byte[]> records) {
@@ -1106,14 +1101,10 @@ public class KPipeConsumer implements AutoCloseable {
     recordProcessor.process(record);
   }
 
-  /// Returns the total number of records currently being tracked for backpressure: whatever
-  /// the per-mode dispatcher reports as pending plus the sum of records buffered across all
-  /// configured batch wrappers. Without the buffered piece, a slow batch sink would let the
-  /// buffer grow unbounded — the dispatcher decrements its counter the moment a record
-  /// finishes `processRecord` (which for batch is "the record was buffered"), so the buffer
-  /// would otherwise be invisible to the watermark check.
-  private long totalInFlight() {
-    var total = dispatcher.activeCount();
+  /// Returns the load the in-flight backpressure strategy reads: `dispatcher.drainableCount()`
+  /// plus the sum of records buffered across all configured batch wrappers.
+  private long backpressureLoad() {
+    var total = dispatcher.drainableCount();
     for (final var wrapper : batchWrappers.values()) total += wrapper.bufferedCount();
     return total;
   }

--- a/lib/kpipe-consumer/src/main/java/io/github/eschizoid/kpipe/consumer/KeyOrderedDispatcher.java
+++ b/lib/kpipe-consumer/src/main/java/io/github/eschizoid/kpipe/consumer/KeyOrderedDispatcher.java
@@ -150,7 +150,7 @@ final class KeyOrderedDispatcher implements Dispatcher {
       if (queue == null) {
         if (!reserveCapacity()) {
           // reserveCapacity returned false because close() fired during the saturation stall.
-          // Roll back the pending increment so totalInFlight() doesn't get stuck; the record
+          // Roll back the pending increment so drainableCount() doesn't get stuck; the record
           // stays tracked-but-unmarked, so it is redelivered on restart.
           pending.decrementAndGet();
           if (abandonWarningEmitted.compareAndSet(false, true)) {
@@ -355,7 +355,7 @@ final class KeyOrderedDispatcher implements Dispatcher {
   }
 
   @Override
-  public long activeCount() {
+  public long drainableCount() {
     return pending.get();
   }
 

--- a/lib/kpipe-consumer/src/main/java/io/github/eschizoid/kpipe/consumer/ParallelDispatcher.java
+++ b/lib/kpipe-consumer/src/main/java/io/github/eschizoid/kpipe/consumer/ParallelDispatcher.java
@@ -15,7 +15,7 @@ import org.apache.kafka.clients.consumer.ConsumerRecord;
 /// `Executors.newVirtualThreadPerTaskExecutor()`. No ordering guarantees within or across
 /// keys; unbounded parallelism bounded only by Loom's carrier-thread capacity.
 ///
-/// Pairs with [BackpressureController#inFlightStrategy] in [KPipeConsumer] — `activeCount()`
+/// Pairs with [BackpressureController#inFlightStrategy] in [KPipeConsumer] — `drainableCount()`
 /// returns the number of records currently submitted but not yet finished.
 ///
 /// Owns its `ExecutorService` and shuts it down in [#close()] using the same `shutdown +
@@ -84,14 +84,14 @@ final class ParallelDispatcher implements Dispatcher {
   }
 
   @Override
-  public long activeCount() {
+  public long drainableCount() {
     return inFlight.get();
   }
 
   /// `shutdownNow()` doesn't strand `inFlight`: the VT-per-task executor has no work queue, so
   /// it returns an empty list and only interrupts running tasks — and interrupt doesn't skip a
   /// `finally`, so each task still decrements. A pooled executor WOULD strand queued tasks here;
-  /// `ParallelDispatcherTest.activeCountDrainsToZeroWhenCloseInterruptsRunningTask` guards it.
+  /// `ParallelDispatcherTest.drainableCountDrainsToZeroWhenCloseInterruptsRunningTask` guards it.
   @Override
   public void close() {
     try {

--- a/lib/kpipe-consumer/src/main/java/io/github/eschizoid/kpipe/consumer/SequentialDispatcher.java
+++ b/lib/kpipe-consumer/src/main/java/io/github/eschizoid/kpipe/consumer/SequentialDispatcher.java
@@ -9,19 +9,11 @@ import org.apache.kafka.clients.consumer.ConsumerRecord;
 ///
 /// Pairs with [BackpressureController#lagStrategy] in [KPipeConsumer] — when one record runs
 /// at a time, the only meaningful backlog metric is Kafka lag, not in-flight count. Lag-based
-/// backpressure does not consult `activeCount()`.
+/// backpressure does not consult `drainableCount()`.
 ///
-/// **Why we still track an in-flight count even though dispatch is inline.** The counter is
-/// reported as `inFlight` in [KPipeConsumer#getMetrics] (OTel + user-visible) and feeds the
-/// `totalInFlight()` reading used by `shutdownGracefully(timeout)` for drain reporting.
-/// Without tracking, both would read 0 even while a record is actively processing, which is
-/// misleading. The value is always 0 or 1 (a single consumer thread, one inline record at a
-/// time), but it's accurate.
-///
-/// Shutdown correctness is preserved by `KPipeConsumer.close()`'s `thread.join` on the
-/// consumer thread — the join waits for any in-flight `processTask.run()` to return regardless
-/// of `activeCount()`. PARALLEL and KEY_ORDERED dispatch onto distinct virtual threads, so
-/// they need a real counter to participate in `waitForInFlightDrain` too.
+/// `drainableCount()` is still tracked (0 or 1) so `inFlight` metrics and drain reporting stay
+/// accurate while a record runs inline. Shutdown correctness is preserved by
+/// `KPipeConsumer.close()`'s `thread.join` on the consumer thread.
 final class SequentialDispatcher implements Dispatcher {
 
   private final AtomicLong inFlight = new AtomicLong(0);
@@ -42,7 +34,7 @@ final class SequentialDispatcher implements Dispatcher {
   }
 
   @Override
-  public long activeCount() {
+  public long drainableCount() {
     return inFlight.get();
   }
 

--- a/lib/kpipe-consumer/src/test/java/io/github/eschizoid/kpipe/consumer/KPipeConsumerTest.java
+++ b/lib/kpipe-consumer/src/test/java/io/github/eschizoid/kpipe/consumer/KPipeConsumerTest.java
@@ -341,7 +341,7 @@ class KPipeConsumerTest {
   void closeDoesNotBurnTimeoutWaitingForBufferedBatchRecords() throws InterruptedException {
     // A size-only batch policy (maxSize=100) means a single buffered record never auto-flushes —
     // it's flushed by BatchPipelineWrapper.close() at teardown. So the in-flight drain must wait
-    // only on the dispatcher's active work (activeCount), not totalInFlight (which counts the
+    // only on the dispatcher's active work (drainableCount), not backpressureLoad (which counts the
     // buffered record); otherwise close() burns the whole waitForMessagesTimeout while the
     // dispatcher is already idle. Probe: close() returns well under the timeout AND the buffered
     // record is still flushed + its offset marked at teardown.

--- a/lib/kpipe-consumer/src/test/java/io/github/eschizoid/kpipe/consumer/KeyOrderedDispatcherCorrectnessTest.java
+++ b/lib/kpipe-consumer/src/test/java/io/github/eschizoid/kpipe/consumer/KeyOrderedDispatcherCorrectnessTest.java
@@ -288,14 +288,15 @@ class KeyOrderedDispatcherCorrectnessTest {
         () -> "key " + key + " reordered under saturation hold: " + tracker.observed
       );
     }
-    // activeCount is decremented in the worker's finally, which can run just after the per-record
+    // drainableCount is decremented in the worker's finally, which can run just after the
+    // per-record
     // latch the producers awaited counts down — so poll for the drain rather than reading it the
     // instant the latch releases (an immediate read flaked on slow CI runners).
     final var drainDeadline = System.nanoTime() + Duration.ofSeconds(5).toNanos();
-    while (dispatcher.activeCount() != 0 && System.nanoTime() < drainDeadline) {
+    while (dispatcher.drainableCount() != 0 && System.nanoTime() < drainDeadline) {
       Thread.onSpinWait();
     }
-    assertEquals(0, dispatcher.activeCount(), "no records may remain pending after saturation drains");
+    assertEquals(0, dispatcher.drainableCount(), "no records may remain pending after saturation drains");
     dispatcher.close();
   }
 
@@ -432,20 +433,21 @@ class KeyOrderedDispatcherCorrectnessTest {
     for (final var p : producers) p.join(Duration.ofSeconds(5));
 
     assertTrue(snapshotErrors.isEmpty(), () -> "diagnostic snapshot errors under churn: " + snapshotErrors);
-    // activeCount is decremented in the worker's finally, which can run just after the per-record
+    // drainableCount is decremented in the worker's finally, which can run just after the
+    // per-record
     // latch the producers awaited counts down — so poll for the drain rather than reading it the
     // instant the latch releases (an immediate read flaked on slow CI runners).
     final var drainDeadline = System.nanoTime() + Duration.ofSeconds(5).toNanos();
-    while (dispatcher.activeCount() != 0 && System.nanoTime() < drainDeadline) {
+    while (dispatcher.drainableCount() != 0 && System.nanoTime() < drainDeadline) {
       Thread.onSpinWait();
     }
-    assertEquals(0, dispatcher.activeCount(), "pending must drain to 0");
+    assertEquals(0, dispatcher.drainableCount(), "pending must drain to 0");
     dispatcher.close();
   }
 
   @Test
   void concurrentDispatchAndCloseNeverLeavesPendingNegativeOrStuck() throws InterruptedException {
-    // Race a close() against in-flight dispatch. activeCount() must never go negative (a
+    // Race a close() against in-flight dispatch. drainableCount() must never go negative (a
     // double-decrement bug) and must settle. We don't assert all records ran — close() is allowed
     // to abandon stragglers — only that the counter is non-negative throughout and ends >= 0.
     final var dispatcher = new KeyOrderedDispatcher(16);
@@ -456,7 +458,7 @@ class KeyOrderedDispatcherCorrectnessTest {
 
     final var watcher = Thread.ofVirtual().start(() -> {
       while (!stopWatch.get()) {
-        if (dispatcher.activeCount() < 0) negativeSeen.set(true);
+        if (dispatcher.drainableCount() < 0) negativeSeen.set(true);
         Thread.onSpinWait();
       }
     });
@@ -488,8 +490,8 @@ class KeyOrderedDispatcherCorrectnessTest {
     stopWatch.set(true);
     watcher.join(Duration.ofSeconds(5));
 
-    assertFalse(negativeSeen.get(), "activeCount() must never go negative under dispatch/close race");
-    assertTrue(dispatcher.activeCount() >= 0, "activeCount() must end non-negative");
+    assertFalse(negativeSeen.get(), "drainableCount() must never go negative under dispatch/close race");
+    assertTrue(dispatcher.drainableCount() >= 0, "drainableCount() must end non-negative");
   }
 
   private static List<Long> expectedOrder(final int n) {

--- a/lib/kpipe-consumer/src/test/java/io/github/eschizoid/kpipe/consumer/KeyOrderedDispatcherTest.java
+++ b/lib/kpipe-consumer/src/test/java/io/github/eschizoid/kpipe/consumer/KeyOrderedDispatcherTest.java
@@ -128,7 +128,7 @@ class KeyOrderedDispatcherTest {
   }
 
   @Test
-  void activeCountReflectsBufferedAndInFlight() throws InterruptedException {
+  void drainableCountReflectsBufferedAndInFlight() throws InterruptedException {
     final var dispatcher = new KeyOrderedDispatcher(KeyOrderedDispatcher.DEFAULT_MAX_KEYS);
     final var allowFinish = new CountDownLatch(1);
     final var firstStarted = new CountDownLatch(1);
@@ -151,15 +151,15 @@ class KeyOrderedDispatcherTest {
     }
 
     assertTrue(firstStarted.await(2, TimeUnit.SECONDS));
-    assertEquals(3, dispatcher.activeCount(), "all 3 records pending (1 in-flight + 2 queued)");
+    assertEquals(3, dispatcher.drainableCount(), "all 3 records pending (1 in-flight + 2 queued)");
 
     allowFinish.countDown();
     // Wait for everything to drain
     final var deadline = System.nanoTime() + Duration.ofSeconds(5).toNanos();
-    while (dispatcher.activeCount() > 0 && System.nanoTime() < deadline) {
+    while (dispatcher.drainableCount() > 0 && System.nanoTime() < deadline) {
       Thread.sleep(10);
     }
-    assertEquals(0, dispatcher.activeCount());
+    assertEquals(0, dispatcher.drainableCount());
     dispatcher.close();
   }
 
@@ -777,7 +777,7 @@ class KeyOrderedDispatcherTest {
     final var pendingBeforeSignal = new AtomicInteger();
     Thread.ofVirtual().start(() -> {
       dispatcher.dispatch(recordWithKey("c", 0), () -> {}, () -> {});
-      pendingBeforeSignal.set((int) dispatcher.activeCount());
+      pendingBeforeSignal.set((int) dispatcher.drainableCount());
       thirdCompleted.countDown();
     });
 
@@ -921,7 +921,7 @@ class KeyOrderedDispatcherTest {
 
       // Wait for everything to drain so the second saturation round has empty queues to fill.
       final var deadline = System.nanoTime() + Duration.ofSeconds(2).toNanos();
-      while (dispatcher.activeCount() > 0 && System.nanoTime() < deadline) Thread.sleep(5);
+      while (dispatcher.drainableCount() > 0 && System.nanoTime() < deadline) Thread.sleep(5);
 
       // Saturation round 2: same scenario, fresh blocked workers.
       final var workerA2 = new CountDownLatch(1);
@@ -1021,7 +1021,7 @@ class KeyOrderedDispatcherTest {
     final var deadline = System.nanoTime() + Duration.ofSeconds(2).toNanos();
     while (firstWorker.isAlive() && System.nanoTime() < deadline) Thread.sleep(5);
     assertFalse(firstWorker.isAlive(), "first worker VT must exit after queue drains");
-    assertEquals(0, dispatcher.activeCount(), "pending must be 0 between batches");
+    assertEquals(0, dispatcher.drainableCount(), "pending must be 0 between batches");
 
     // Second dispatch on the same key — must spawn a fresh worker, not reuse the dead one.
     dispatcher.dispatch(

--- a/lib/kpipe-consumer/src/test/java/io/github/eschizoid/kpipe/consumer/ParallelDispatcherRaceTest.java
+++ b/lib/kpipe-consumer/src/test/java/io/github/eschizoid/kpipe/consumer/ParallelDispatcherRaceTest.java
@@ -16,7 +16,7 @@ import org.junit.jupiter.api.Test;
 /// Race-on-throw correctness tests for [ParallelDispatcher].
 ///
 /// The dispatcher owns the in-flight counter that the parallel-mode in-flight backpressure
-/// strategy reads through `KPipeConsumer.totalInFlight()`. The counter is the single source
+/// strategy reads through `KPipeConsumer.backpressureLoad()`. The counter is the single source
 /// of truth for the high/low watermark, so a leaked or double-counted in-flight on the throw
 /// path translates directly into either pause-forever (the watermark latches high and the
 /// consumer parks indefinitely) or pause-never (the count underflows and backpressure stops
@@ -43,7 +43,7 @@ class ParallelDispatcherRaceTest {
 
   private static void awaitInFlightZero(final ParallelDispatcher dispatcher) throws InterruptedException {
     final var deadline = System.nanoTime() + Duration.ofSeconds(5).toNanos();
-    while (dispatcher.activeCount() > 0 && System.nanoTime() < deadline) Thread.sleep(5);
+    while (dispatcher.drainableCount() > 0 && System.nanoTime() < deadline) Thread.sleep(5);
   }
 
   @Test
@@ -62,7 +62,7 @@ class ParallelDispatcherRaceTest {
       // Park until the throw-path onComplete unparks us, the way the consumer thread
       // waits for
       // the in-flight count to drop. A while-loop guards against spurious wakeups.
-      while (dispatcher.activeCount() > 0) {
+      while (dispatcher.drainableCount() > 0) {
         LockSupport.park();
       }
       waiterReleased.countDown();
@@ -83,7 +83,7 @@ class ParallelDispatcherRaceTest {
       "throw-path onComplete must unpark the waiter; a swallowed onComplete would strand it"
     );
     awaitInFlightZero(dispatcher);
-    assertEquals(0, dispatcher.activeCount(), "in-flight must drain to 0 after the throwing record");
+    assertEquals(0, dispatcher.drainableCount(), "in-flight must drain to 0 after the throwing record");
     assertEquals(0, rejectCount.get(), "a throwing task body is not a rejection");
     dispatcher.close();
   }
@@ -132,7 +132,7 @@ class ParallelDispatcherRaceTest {
     assertTrue(allCompleted.await(10, TimeUnit.SECONDS), "onComplete must fire for every record");
 
     awaitInFlightZero(dispatcher);
-    assertEquals(0, dispatcher.activeCount(), "interleaved throws and successes must drain to 0");
+    assertEquals(0, dispatcher.drainableCount(), "interleaved throws and successes must drain to 0");
     assertEquals(total, onCompleteCount.get(), "onComplete must fire exactly once per record");
     assertEquals(0, rejectCount.get(), "no dispatch was rejected before close");
     dispatcher.close();
@@ -140,7 +140,7 @@ class ParallelDispatcherRaceTest {
 
   @Test
   void backpressureRecoversAfterABurstOfThrows() throws InterruptedException {
-    // The consumer's totalInFlight() feeds the dispatcher's activeCount() into the in-flight
+    // The consumer's backpressureLoad() feeds the dispatcher's drainableCount() into the in-flight
     // backpressure strategy. This test wires a real BackpressureController to the dispatcher's
     // count, the same way the consumer does, and then exercises the pause/resume transition
     // across a burst of records that all throw.
@@ -157,7 +157,7 @@ class ParallelDispatcherRaceTest {
     final var controller = new BackpressureController(
       8,
       4,
-      BackpressureController.inFlightStrategy(dispatcher::activeCount)
+      BackpressureController.inFlightStrategy(dispatcher::drainableCount)
     );
     final var total = 32;
     final var release = new CountDownLatch(1);
@@ -196,7 +196,7 @@ class ParallelDispatcherRaceTest {
     assertTrue(allCompleted.await(10, TimeUnit.SECONDS), "every throwing record must complete after release");
     awaitInFlightZero(dispatcher);
 
-    assertEquals(0, dispatcher.activeCount(), "a burst of throws must leave no residual in-flight count");
+    assertEquals(0, dispatcher.drainableCount(), "a burst of throws must leave no residual in-flight count");
     // A consumer that paused at the high watermark must now be told to RESUME — the throwing
     // burst did not corrupt the count, so the watermark recovers.
     assertEquals(
@@ -222,7 +222,7 @@ class ParallelDispatcherRaceTest {
 
     final var watcher = Thread.ofVirtual().start(() -> {
       while (stopWatching.getCount() > 0) {
-        final var current = dispatcher.activeCount();
+        final var current = dispatcher.drainableCount();
         minObserved.updateAndGet(prev -> Math.min(prev, current));
         Thread.onSpinWait();
       }
@@ -255,7 +255,7 @@ class ParallelDispatcherRaceTest {
     watcher.join(Duration.ofSeconds(2));
 
     assertTrue(minObserved.get() >= 0, "in-flight count must never go negative; saw " + minObserved.get());
-    assertEquals(0, dispatcher.activeCount(), "in-flight must settle at exactly 0 after the throwing burst");
+    assertEquals(0, dispatcher.drainableCount(), "in-flight must settle at exactly 0 after the throwing burst");
     dispatcher.close();
   }
 }

--- a/lib/kpipe-consumer/src/test/java/io/github/eschizoid/kpipe/consumer/ParallelDispatcherTest.java
+++ b/lib/kpipe-consumer/src/test/java/io/github/eschizoid/kpipe/consumer/ParallelDispatcherTest.java
@@ -115,10 +115,13 @@ class ParallelDispatcherTest {
         throw new IllegalStateException("onComplete boom");
       });
       assertTrue(ran.await(2, TimeUnit.SECONDS), "processTask must run");
-      awaitTrue(() -> dispatcher.activeCount() == 0 && !capture.records().isEmpty());
-      assertEquals(0, dispatcher.activeCount(), "a throwing onComplete must not strand in-flight");
+      awaitTrue(() -> dispatcher.drainableCount() == 0 && !capture.records().isEmpty());
+      assertEquals(0, dispatcher.drainableCount(), "a throwing onComplete must not strand in-flight");
       assertTrue(
-        capture.records().stream().anyMatch(r -> r.getMessage().contains("onComplete callback threw")),
+        capture
+          .records()
+          .stream()
+          .anyMatch(r -> r.getMessage().contains("onComplete callback threw")),
         "the throwing onComplete must be logged at WARNING"
       );
     } finally {
@@ -139,7 +142,7 @@ class ParallelDispatcherTest {
 
     dispatcher.dispatch(record(0), () -> {}, () -> {});
     assertEquals(1, rejectCount.get(), "dispatch after close must be rejected (executor shut down)");
-    assertEquals(0, dispatcher.activeCount(), "rejected dispatch must roll back the in-flight counter");
+    assertEquals(0, dispatcher.drainableCount(), "rejected dispatch must roll back the in-flight counter");
   }
 
   @Test
@@ -154,17 +157,17 @@ class ParallelDispatcherTest {
     assertTrue(ran.await(2, TimeUnit.SECONDS), "task must run on a virtual thread");
     assertTrue(completed.await(2, TimeUnit.SECONDS), "onComplete must fire");
     final var deadline = System.nanoTime() + Duration.ofSeconds(2).toNanos();
-    while (dispatcher.activeCount() > 0 && System.nanoTime() < deadline) Thread.sleep(5);
-    assertEquals(0, dispatcher.activeCount(), "in-flight must drain to 0");
+    while (dispatcher.drainableCount() > 0 && System.nanoTime() < deadline) Thread.sleep(5);
+    assertEquals(0, dispatcher.drainableCount(), "in-flight must drain to 0");
     assertEquals(0, rejectCount.get(), "no rejection on the happy path");
     dispatcher.close();
   }
 
   @Test
-  void activeCountDecrementedWhenTaskThrows() throws InterruptedException {
+  void drainableCountDecrementedWhenTaskThrows() throws InterruptedException {
     // Guards the criticality-9 race in §20: ParallelDispatcher owns the in-flight counter that
     // drives PARALLEL-mode backpressure (§5). If the task body throws and the finally block did
-    // NOT decrement, activeCount() would climb monotonically per failed record — the watermark
+    // NOT decrement, drainableCount() would climb monotonically per failed record — the watermark
     // would latch at HIGH and the consumer would pause forever (deadlock). Conversely, double
     // decrement would underflow toward negative and the consumer would never pause (false-
     // negative backpressure). The production code wraps processTask.run() in try/finally so
@@ -183,17 +186,17 @@ class ParallelDispatcherTest {
 
     assertTrue(completed.await(2, TimeUnit.SECONDS), "onComplete must fire even when task throws");
     final var deadline = System.nanoTime() + Duration.ofSeconds(2).toNanos();
-    while (dispatcher.activeCount() > 0 && System.nanoTime() < deadline) Thread.sleep(5);
-    assertEquals(0, dispatcher.activeCount(), "throwing task's finally must still decrement in-flight");
+    while (dispatcher.drainableCount() > 0 && System.nanoTime() < deadline) Thread.sleep(5);
+    assertEquals(0, dispatcher.drainableCount(), "throwing task's finally must still decrement in-flight");
     assertEquals(0, rejectCount.get(), "a throwing task body is not a rejection");
     dispatcher.close();
   }
 
   @Test
-  void activeCountDrainsWhenTaskThrowsError() throws InterruptedException {
-    // Sibling of activeCountDecrementedWhenTaskThrows for `Error` (e.g. `AssertionError`),
+  void drainableCountDrainsWhenTaskThrowsError() throws InterruptedException {
+    // Sibling of drainableCountDecrementedWhenTaskThrows for `Error` (e.g. `AssertionError`),
     // which is a Throwable-not-Exception and would bypass any future narrowing of the production
-    // try/finally to `catch (Exception) { ... } finally { ... }` — activeCount would silently
+    // try/finally to `catch (Exception) { ... } finally { ... }` — drainableCount would silently
     // strand on every Error escape.
     final var rejectCount = new AtomicInteger(0);
     final var dispatcher = newDispatcher(rejectCount);
@@ -209,14 +212,14 @@ class ParallelDispatcherTest {
 
     assertTrue(completed.await(2, TimeUnit.SECONDS), "onComplete must fire even when task throws an Error");
     final var deadline = System.nanoTime() + Duration.ofSeconds(2).toNanos();
-    while (dispatcher.activeCount() > 0 && System.nanoTime() < deadline) Thread.sleep(5);
-    assertEquals(0, dispatcher.activeCount(), "Error-throwing task's finally must still decrement in-flight");
+    while (dispatcher.drainableCount() > 0 && System.nanoTime() < deadline) Thread.sleep(5);
+    assertEquals(0, dispatcher.drainableCount(), "Error-throwing task's finally must still decrement in-flight");
     dispatcher.close();
   }
 
   @Test
   void onCompleteFiresExactlyOnceWhenTaskThrows() throws InterruptedException {
-    // Pair test for activeCountDecrementedWhenTaskThrows: the consumer's afterRecordComplete()
+    // Pair test for drainableCountDecrementedWhenTaskThrows: the consumer's afterRecordComplete()
     // unparks the consumer thread when backpressure is held (§11 LockSupport park/unpark). If
     // onComplete fired twice on the throw path (e.g. once in a catch and once in finally), the
     // consumer would re-evaluate twice per failed record — wasteful but tolerable. If it fired
@@ -243,8 +246,8 @@ class ParallelDispatcherTest {
     Thread.sleep(100);
     assertEquals(1, completeCount.get(), "onComplete must fire exactly once when task throws");
     final var deadline = System.nanoTime() + Duration.ofSeconds(2).toNanos();
-    while (dispatcher.activeCount() > 0 && System.nanoTime() < deadline) Thread.sleep(5);
-    assertEquals(0, dispatcher.activeCount(), "in-flight must drain to 0 after throwing task");
+    while (dispatcher.drainableCount() > 0 && System.nanoTime() < deadline) Thread.sleep(5);
+    assertEquals(0, dispatcher.drainableCount(), "in-flight must drain to 0 after throwing task");
     dispatcher.close();
   }
 
@@ -252,7 +255,7 @@ class ParallelDispatcherTest {
   void dispatchAfterCloseHitsRejectHandler() throws InterruptedException {
     // Explicit pin for the post-close rejection path. closeShutsDownExecutorEvenWithNoDispatches
     // already exercises the reject handler via a never-dispatched dispatcher; this test adds the
-    // stronger contract: the task body itself MUST NOT execute on rejection, and activeCount()
+    // stronger contract: the task body itself MUST NOT execute on rejection, and drainableCount()
     // must roll back from the speculative increment in dispatch(). If the increment were not
     // rolled back, every shutdown-race rejection would leak a count, and shutdownGracefully()
     // would burn its full timeout waiting on a ghost.
@@ -272,7 +275,7 @@ class ParallelDispatcherTest {
       onCompleteRan.get(),
       "rejected dispatch must NOT invoke onComplete (the consumer takes the reject path instead)"
     );
-    assertEquals(0, dispatcher.activeCount(), "rejected dispatch must roll back the speculative increment");
+    assertEquals(0, dispatcher.drainableCount(), "rejected dispatch must roll back the speculative increment");
   }
 
   @Test
@@ -281,8 +284,9 @@ class ParallelDispatcherTest {
     // shut-down mid-flight while N dispatcher threads call dispatch() concurrently. Each
     // dispatch ends in one of two terminal accounting states — task started + finally drained,
     // OR rejected + counter rolled back. There is no third "leaked" state. The invariant: after
-    // all dispatcher threads return and close() has completed, activeCount() must drain to 0,
-    // AND (started + rejected) must equal total. A leak shows up either as a non-zero activeCount
+    // all dispatcher threads return and close() has completed, drainableCount() must drain to 0,
+    // AND (started + rejected) must equal total. A leak shows up either as a non-zero
+    // drainableCount
     // (decrement missing) or as a started + rejected != total mismatch (silent drop).
     final var rejectCount = new AtomicInteger(0);
     final var dispatcher = newDispatcher(rejectCount, Duration.ofSeconds(2));
@@ -322,8 +326,8 @@ class ParallelDispatcherTest {
     assertTrue(closeReturned.await(10, TimeUnit.SECONDS), "close() must return");
 
     final var deadline = System.nanoTime() + Duration.ofSeconds(5).toNanos();
-    while (dispatcher.activeCount() > 0 && System.nanoTime() < deadline) Thread.sleep(10);
-    assertEquals(0, dispatcher.activeCount(), "activeCount must drain to 0 after concurrent dispatch+close");
+    while (dispatcher.drainableCount() > 0 && System.nanoTime() < deadline) Thread.sleep(10);
+    assertEquals(0, dispatcher.drainableCount(), "drainableCount must drain to 0 after concurrent dispatch+close");
     assertEquals(
       totalDispatches,
       started.get() + rejectCount.get(),
@@ -332,7 +336,7 @@ class ParallelDispatcherTest {
   }
 
   @Test
-  void activeCountDrainsToZeroWhenCloseInterruptsRunningTask() throws InterruptedException {
+  void drainableCountDrainsToZeroWhenCloseInterruptsRunningTask() throws InterruptedException {
     // close() calls shutdownNow() when awaitTermination times out. The concern: an interrupted
     // task never runs its finally, leaving inFlight stuck > 0. That's a real risk for a POOLED
     // executor (shutdownNow returns queued-unstarted tasks), but ParallelDispatcher uses
@@ -358,12 +362,12 @@ class ParallelDispatcherTest {
       () -> {}
     );
     assertTrue(started.await(2, TimeUnit.SECONDS), "task must start");
-    assertEquals(1, dispatcher.activeCount(), "one task in flight before close");
+    assertEquals(1, dispatcher.drainableCount(), "one task in flight before close");
 
     dispatcher.close(); // awaitTermination(50ms) times out → shutdownNow() interrupts the sleep
 
     final var deadline = System.nanoTime() + Duration.ofSeconds(5).toNanos();
-    while (dispatcher.activeCount() > 0 && System.nanoTime() < deadline) Thread.sleep(5);
-    assertEquals(0, dispatcher.activeCount(), "interrupted task's finally must still decrement in-flight");
+    while (dispatcher.drainableCount() > 0 && System.nanoTime() < deadline) Thread.sleep(5);
+    assertEquals(0, dispatcher.drainableCount(), "interrupted task's finally must still decrement in-flight");
   }
 }

--- a/lib/kpipe-consumer/src/test/java/io/github/eschizoid/kpipe/consumer/SequentialDispatcherTest.java
+++ b/lib/kpipe-consumer/src/test/java/io/github/eschizoid/kpipe/consumer/SequentialDispatcherTest.java
@@ -20,21 +20,21 @@ class SequentialDispatcherTest {
   }
 
   @Test
-  void activeCountIsZeroWhenIdle() {
+  void drainableCountIsZeroWhenIdle() {
     final var dispatcher = new SequentialDispatcher();
-    assertEquals(0L, dispatcher.activeCount());
+    assertEquals(0L, dispatcher.drainableCount());
     dispatcher.close();
   }
 
   @Test
-  void activeCountReadsOneWhileProcessingThenZero() throws InterruptedException {
+  void drainableCountReadsOneWhileProcessingThenZero() throws InterruptedException {
     final var dispatcher = new SequentialDispatcher();
     final var insideTask = new CountDownLatch(1);
     final var allowFinish = new CountDownLatch(1);
     final var observed = new AtomicLong(-1);
 
     // SequentialDispatcher.dispatch is synchronous on the calling thread, so we have to run
-    // it on a separate thread to observe activeCount mid-flight.
+    // it on a separate thread to observe drainableCount mid-flight.
     final var worker = Thread.ofVirtual().start(() ->
       dispatcher.dispatch(
         record(0),
@@ -51,12 +51,12 @@ class SequentialDispatcherTest {
     );
 
     assertTrue(insideTask.await(2, TimeUnit.SECONDS), "task should start");
-    observed.set(dispatcher.activeCount());
+    observed.set(dispatcher.drainableCount());
     allowFinish.countDown();
     worker.join(2_000);
 
-    assertEquals(1L, observed.get(), "activeCount must report 1 while processing");
-    assertEquals(0L, dispatcher.activeCount(), "activeCount must drop to 0 after task returns");
+    assertEquals(1L, observed.get(), "drainableCount must report 1 while processing");
+    assertEquals(0L, dispatcher.drainableCount(), "drainableCount must drop to 0 after task returns");
     dispatcher.close();
   }
 
@@ -78,7 +78,7 @@ class SequentialDispatcherTest {
     }
 
     assertEquals(1L, completed.get(), "onComplete must fire even when task throws");
-    assertEquals(0L, dispatcher.activeCount(), "activeCount must drop to 0 even when task throws");
+    assertEquals(0L, dispatcher.drainableCount(), "drainableCount must drop to 0 even when task throws");
     dispatcher.close();
   }
 
@@ -109,6 +109,6 @@ class SequentialDispatcherTest {
 
     assertEquals(1L, ran.get(), "processTask must still run inline after close()");
     assertEquals(1L, completed.get(), "onComplete must still fire after close()");
-    assertEquals(0L, dispatcher.activeCount(), "in-flight must drain to 0 after the inline run");
+    assertEquals(0L, dispatcher.drainableCount(), "in-flight must drain to 0 after the inline run");
   }
 }

--- a/lib/kpipe-consumer/src/test/java/io/github/eschizoid/kpipe/consumer/WatermarkHysteresisTest.java
+++ b/lib/kpipe-consumer/src/test/java/io/github/eschizoid/kpipe/consumer/WatermarkHysteresisTest.java
@@ -35,7 +35,7 @@ import org.mockito.Mockito;
 /// above it, and a value oscillating inside the band never flips the decision. Both the
 /// in-flight (PARALLEL) and lag (SEQUENTIAL) strategies are exercised through the same
 /// decision path, and the in-flight reading is verified to include buffered batch records the
-/// way the consumer's `totalInFlight()` composes the metric.
+/// way the consumer's `backpressureLoad()` composes the metric.
 ///
 /// Watermarks of `100` (high) / `50` (low) are used throughout so the boundary indices read
 /// cleanly.
@@ -292,7 +292,7 @@ class WatermarkHysteresisTest {
   @Nested
   class InFlightIncludesBufferedBatchRecords {
 
-    /// The consumer composes its in-flight metric as `dispatcher.activeCount() + Σ buffered
+    /// The consumer composes its in-flight metric as `dispatcher.drainableCount() + Σ buffered
     /// batch records`. A controller wired to that composite supplier must see buffered records
     /// as real pressure: a dispatcher that has drained to zero can still keep the consumer
     /// paused if enough records are sitting in batch buffers. This models that composite supplier
@@ -301,7 +301,7 @@ class WatermarkHysteresisTest {
     void bufferedBatchRecordsAloneCanTripAndHoldThePauseDecision() {
       final var dispatcherPending = new AtomicLong(0);
       final var bufferedBatch = new AtomicLong(0);
-      // Mirrors KPipeConsumer.totalInFlight(): pending workers + buffered batch records.
+      // Mirrors KPipeConsumer.backpressureLoad(): pending workers + buffered batch records.
       final var controller = new BackpressureController(
         HIGH,
         LOW,
@@ -317,7 +317,7 @@ class WatermarkHysteresisTest {
       );
 
       // The dispatcher fully drains, yet buffered records still sit above the low watermark →
-      // stay paused. If totalInFlight ignored the buffer this would wrongly resume.
+      // stay paused. If backpressureLoad ignored the buffer this would wrongly resume.
       dispatcherPending.set(0);
       bufferedBatch.set(LOW + 1);
       assertEquals(

--- a/lib/kpipe-core/src/main/java/io/github/eschizoid/kpipe/registry/SchemaResolver.java
+++ b/lib/kpipe-core/src/main/java/io/github/eschizoid/kpipe/registry/SchemaResolver.java
@@ -20,4 +20,20 @@ public interface SchemaResolver {
   /// @return the schema text (Avro JSON or Protobuf `.proto` source)
   /// @throws RuntimeException if the lookup fails or the schema is not found
   String lookupById(int schemaId);
+
+  /// Returns [#lookupById(int)]'s result after enforcing the no-null/no-blank contract. Format
+  /// modules call this on the read path so a misbehaving resolver fails with one uniform
+  /// message instead of each format re-checking locally. Read-path failures throw
+  /// `IllegalStateException`, matching the formats' own deserialize failures.
+  ///
+  /// @param schemaId the integer schema identifier (typically extracted from the wire envelope)
+  /// @return the schema text, guaranteed non-null and non-blank
+  /// @throws IllegalStateException if the resolver returned null or blank text
+  default String lookupRequired(final int schemaId) {
+    final var text = lookupById(schemaId);
+    if (text == null || text.isBlank()) throw new IllegalStateException(
+      "Schema resolver returned empty schema for id " + schemaId
+    );
+    return text;
+  }
 }

--- a/lib/kpipe-core/src/test/java/io/github/eschizoid/kpipe/registry/SchemaResolverLookupRequiredTest.java
+++ b/lib/kpipe-core/src/test/java/io/github/eschizoid/kpipe/registry/SchemaResolverLookupRequiredTest.java
@@ -1,0 +1,42 @@
+package io.github.eschizoid.kpipe.registry;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+/// Pins the [SchemaResolver#lookupRequired(int)] default method: a resolver that violates the
+/// no-null/no-blank contract fails with the one uniform message, and a well-behaved resolver's
+/// text passes through unchanged. Format modules rely on this instead of re-checking locally.
+class SchemaResolverLookupRequiredTest {
+
+  @Test
+  void nullSchemaTextThrowsIllegalStateWithUniformMessage() {
+    final SchemaResolver resolver = schemaId -> null;
+    final var ex = assertThrows(IllegalStateException.class, () -> resolver.lookupRequired(42));
+    assertEquals("Schema resolver returned empty schema for id 42", ex.getMessage());
+  }
+
+  @Test
+  void blankSchemaTextThrowsIllegalStateWithUniformMessage() {
+    final SchemaResolver resolver = schemaId -> "   ";
+    final var ex = assertThrows(IllegalStateException.class, () -> resolver.lookupRequired(7));
+    assertEquals("Schema resolver returned empty schema for id 7", ex.getMessage());
+  }
+
+  @Test
+  void nonBlankSchemaTextPassesThroughUnchanged() {
+    final SchemaResolver resolver = schemaId -> "{\"type\":\"string\"} for " + schemaId;
+    assertEquals("{\"type\":\"string\"} for 5", resolver.lookupRequired(5));
+  }
+
+  @Test
+  void resolverExceptionPropagatesUnchanged() {
+    final SchemaResolver resolver = schemaId -> {
+      throw new RuntimeException("registry down");
+    };
+    final var ex = assertThrows(RuntimeException.class, () -> resolver.lookupRequired(1));
+    assertTrue(ex.getMessage().contains("registry down"));
+  }
+}

--- a/lib/kpipe-format-avro/src/main/java/io/github/eschizoid/kpipe/format/avro/AvroFormat.java
+++ b/lib/kpipe-format-avro/src/main/java/io/github/eschizoid/kpipe/format/avro/AvroFormat.java
@@ -45,7 +45,8 @@ import org.apache.avro.io.EncoderFactory;
 /// }
 /// ```
 ///
-/// Schema-Registry mode replaces the manual `KPipe.avro(topic, props, format).skipBytes(5).pipe(...)` pattern.
+/// Schema-Registry mode replaces the manual `KPipe.avro(topic, props,
+// format).skipBytes(5).pipe(...)` pattern.
 /// Do **not** combine `withRegistry(...)` with `skipBytes(5)` — the format already consumes
 /// the envelope.
 public final class AvroFormat implements MessageFormat<GenericRecord> {
@@ -165,8 +166,13 @@ public final class AvroFormat implements MessageFormat<GenericRecord> {
       // original cause is always attached, so a genuine programming error (e.g. an NPE) is still
       // visible in the cause chain rather than swallowed.
       throw new IllegalStateException(
-        "AvroFormat.deserialize failed in static mode on " + data.length + " bytes against schema " +
-          staticSchema.getFullName() + " (first bytes " + WireDiagnostics.hexPreview(data) + ")",
+        "AvroFormat.deserialize failed in static mode on " +
+          data.length +
+          " bytes against schema " +
+          staticSchema.getFullName() +
+          " (first bytes " +
+          WireDiagnostics.hexPreview(data) +
+          ")",
         e
       );
     }
@@ -175,27 +181,31 @@ public final class AvroFormat implements MessageFormat<GenericRecord> {
   private GenericRecord deserializeFromEnvelope(final byte[] data) {
     final int schemaId = ConfluentEnvelope.readSchemaId(data);
 
-    final var schema = resolvedSchemas.computeIfAbsent(schemaId, id -> {
-      final var json = resolver.lookupById(id);
-      if (json == null || json.isBlank()) throw new IllegalStateException(
-        "Schema resolver returned empty schema for id " + id
-      );
-      return new Schema.Parser().parse(json);
-    });
+    final var schema = resolvedSchemas.computeIfAbsent(schemaId, id ->
+      new Schema.Parser().parse(resolver.lookupRequired(id))
+    );
 
     final var reader = new GenericDatumReader<GenericRecord>(schema);
-    final var decoder = DecoderFactory.get()
-      .binaryDecoder(data, ConfluentEnvelope.HEADER_LENGTH, data.length - ConfluentEnvelope.HEADER_LENGTH, null);
+    final var decoder = DecoderFactory.get().binaryDecoder(
+      data,
+      ConfluentEnvelope.HEADER_LENGTH,
+      data.length - ConfluentEnvelope.HEADER_LENGTH,
+      null
+    );
     try {
       return reader.read(null, decoder);
     } catch (final IOException | RuntimeException e) {
       // RuntimeException is caught alongside IOException to match the static path: a malformed
-      // payload under a valid envelope surfaces as Avro's own AvroRuntimeException, not IOException,
+      // payload under a valid envelope surfaces as Avro's own AvroRuntimeException, not
+      // IOException,
       // so the production SR path would otherwise debug worse than the static path (context-free
       // escape). The original cause is always attached.
       throw new IllegalStateException(
-        "Failed to decode Avro record under Confluent wire envelope (schema id " + schemaId +
-          ", first bytes " + WireDiagnostics.hexPreview(data) + ")",
+        "Failed to decode Avro record under Confluent wire envelope (schema id " +
+          schemaId +
+          ", first bytes " +
+          WireDiagnostics.hexPreview(data) +
+          ")",
         e
       );
     }

--- a/lib/kpipe-format-protobuf/src/main/java/io/github/eschizoid/kpipe/format/protobuf/ProtobufFormat.java
+++ b/lib/kpipe-format-protobuf/src/main/java/io/github/eschizoid/kpipe/format/protobuf/ProtobufFormat.java
@@ -96,7 +96,8 @@ public final class ProtobufFormat implements MessageFormat<Message> {
     // ServiceLoader iteration order is unspecified — sort providers by implementation class name so
     // the pick is deterministic across classpath layouts. Sort on `provider.type()` (the Class,
     // no instantiation) and only `get()` the chosen provider.
-    final var providers = ServiceLoader.load(ProtobufDescriptorCompiler.class).stream()
+    final var providers = ServiceLoader.load(ProtobufDescriptorCompiler.class)
+      .stream()
       .sorted(Comparator.comparing(provider -> provider.type().getName()))
       .toList();
     if (providers.isEmpty()) throw new IllegalStateException(
@@ -190,15 +191,8 @@ public final class ProtobufFormat implements MessageFormat<Message> {
     final var messageIndex = readMessageIndex(cursor, data, schemaId);
     final var payloadOffset = cursor.offset();
 
-    final var messageDescriptor = resolvedDescriptors.computeIfAbsent(
-      new DescriptorKey(schemaId, messageIndex),
-      key -> {
-        final var protoText = resolver.lookupById(key.schemaId());
-        if (protoText == null || protoText.isBlank()) throw new IllegalStateException(
-          "Schema resolver returned empty schema for id " + key.schemaId()
-        );
-        return compiler.compile(protoText, key.messageIndex());
-      }
+    final var messageDescriptor = resolvedDescriptors.computeIfAbsent(new DescriptorKey(schemaId, messageIndex), key ->
+      compiler.compile(resolver.lookupRequired(key.schemaId()), key.messageIndex())
     );
 
     try {
@@ -292,5 +286,4 @@ public final class ProtobufFormat implements MessageFormat<Message> {
       return List.copyOf(list);
     }
   }
-
 }


### PR DESCRIPTION
Architecture-pass items #10 + #12 + #13, three small independent fixes:

- **In-flight concept split:** `Dispatcher.activeCount()` → `drainableCount()` (what shutdown drain waits on) and `KPipeConsumer.totalInFlight()` → `backpressureLoad()` (drainable + buffered batch records, what the watermark reads). The four comment blocks that re-litigated this distinction are deleted — the names now carry the invariant. Verified internal-only surface before renaming; the `inFlight` metric key and `HealthSnapshot.inFlight` are untouched public surface. `DispatcherActiveCountJCStressTest` → `DispatcherDrainableCountJCStressTest`.
- **`SchemaResolver.lookupRequired(int)` default** owns the null/blank contract check both AvroFormat and ProtobufFormat duplicated verbatim; both formats collapse to one-liners. 4 new contract tests.
- **Registry-mode `Collection<String>` overloads** for `KPipe.avro/protobuf(topics, props, resolver)` — exact mirrors of the single-topic siblings incl. the correct unsupported-console factories; docs/API.md notes flipped. Facade build tests added (protobuf asserts the ServiceLoader delegation, per the established pattern for the deliberately-absent `-confluent` test dependency).

Suites green: core 89, consumer 425, api 88, avro 45, protobuf 40, jcstress compiles.