### PR TITLE
refactor(core)!: registry namespace symmetry — unregisterOperator/clearOperators/getOperatorKeys/getOperatorMetrics + getAllOperators

### DIFF
--- a/lib/kpipe-consumer/src/main/java/io/github/eschizoid/kpipe/consumer/metrics/EntryMetricsReporter.java
+++ b/lib/kpipe-consumer/src/main/java/io/github/eschizoid/kpipe/consumer/metrics/EntryMetricsReporter.java
@@ -90,7 +90,7 @@ public record EntryMetricsReporter(
   /// @return a new reporter wired with the [#LOGGING] default output
   public static EntryMetricsReporter forProcessors(final MessageProcessorRegistry registry) {
     Objects.requireNonNull(registry, "registry cannot be null");
-    return new EntryMetricsReporter("Processor", registry::getKeys, registry::getMetrics, LOGGING);
+    return new EntryMetricsReporter("Processor", registry::getOperatorKeys, registry::getOperatorMetrics, LOGGING);
   }
 
   /// Creates a reporter for the given subset of operator keys, with default log-based output.
@@ -104,7 +104,7 @@ public record EntryMetricsReporter(
   ) {
     Objects.requireNonNull(registry, "registry cannot be null");
     Objects.requireNonNull(keys, "keys cannot be null");
-    return new EntryMetricsReporter("Processor", () -> keys, registry::getMetrics, LOGGING);
+    return new EntryMetricsReporter("Processor", () -> keys, registry::getOperatorMetrics, LOGGING);
   }
 
   /// Creates a reporter for every sink registered in `registry`, with default log-based output.

--- a/lib/kpipe-consumer/src/test/java/io/github/eschizoid/kpipe/consumer/metrics/EntryMetricsReporterTest.java
+++ b/lib/kpipe-consumer/src/test/java/io/github/eschizoid/kpipe/consumer/metrics/EntryMetricsReporterTest.java
@@ -52,10 +52,15 @@ class EntryMetricsReporterTest {
 
   @Test
   void forProcessors_emitsOneLinePerKeyUsingProcessorPrefix() {
-    doReturn(keys).when(registry).getKeys();
-    doReturn(testMetrics).when(registry).getMetrics(any(RegistryKey.class));
+    doReturn(keys).when(registry).getOperatorKeys();
+    doReturn(testMetrics).when(registry).getOperatorMetrics(any(RegistryKey.class));
 
-    new EntryMetricsReporter("Processor", registry::getKeys, registry::getMetrics, reporter).reportMetrics();
+    new EntryMetricsReporter(
+      "Processor",
+      registry::getOperatorKeys,
+      registry::getOperatorMetrics,
+      reporter
+    ).reportMetrics();
 
     verify(reporter, times(keys.size())).accept(reportCaptor.capture());
     for (final var line : reportCaptor.getAllValues()) {
@@ -68,18 +73,18 @@ class EntryMetricsReporterTest {
   void forProcessors_subset_doesNotQueryAllKeys() {
     final RegistryKey<?> selectedKey = RegistryKey.of("selected", Object.class);
     final Set<RegistryKey<?>> selected = Collections.singleton(selectedKey);
-    doReturn(testMetrics).when(registry).getMetrics(selectedKey);
+    doReturn(testMetrics).when(registry).getOperatorMetrics(selectedKey);
 
-    new EntryMetricsReporter("Processor", () -> selected, registry::getMetrics, reporter).reportMetrics();
+    new EntryMetricsReporter("Processor", () -> selected, registry::getOperatorMetrics, reporter).reportMetrics();
 
     verify(reporter, times(1)).accept(contains("selected"));
-    verify(registry, never()).getKeys();
+    verify(registry, never()).getOperatorKeys();
   }
 
   @Test
   void forProcessors_defaultReporterUsesLOGGING() {
-    doReturn(keys).when(registry).getKeys();
-    doReturn(testMetrics).when(registry).getMetrics(any(RegistryKey.class));
+    doReturn(keys).when(registry).getOperatorKeys();
+    doReturn(testMetrics).when(registry).getOperatorMetrics(any(RegistryKey.class));
 
     final var rep = EntryMetricsReporter.forProcessors(registry);
     assertSame(EntryMetricsReporter.LOGGING, rep.reporter(), "factory must wire the LOGGING reporter");

--- a/lib/kpipe-core/src/main/java/io/github/eschizoid/kpipe/registry/MessageProcessorRegistry.java
+++ b/lib/kpipe-core/src/main/java/io/github/eschizoid/kpipe/registry/MessageProcessorRegistry.java
@@ -18,6 +18,14 @@ import java.util.function.UnaryOperator;
 /// operator, as a sink, as both, or as neither. Internally both namespaces share a single
 /// `Namespace` helper so the structural-mirror methods all funnel into one body each.
 ///
+/// The public surface is a perfect per-namespace mirror: every operation carries its namespace
+/// in the method name (`registerOperator`/`registerSink`, `getOperator`/`getSink`,
+/// `unregisterOperator`/`unregisterSink`, `clearOperators`/`clearSinks`,
+/// `getOperatorKeys`/`getSinkKeys`, `getAllOperators`/`getAllSinks`,
+/// `getOperatorMetrics`/`getSinkMetrics`). Renamed in 1.19.0 from the bare operator-side names
+/// (`unregister`/`clear`/`getKeys`/`getMetrics`), which read registry-wide but touched only
+/// operators.
+///
 /// Example:
 ///
 /// ```java
@@ -165,11 +173,7 @@ public class MessageProcessorRegistry {
         // Warn once per distinct key — repeats are suppressed so a sustained misconfig
         // doesn't flood logs while still surfacing the unrouted key the first time.
         if (warnedMissingOperatorKeys.add(key)) {
-          LOGGER.log(
-            Level.WARNING,
-            "No operator registered under key {0} — passing input through unchanged",
-            key
-          );
+          LOGGER.log(Level.WARNING, "No operator registered under key {0} — passing input through unchanged", key);
         }
         return input;
       }
@@ -182,27 +186,34 @@ public class MessageProcessorRegistry {
   ///
   /// @param key the registry key to remove
   /// @return `true` iff an entry was removed
-  public boolean unregister(final RegistryKey<?> key) {
+  public boolean unregisterOperator(final RegistryKey<?> key) {
     return operators.remove(key);
   }
 
   /// Removes every operator entry. Sinks are untouched — use [#clearSinks()] for those.
-  public void clear() {
+  public void clearOperators() {
     operators.clear();
   }
 
   /// Returns the registered operator keys.
   ///
   /// @return an unmodifiable view of registered operator keys
-  public Set<RegistryKey<?>> getKeys() {
+  public Set<RegistryKey<?>> getOperatorKeys() {
     return operators.keys();
+  }
+
+  /// Returns a summary of registered operators.
+  ///
+  /// @return an unmodifiable view of registered operators (key → implementation simple name)
+  public Map<RegistryKey<?>, String> getAllOperators() {
+    return operators.all();
   }
 
   /// Gets metrics for a specific operator entry.
   ///
   /// @param key the registry key to look up
   /// @return the entry's metrics, or an empty map if `key` is not registered
-  public Map<String, Object> getMetrics(final RegistryKey<?> key) {
+  public Map<String, Object> getOperatorMetrics(final RegistryKey<?> key) {
     return operators.metrics(key);
   }
 

--- a/lib/kpipe-core/src/test/java/io/github/eschizoid/kpipe/registry/MessageProcessorRegistryNamespaceSymmetryTest.java
+++ b/lib/kpipe-core/src/test/java/io/github/eschizoid/kpipe/registry/MessageProcessorRegistryNamespaceSymmetryTest.java
@@ -1,0 +1,100 @@
+package io.github.eschizoid.kpipe.registry;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import io.github.eschizoid.kpipe.sink.MessageSink;
+import java.util.function.UnaryOperator;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/// Asserts the two [MessageProcessorRegistry] namespaces expose the same seven operations —
+/// register / get / unregister / clear / keys / all / metrics — and that each acts on its own
+/// namespace only. A key registered on both sides must survive removal or clearing of the
+/// other side untouched.
+class MessageProcessorRegistryNamespaceSymmetryTest {
+
+  private MessageProcessorRegistry registry;
+  private RegistryKey<Object> key;
+
+  @BeforeEach
+  void setUp() {
+    registry = new MessageProcessorRegistry();
+    key = RegistryKey.of("shared", Object.class);
+    final UnaryOperator<Object> operator = value -> value;
+    final MessageSink<Object> sink = _ -> {};
+    registry.registerOperator(key, operator);
+    registry.registerSink(key, sink);
+  }
+
+  @Test
+  void keysAreTrackedPerNamespace() {
+    assertTrue(registry.getOperatorKeys().contains(key));
+    assertTrue(registry.getSinkKeys().contains(key));
+  }
+
+  @Test
+  void allViewsMirrorEachOther() {
+    assertTrue(registry.getAllOperators().containsKey(key));
+    assertTrue(registry.getAllSinks().containsKey(key));
+    assertNotNull(registry.getAllOperators().get(key));
+    assertNotNull(registry.getAllSinks().get(key));
+  }
+
+  @Test
+  void allViewsAreUnmodifiable() {
+    assertThrows(UnsupportedOperationException.class, () -> registry.getAllOperators().remove(key));
+    assertThrows(UnsupportedOperationException.class, () -> registry.getAllSinks().remove(key));
+  }
+
+  @Test
+  void metricsAreTrackedPerNamespace() {
+    registry.getOperator(key).apply("value");
+    registry.getSink(key).accept("value");
+
+    assertEquals(1L, registry.getOperatorMetrics(key).get("invocationCount"));
+    assertEquals(1L, registry.getSinkMetrics(key).get("invocationCount"));
+  }
+
+  @Test
+  void metricsAreEmptyForUnknownKeys() {
+    final var unknown = RegistryKey.of("unknown", Object.class);
+    assertTrue(registry.getOperatorMetrics(unknown).isEmpty());
+    assertTrue(registry.getSinkMetrics(unknown).isEmpty());
+  }
+
+  @Test
+  void unregisterOperatorLeavesSinkNamespaceUntouched() {
+    assertTrue(registry.unregisterOperator(key));
+    assertFalse(registry.unregisterOperator(key), "second removal must report nothing removed");
+
+    assertFalse(registry.getOperatorKeys().contains(key));
+    assertTrue(registry.getSinkKeys().contains(key));
+  }
+
+  @Test
+  void unregisterSinkLeavesOperatorNamespaceUntouched() {
+    assertTrue(registry.unregisterSink(key));
+    assertFalse(registry.unregisterSink(key), "second removal must report nothing removed");
+
+    assertFalse(registry.getSinkKeys().contains(key));
+    assertTrue(registry.getOperatorKeys().contains(key));
+  }
+
+  @Test
+  void clearOperatorsLeavesSinkNamespaceUntouched() {
+    registry.clearOperators();
+
+    assertTrue(registry.getOperatorKeys().isEmpty());
+    assertTrue(registry.getAllOperators().isEmpty());
+    assertTrue(registry.getSinkKeys().contains(key));
+  }
+
+  @Test
+  void clearSinksLeavesOperatorNamespaceUntouched() {
+    registry.clearSinks();
+
+    assertTrue(registry.getSinkKeys().isEmpty());
+    assertTrue(registry.getAllSinks().isEmpty());
+    assertTrue(registry.getOperatorKeys().contains(key));
+  }
+}

--- a/lib/kpipe-core/src/test/java/io/github/eschizoid/kpipe/registry/MessageProcessorRegistrySinksTest.java
+++ b/lib/kpipe-core/src/test/java/io/github/eschizoid/kpipe/registry/MessageProcessorRegistrySinksTest.java
@@ -65,9 +65,9 @@ class MessageProcessorRegistrySinksTest {
     final var sinkKey = RegistryKey.of("aSink", Object.class);
     registry.registerSink(sinkKey, testSink);
 
-    registry.clear(); // operator-side only
+    registry.clearOperators();
 
-    assertTrue(registry.getAllSinks().containsKey(sinkKey), "clear() must not touch the sink namespace");
+    assertTrue(registry.getAllSinks().containsKey(sinkKey), "clearOperators() must not touch the sink namespace");
   }
 
   @Test

--- a/lib/kpipe-format-json/src/test/java/io/github/eschizoid/kpipe/format/json/MessageProcessorRegistryJsonTest.java
+++ b/lib/kpipe-format-json/src/test/java/io/github/eschizoid/kpipe/format/json/MessageProcessorRegistryJsonTest.java
@@ -162,7 +162,7 @@ class MessageProcessorRegistryJsonTest {
     final var key = RegistryKey.json("p1");
     registry.registerOperator(key, obj -> obj);
 
-    assertTrue(registry.getKeys().contains(key));
+    assertTrue(registry.getOperatorKeys().contains(key));
   }
 
   @Test
@@ -170,11 +170,11 @@ class MessageProcessorRegistryJsonTest {
     final var key = RegistryKey.json("p1");
     registry.registerOperator(key, obj -> obj);
 
-    assertTrue(registry.getKeys().contains(key));
-    final var removed = registry.unregister(key);
+    assertTrue(registry.getOperatorKeys().contains(key));
+    final var removed = registry.unregisterOperator(key);
 
     assertTrue(removed);
-    assertFalse(registry.getKeys().contains(key));
+    assertFalse(registry.getOperatorKeys().contains(key));
   }
 
   @Test
@@ -187,7 +187,7 @@ class MessageProcessorRegistryJsonTest {
     roundTrip(pipeline, "{}".getBytes());
     roundTrip(pipeline, "{}".getBytes());
 
-    final var metrics = registry.getMetrics(key);
+    final var metrics = registry.getOperatorMetrics(key);
     assertEquals(2L, metrics.get("invocationCount"));
   }
 


### PR DESCRIPTION
Architecture-pass item #11 (breaking, delete-and-migrate → 1.19.0 migration notes).

The registry's two namespaces sold themselves as mirrors but had drifted: `registerOperator` paired with bare `unregister`/`clear`/`getKeys`/`getMetrics` (all four verified operator-scoped) — so `registry.clear()` looked like clear-everything and silently wiped only operators, and `getAllSinks` had no operator counterpart.

Now a perfect 7×2 mirror per namespace: register/get/unregister/clear/keys/all/metrics with the namespace in every name; `getAllOperators()` added. All callers migrated in the same commit (consumer main + 3 test files; examples/benchmarks/docs verified zero references). New `MessageProcessorRegistryNamespaceSymmetryTest` (9 tests) pins the mirror and cross-namespace independence in both directions.

**Migration:** `unregister`→`unregisterOperator`, `clear`→`clearOperators`, `getKeys`→`getOperatorKeys`, `getMetrics`→`getOperatorMetrics`.