### PR TITLE
test: port the concurrency suite to Fray across four modules

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -127,9 +127,15 @@ jobs:
         uses: gradle/actions/setup-gradle@v6.3.0
 
       - name: Controlled concurrency (Fray)
+        # One task per module carrying Fray tests. The plugin rewires each Test task
+        # independently, so a module missing from this list is not covered by any other module's
+        # run — and each module carries its own FrayInstrumentationGuardTest for the same reason.
         run: |
           ./gradlew --no-daemon --stacktrace \
-            :lib:kpipe-consumer:frayTest
+            :lib:kpipe-consumer:frayTest \
+            :lib:kpipe-core:frayTest \
+            :lib:kpipe-producer:frayTest \
+            :lib:kpipe-schema-registry-confluent:frayTest
 
       - name: Upload Fray report
         # The report directory carries fray.log plus the recording files that replay a

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -130,8 +130,11 @@ jobs:
         # One task per module carrying Fray tests. The plugin rewires each Test task
         # independently, so a module missing from this list is not covered by any other module's
         # run — and each module carries its own FrayInstrumentationGuardTest for the same reason.
+        # --continue so every module's suite reports: without it the first failing module
+        # aborts the build and the modules after it never run, hiding their results behind
+        # one failure.
         run: |
-          ./gradlew --no-daemon --stacktrace \
+          ./gradlew --no-daemon --stacktrace --continue \
             :lib:kpipe-consumer:frayTest \
             :lib:kpipe-core:frayTest \
             :lib:kpipe-producer:frayTest \

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -96,3 +96,48 @@ jobs:
             :lib:kpipe-core:jcstress \
             :lib:kpipe-producer:jcstress \
             :lib:kpipe-schema-registry-confluent:jcstress
+
+  fray:
+    # Fray controlled-concurrency pilot, running alongside the jcstress job rather than
+    # replacing it — jcstress stays the gate until the pilot's evidence says otherwise.
+    # Fray explores schedules under its own scheduler instead of running racy code many
+    # times and hoping, so this job is expected to be far shorter than the ~33-minute
+    # stress baseline; the timeout is a wedge guard sized for a bounded exploration plus
+    # the one-off jlink of Fray's instrumented JDK, not a budget.
+    #
+    # ubuntu-latest is linux-x8664, which is one of the three platforms Fray publishes its
+    # native JVMTI agent for. On anything else the plugin skips the agent and the suite
+    # would run un-instrumented; FrayInstrumentationSelfCheckTest fails the job in that
+    # case rather than letting it read green, so pinning the runner is a performance
+    # choice, not the safety mechanism.
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Set up JDK
+        uses: actions/setup-java@v6
+        with:
+          distribution: "graalvm"
+          java-version: "25"
+          cache: "gradle"
+
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@v6.3.0
+
+      - name: Controlled concurrency (Fray)
+        run: |
+          ./gradlew --no-daemon --stacktrace \
+            :lib:kpipe-consumer:frayTest
+
+      - name: Upload Fray report
+        # The report directory carries fray.log plus the recording files that replay a
+        # failing schedule deterministically. Without it a red job leaves nothing to debug,
+        # since the interesting schedule is not reproducible from the test output alone.
+        if: ${{ failure() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: fray-report
+          path: build/fray/fray-report
+          if-no-files-found: ignore

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -135,7 +135,9 @@ jobs:
         # The report directory carries fray.log plus the recording files that replay a
         # failing schedule deterministically. Without it a red job leaves nothing to debug,
         # since the interesting schedule is not reproducible from the test output alone.
-        if: ${{ failure() }}
+        # always(), not failure(): a job that exceeds timeout-minutes is CANCELLED rather
+        # than failed, and that is precisely the run whose partial report is worth reading.
+        if: ${{ always() }}
         uses: actions/upload-artifact@v4
         with:
           name: fray-report

--- a/docs/adr/running-fray-locally.md
+++ b/docs/adr/running-fray-locally.md
@@ -1,12 +1,12 @@
 # Running the Fray suite locally
 
-Companion note to ADR 0001. That ADR records _why_ the concurrency suite is moving to Fray; this one records how to
-run it on a machine Fray does not support natively.
+Companion note to ADR 0001. That ADR records _why_ the concurrency suite is moving to Fray; this one records how to run
+it on a machine Fray does not support natively.
 
 ## Why there is a problem
 
-Fray drives the JVM with a native JVMTI agent, and its Gradle plugin only wires that agent in on the three platforms
-the agent is published for:
+Fray drives the JVM with a native JVMTI agent, and its Gradle plugin only wires that agent in on the three platforms the
+agent is published for:
 
 ```kotlin
 val supportedOsArchitectures = listOf("linux-x8664", "windows-x8664", "macos-aarch64")
@@ -63,8 +63,8 @@ Notes on the flags:
   changes.
 - `--user` keeps build outputs owned by the host user rather than root.
 
-On an Apple Silicon Mac none of this is needed: `macos-aarch64` is supported, so `./gradlew :lib:kpipe-consumer:frayTest`
-works directly on the host.
+On an Apple Silicon Mac none of this is needed: `macos-aarch64` is supported, so
+`./gradlew :lib:kpipe-consumer:frayTest` works directly on the host.
 
 ## What a real run looks like
 
@@ -85,5 +85,5 @@ Two signals distinguish an instrumented run from the no-op:
 ## Reproducing a failure
 
 A failing schedule writes a report directory under `build/fray/fray-report`, containing `fray.log` and the recording
-files needed to replay that exact schedule. The CI job uploads it as an artifact on failure, because the schedule is
-not recoverable from the test output alone.
+files needed to replay that exact schedule. The CI job uploads it as an artifact on failure, because the schedule is not
+recoverable from the test output alone.

--- a/docs/adr/running-fray-locally.md
+++ b/docs/adr/running-fray-locally.md
@@ -1,0 +1,89 @@
+# Running the Fray suite locally
+
+Companion note to ADR 0001. That ADR records _why_ the concurrency suite is moving to Fray; this one records how to
+run it on a machine Fray does not support natively.
+
+## Why there is a problem
+
+Fray drives the JVM with a native JVMTI agent, and its Gradle plugin only wires that agent in on the three platforms
+the agent is published for:
+
+```kotlin
+val supportedOsArchitectures = listOf("linux-x8664", "windows-x8664", "macos-aarch64")
+```
+
+macOS on **x86_64** is not on that list, and it is this project's primary development machine. On an unsupported
+platform the plugin prints `Fray JVMTI agent will not be added as a dependency` and the build continues, so
+`:lib:kpipe-consumer:frayTest` runs the tests on an ordinary JDK with no scheduling control at all.
+
+That run is not merely useless, it is misleading: `@FrayTest` methods are reported as **skipped**, and any launcher
+driven test degrades into repeating racy code and hoping. Both outcomes are green. `FrayInstrumentationSelfCheckTest`
+exists to turn that state red, so on macOS x86_64 the expected local result is a **failing** `frayTest` task with:
+
+```
+The JVM running the Fray suite is /path/to/jdk, which carries no IMPLEMENTOR=Fray stamp.
+```
+
+A green `frayTest` on macOS x86_64 would mean the self-check itself has stopped working.
+
+## Running it for real, in a container
+
+`linux/amd64` is a supported Fray platform, and on an x86_64 Mac a `linux/amd64` container runs natively — there is no
+emulation and no speed penalty. That makes a container the local equivalent of the CI runner rather than a slow
+approximation of it.
+
+The one wrinkle is that this repository is often checked out as a **linked git worktree**, whose `.git` file points at
+an absolute path inside the main clone. Mounting the repository at its own absolute path keeps that pointer valid, and
+keeps the axion-release plugin (which reads the repository through jgit at configuration time) working:
+
+```bash
+REPO=/absolute/path/to/kpipe          # the MAIN clone, even when working in a worktree
+WORK=$PWD                             # the checkout you want to build
+
+docker run --rm --platform linux/amd64 \
+  --user "$(id -u):$(id -g)" \
+  -v "$REPO:$REPO" \
+  -v "$HOME/.gradle-fray:/gradle-home" \
+  -e HOME=/tmp/fray-home \
+  -e GRADLE_USER_HOME=/gradle-home \
+  -e JDK25_HOME=/opt/java/openjdk \
+  -w "$WORK" \
+  eclipse-temurin:25-jdk \
+  ./gradlew --no-daemon :lib:kpipe-consumer:frayTest
+```
+
+Notes on the flags:
+
+- `--platform linux/amd64` is what selects the supported Fray platform. Without it, Docker on an Apple Silicon host
+  picks `linux/arm64`, for which no agent is published, and the self-check fails exactly as it does on the host.
+- `JDK25_HOME` points Fray's `jlink` step at the JDK already in the image. Without it Fray downloads its own Amazon
+  Corretto 25 (~200 MB) into `build/fray` on the first run.
+- The bind-mounted `GRADLE_USER_HOME` keeps the Gradle distribution and the resolved dependencies between runs. The
+  jlinked Fray JDK itself is cached separately, under `build/fray/fray-java`, and is rebuilt only when the Fray version
+  changes.
+- `--user` keeps build outputs owned by the host user rather than root.
+
+On an Apple Silicon Mac none of this is needed: `macos-aarch64` is supported, so `./gradlew :lib:kpipe-consumer:frayTest`
+works directly on the host.
+
+## What a real run looks like
+
+Two signals distinguish an instrumented run from the no-op:
+
+1. `FrayInstrumentationSelfCheckTest` passes. Both of its gates have to hold — the JVM is Fray's jlinked image, **and**
+   the scheduler finds a planted lost update.
+2. `KeyOrderedEvictTombstoneFrayTest` prints its window hit rate, for example:
+
+   ```
+   Fray reached the eviction-tombstone window in N of M schedules
+   ```
+
+   The un-instrumented control on macOS x86_64 reaches it in roughly 1 schedule in 10,000, which is the same
+   found-by-luck rate the jcstress suite showed (78 hits in 23,427 runs). A run whose rate is in that neighbourhood is
+   not being scheduled by Fray, whatever the plugin logged.
+
+## Reproducing a failure
+
+A failing schedule writes a report directory under `build/fray/fray-report`, containing `fray.log` and the recording
+files needed to replay that exact schedule. The CI job uploads it as an artifact on failure, because the schedule is
+not recoverable from the test output alone.

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -19,6 +19,7 @@ jreleaser = "1.19.0"
 jgit = "6.10.0.202406032230-r"
 jqwik = "1.10.1"
 jcstress = "0.16"
+fray = "0.9.0"
 confluentSchemaRegistry = "8.3.0"
 
 [libraries]
@@ -65,4 +66,5 @@ spotless = { id = "com.diffplug.spotless", version.ref = "spotless" }
 axion = { id = "pl.allegro.tech.build.axion-release", version.ref = "axion" }
 shadow = { id = "com.gradleup.shadow", version.ref = "shadow" }
 jmh = { id = "me.champeau.jmh", version.ref = "jmh" }
+fray = { id = "org.pastalab.fray.gradle", version.ref = "fray" }
 jreleaser = { id = "org.jreleaser", version.ref = "jreleaser" }

--- a/lib/kpipe-consumer/build.gradle.kts
+++ b/lib/kpipe-consumer/build.gradle.kts
@@ -1,6 +1,9 @@
+import org.pastalab.fray.gradle.FrayExtension
+
 plugins {
   `java-library`
   jacoco
+  alias(libs.plugins.fray)
 }
 
 description = "KPipe Consumer - Functional Kafka consumer with virtual threads"
@@ -71,6 +74,55 @@ tasks.register<JavaExec>("jcstress") {
   workingDir = outDir
   // -t matches every jcstress test in the consumer package by its shared JCStressTest suffix.
   args("-t", "JCStressTest", "-iters", "1", "-time", "50", "-f", "1", "-v", "-r", "results")
+}
+
+// Fray controlled-concurrency pilot. Mirrors the jcstress layout above: its own source set so
+// the Fray tests never run inside the plain `test` task, and classpath-only compilation so the
+// tests can reach package-private consumer internals (KeyOrderedDispatcher.tombstoneRetries)
+// without reflection and without a module-path dance.
+//
+// The source set MUST be named `frayTest`: the Fray plugin derives the configuration names it
+// injects its own dependencies into from the configured test-task name (`frayTestImplementation`,
+// `frayTestCompileOnly`). Renaming one without the other silently drops fray-core/fray-junit off
+// the compile classpath.
+val frayTest: SourceSet by sourceSets.creating {
+  java.srcDir("src/frayTest/java")
+  compileClasspath += sourceSets.main.get().output
+  runtimeClasspath += sourceSets.main.get().output
+}
+
+val frayTestImplementation: Configuration by configurations.getting
+
+dependencies {
+  frayTestImplementation(platform(libs.junitBom))
+  frayTestImplementation(libs.junitJupiter)
+  frayTestImplementation(libs.kafkaClients)
+  "frayTestRuntimeOnly"(libs.junitPlatformLauncher)
+}
+
+// Same rationale as compileJcstressJava: this source set compiles against the main module's
+// exported packages as plain classpath classes.
+tasks.named<JavaCompile>("compileFrayTestJava") {
+  modularity.inferModulePath.set(false)
+}
+
+// The Fray plugin rewires whichever Test task `fray.testTask` names: it points the task at the
+// jlink-instrumented Fray JDK, attaches the JVMTI + bytecode agents, and narrows the JUnit
+// selection to the `FrayTest` tag. On an unsupported OS/arch it skips all of that and leaves the
+// task as a plain Test run — which is exactly the silent no-op the instrumentation self-check in
+// this source set exists to turn red.
+tasks.register<Test>("frayTest") {
+  group = "verification"
+  description = "Runs the Fray controlled-concurrency suite for kpipe-consumer."
+  testClassesDirs = frayTest.output.classesDirs
+  classpath = frayTest.runtimeClasspath
+  // Fray forks one JVM and drives scheduling itself; parallel forks would only fight over cores.
+  maxParallelForks = 1
+  testLogging { showStandardStreams = true }
+}
+
+configure<FrayExtension> {
+  testTask = "frayTest"
 }
 
 tasks.test {

--- a/lib/kpipe-consumer/build.gradle.kts
+++ b/lib/kpipe-consumer/build.gradle.kts
@@ -97,6 +97,10 @@ dependencies {
   frayTestImplementation(platform(libs.junitBom))
   frayTestImplementation(libs.junitJupiter)
   frayTestImplementation(libs.kafkaClients)
+  // Scenarios that build a pipeline or a batch sink need the core types by name. Declared
+  // explicitly rather than by extending testImplementation, which would also drag Testcontainers
+  // and the rest of the integration-test stack onto this source set.
+  frayTestImplementation(project(":lib:kpipe-core"))
   "frayTestRuntimeOnly"(libs.junitPlatformLauncher)
 }
 

--- a/lib/kpipe-consumer/src/frayTest/java/io/github/eschizoid/kpipe/consumer/BatchWrapperLockFrayTest.java
+++ b/lib/kpipe-consumer/src/frayTest/java/io/github/eschizoid/kpipe/consumer/BatchWrapperLockFrayTest.java
@@ -1,0 +1,98 @@
+package io.github.eschizoid.kpipe.consumer;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import io.github.eschizoid.kpipe.registry.MessageFormat;
+import io.github.eschizoid.kpipe.registry.MessagePipeline;
+import io.github.eschizoid.kpipe.registry.MessageProcessorRegistry;
+import io.github.eschizoid.kpipe.sink.BatchPolicy;
+import io.github.eschizoid.kpipe.sink.BatchResult;
+import io.github.eschizoid.kpipe.sink.BatchSink;
+import java.time.Duration;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.pastalab.fray.junit.junit5.FrayTestExtension;
+import org.pastalab.fray.junit.junit5.annotations.FrayTest;
+
+/// Fray ports of the batch-wrapper buffer-lock races.
+///
+/// The wrapper's `ReentrantLock` serializes enqueue against flush so parallel-mode workers can
+/// buffer records while a flush is mid-flight. `bufferedCount` feeds the in-flight backpressure
+/// watermark, so an increment lost to a race understates memory pressure and a decrement that
+/// does not match what the flush actually drained strands records against the watermark.
+///
+/// The wrapper is constructed but never started: the age-tick scheduler is started separately by
+/// the consumer, and a live scheduler thread would stop Fray from finishing an iteration. Both
+/// scenarios use a one-minute age window so only the size trigger is ever in play.
+@ExtendWith(FrayTestExtension.class)
+@Tag("FrayTest")
+class BatchWrapperLockFrayTest {
+
+  private static final String TOPIC = "fray-batch";
+
+  /// Two enqueues race with no flush in play — the size threshold is far above the record count,
+  /// so both records stay buffered. Each enqueue is one read-modify-write on the counter, and the
+  /// lock is what makes the pair add up: any total other than two means an increment was lost or
+  /// applied twice.
+  @FrayTest(iterations = 500)
+  void concurrentEnqueuesAreBothCounted() {
+    final var wrapper = newWrapper(new BatchPolicy(1000, Duration.ofMinutes(1)));
+
+    FrayScenarios.runConcurrently(
+      () -> wrapper.enqueue(record(1L), record(1L).value()),
+      () -> wrapper.enqueue(record(2L), record(2L).value())
+    );
+
+    assertEquals(2L, wrapper.bufferedCount(), "both enqueues should be buffered exactly once");
+  }
+
+  /// An enqueue races the size-triggered flush that another enqueue sets off. With one record
+  /// pre-loaded and a threshold of two, whichever enqueue arrives second trips an inline flush of
+  /// two records, leaving exactly one buffered. The flush's decrement has to match the records it
+  /// actually drained — decrementing by the wrong amount either strands a record against the
+  /// backpressure watermark or double-counts one out of it.
+  @FrayTest(iterations = 500)
+  void flushDecrementMatchesWhatItDrained() {
+    final var wrapper = newWrapper(new BatchPolicy(2, Duration.ofMinutes(1)));
+    wrapper.enqueue(record(0L), record(0L).value());
+
+    FrayScenarios.runConcurrently(
+      () -> wrapper.enqueue(record(1L), record(1L).value()),
+      () -> wrapper.enqueue(record(2L), record(2L).value())
+    );
+
+    assertEquals(1L, wrapper.bufferedCount(), "one record should remain buffered after the size-triggered flush");
+  }
+
+  private static BatchPipelineWrapper<byte[]> newWrapper(final BatchPolicy policy) {
+    return new BatchPipelineWrapper<>(TOPIC, identityPipeline(), succeedingSink(), policy, null, noopCallbacks());
+  }
+
+  private static MessagePipeline<byte[]> identityPipeline() {
+    return new MessageProcessorRegistry().pipeline(MessageFormat.bytes()).build();
+  }
+
+  /// Reports every batch as fully succeeded, so a size-triggered flush runs the real flush path
+  /// without routing anything to a failure callback.
+  private static BatchSink<byte[]> succeedingSink() {
+    return batch -> BatchResult.allSucceeded(batch.size());
+  }
+
+  /// The assertions read the wrapper's own `bufferedCount`, not downstream offset bookkeeping,
+  /// so the callbacks do nothing.
+  private static BatchPipelineWrapper.BatchCallbacks noopCallbacks() {
+    return new BatchPipelineWrapper.BatchCallbacks() {
+      @Override
+      public void markProcessed(final ConsumerRecord<byte[], byte[]> record) {}
+
+      @Override
+      public void onBatchFailure(final ConsumerRecord<byte[], byte[]> record, final Exception cause) {}
+    };
+  }
+
+  private static ConsumerRecord<byte[], byte[]> record(final long offset) {
+    return new ConsumerRecord<>(TOPIC, 0, offset, ("k-" + offset).getBytes(UTF_8), ("v-" + offset).getBytes(UTF_8));
+  }
+}

--- a/lib/kpipe-consumer/src/frayTest/java/io/github/eschizoid/kpipe/consumer/ConsumerHealthFrayTest.java
+++ b/lib/kpipe-consumer/src/frayTest/java/io/github/eschizoid/kpipe/consumer/ConsumerHealthFrayTest.java
@@ -1,0 +1,98 @@
+package io.github.eschizoid.kpipe.consumer;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicLong;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.pastalab.fray.junit.junit5.FrayTestExtension;
+import org.pastalab.fray.junit.junit5.annotations.FrayTest;
+
+/// Fray ports of the health-controller races: the backpressure pause handshake and the circuit
+/// breaker's rolling window.
+@ExtendWith(FrayTestExtension.class)
+@Tag("FrayTest")
+class ConsumerHealthFrayTest {
+
+  /// The lost-wakeup handshake between the consumer thread and the last worker to finish.
+  ///
+  /// The consumer publishes the pause bit and then re-reads the in-flight count; the worker
+  /// decrements the in-flight count and then reads the pause bit to decide whether to nudge the
+  /// consumer. Three outcomes are fine — either side may observe the other, or both may. The one
+  /// forbidden state is neither side seeing the other: the consumer would hold with nothing in
+  /// flight and no completion left to release it.
+  ///
+  /// The handshake stopped being a liveness invariant when the paused consumer moved to
+  /// polling on a fixed cadence instead of parking indefinitely, so today this bounds resume
+  /// latency rather than preventing a permanent stall. It is still the property the ordering is
+  /// written to provide.
+  @FrayTest(iterations = 500)
+  void pauseHandshakeIsNeverMutuallyBlind() {
+    final var health = new ConsumerHealthController(null, null, null, NoopHook.INSTANCE, NoopHook.INSTANCE);
+    final var inFlight = new AtomicLong(1);
+    final var consumerSawDrain = new AtomicBoolean();
+    final var workerSawPause = new AtomicBoolean();
+
+    FrayScenarios.runConcurrently(
+      () -> {
+        health.requestPause(ConsumerHealthController.Source.BACKPRESSURE);
+        consumerSawDrain.set(inFlight.get() == 0);
+      },
+      () -> {
+        inFlight.decrementAndGet();
+        workerSawPause.set(health.isHeldBy(ConsumerHealthController.Source.BACKPRESSURE));
+      }
+    );
+
+    assertFalse(
+      !consumerSawDrain.get() && !workerSawPause.get(),
+      "neither side observed the other: the consumer holds with nothing in flight and no " +
+        "completion left to release it"
+    );
+  }
+
+  /// A success and a failure land in the breaker's rolling window at once. Both must be counted:
+  /// the window is what the trip decision reads, so a lost sample moves the failure rate and can
+  /// either trip the breaker early or fail to trip it when the threshold was genuinely crossed.
+  @FrayTest(iterations = 500)
+  void concurrentOutcomesBothLandInTheWindow() {
+    final var window = new ConsumerHealthController.SlidingWindow(2);
+
+    FrayScenarios.runConcurrently(() -> window.record(true), () -> window.record(false));
+
+    assertEquals(2L, window.totalSamples(), "both outcomes should have been recorded");
+    assertEquals(0.5d, window.failureRate(), 0.0d, "one of the two samples was a failure");
+  }
+
+  /// Side-effect-free hook: these scenarios exercise the pause mask and the sample window, never
+  /// the pause / resume choreography, so every callback does nothing.
+  private static final class NoopHook
+    implements ConsumerHealthController.PauseLifecycleHook, ConsumerHealthController.HealthMetricsObserver
+  {
+
+    private static final NoopHook INSTANCE = new NoopHook();
+
+    @Override
+    public void onPause() {}
+
+    @Override
+    public void onResume() {}
+
+    @Override
+    public void onBackpressurePause() {}
+
+    @Override
+    public void onBackpressureTimeMs(final long ms) {}
+
+    @Override
+    public void onCircuitBreakerTrip() {}
+
+    @Override
+    public void onCircuitBreakerStateChange(final CircuitBreakerState state) {}
+
+    @Override
+    public void onCircuitBreakerTimeOpenMs(final long ms) {}
+  }
+}

--- a/lib/kpipe-consumer/src/frayTest/java/io/github/eschizoid/kpipe/consumer/FrayInstrumentationSelfCheckTest.java
+++ b/lib/kpipe-consumer/src/frayTest/java/io/github/eschizoid/kpipe/consumer/FrayInstrumentationSelfCheckTest.java
@@ -1,0 +1,155 @@
+package io.github.eschizoid.kpipe.consumer;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.pastalab.fray.junit.plain.FrayInTestLauncher;
+
+/// Permanent guard against a Fray run that reads green without instrumenting anything.
+///
+/// The concurrency suite is a correctness gate, and two candidate tools have already been
+/// caught passing deliberately racy code when they could not instrument it — the worst
+/// possible failure mode, because it turns an untested invariant into a green check. Fray
+/// carries the same hazard in two places. Its Gradle plugin ships a native JVMTI agent for
+/// `linux-x8664`, `windows-x8664` and `macos-aarch64` only; on any other platform it logs a
+/// warning, skips the agent, and lets the build proceed. And its JUnit extension answers
+/// "Fray is not enabled in this JVM" by marking every `@FrayTest` method **skipped**, which
+/// is also green. This class exists so neither can happen quietly.
+///
+/// **Two independent gates, both required.** Each is blind to a failure the other catches,
+/// so a green suite needs both to hold.
+///
+/// 1. [#frayInstrumentedJdkIsTheRunningJvm()] — the JVM executing these tests must be
+///    Fray's jlink-instrumented JDK. Fray stamps `IMPLEMENTOR=Fray` into that image's
+///    `release` file, and its own JUnit extension reads exactly that line to decide whether
+///    to run or skip a `@FrayTest`. Asserting on it therefore fails the build under
+///    precisely the condition that would otherwise skip the suite in silence. The gate
+///    reads the running image, so nothing about it is probabilistic.
+/// 2. [#frayReportsTheKnownLostUpdate()] — the scheduler must actually find a planted race.
+///    A non-atomic increment of a `volatile` field from two threads is a lost update, and
+///    Fray treats volatile reads and writes as scheduling points, so a live install parks
+///    one thread inside the read-modify-write and reports the violation within a handful of
+///    schedules. Nothing reported means the assertion fails.
+///
+/// **Why this cannot read green on a no-op.** The state being guarded against is "Fray did
+/// not instrument", and that state always fails gate 1: with no jlinked image there is no
+/// `IMPLEMENTOR=Fray` stamp to find. Gate 2 is deliberately not load-bearing for that case,
+/// because a race can in principle be lost by chance on an ordinary JVM and a probe that
+/// leans on chance is the thing this suite replaces. Gate 2 covers the narrower case gate 1
+/// cannot see: the JDK is Fray's, but the agents are missing or inert, so no schedule is
+/// ever controlled. Neither gate can be neutralised by being skipped — both are plain JUnit
+/// `@Test` methods, so a disabled Fray cannot quietly disable them the way it disables
+/// `@FrayTest`.
+@Tag("FrayTest")
+class FrayInstrumentationSelfCheckTest {
+
+  /// Marker embedded in the planted violation. Matching on it, rather than on "something was
+  /// thrown", keeps an unrelated internal Fray error from being credited as a detection.
+  private static final String LOST_UPDATE_MARKER = "kpipe-fray-self-check-lost-update";
+
+  /// The line Fray's jlink step writes into the instrumented image's `release` file, and the
+  /// exact string its JUnit extension looks for before agreeing to run a `@FrayTest`.
+  private static final String FRAY_IMPLEMENTOR = "IMPLEMENTOR=Fray";
+
+  @Test
+  void frayInstrumentedJdkIsTheRunningJvm() throws IOException {
+    final var release = Path.of(System.getProperty("java.home"), "release");
+    assertTrue(
+      Files.isRegularFile(release),
+      () -> "No release file at " + release + "; this JVM is not a jlink image, so it cannot be Fray's."
+    );
+    final var stamped = Files.readAllLines(release)
+      .stream()
+      .anyMatch(line -> line.contains(FRAY_IMPLEMENTOR));
+    assertTrue(
+      stamped,
+      () ->
+        "The JVM running the Fray suite is " +
+        System.getProperty("java.home") +
+        ", which carries no " +
+        FRAY_IMPLEMENTOR +
+        " stamp. Fray is not instrumenting, so every @FrayTest in this source set would be " +
+        "reported as skipped and the build would read green. The usual cause is an unsupported " +
+        "OS/architecture — the agent is published for linux-x8664, windows-x8664 and " +
+        "macos-aarch64 only. Run the suite on a supported platform (see docs/adr/running-fray-locally.md)."
+    );
+  }
+
+  @Test
+  void frayReportsTheKnownLostUpdate() {
+    final var reported = assertThrows(
+      Throwable.class,
+      () -> FrayInTestLauncher.INSTANCE.launchFrayTest(FrayInstrumentationSelfCheckTest::race),
+      "Fray explored its schedules without reporting the planted lost update. The race is real " +
+        "and unguarded, so a working scheduler must find it: scheduling control is not live here."
+    );
+    assertTrue(
+      carriesMarker(reported),
+      () ->
+        "Fray reported '" +
+        reported +
+        "' rather than the planted lost update, so the detection cannot be credited to this probe."
+    );
+  }
+
+  /// Plants a lost update and reports it by throwing. Fray surfaces whatever the test body
+  /// throws as the bug it found, so the thrown marker is what the assertion matches on.
+  private static void race() {
+    final var counter = new RacyCounter();
+    final var first = new Thread(counter::increment, "fray-self-check-a");
+    final var second = new Thread(counter::increment, "fray-self-check-b");
+    first.start();
+    second.start();
+    join(first);
+    join(second);
+    final var observed = counter.count();
+    if (observed != 2) {
+      throw new AssertionError(LOST_UPDATE_MARKER + ": expected 2 increments, observed " + observed);
+    }
+  }
+
+  private static void join(final Thread thread) {
+    try {
+      thread.join();
+    } catch (final InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new IllegalStateException("interrupted while joining " + thread.getName(), e);
+    }
+  }
+
+  /// Walks the cause chain so the marker is still recognised if Fray ever starts wrapping
+  /// the throwable it reports.
+  private static boolean carriesMarker(final Throwable reported) {
+    var current = reported;
+    while (current != null) {
+      final var message = current.getMessage();
+      if (message != null && message.contains(LOST_UPDATE_MARKER)) return true;
+      current = current.getCause() == current ? null : current.getCause();
+    }
+    return false;
+  }
+
+  /// Deliberately racy: `count` is `volatile`, so each read and each write is a Fray
+  /// scheduling point, while the read-modify-write as a whole is not atomic. Fray can
+  /// therefore park one thread between its read and its write and let the other run to
+  /// completion, losing an update. The field must be `volatile`: Fray's JUnit configurations
+  /// run with memory-op interleaving disabled, under which plain field accesses are not
+  /// scheduling points and this race would never be explored.
+  private static final class RacyCounter {
+
+    private volatile int count;
+
+    void increment() {
+      count = count + 1;
+    }
+
+    int count() {
+      return count;
+    }
+  }
+}

--- a/lib/kpipe-consumer/src/frayTest/java/io/github/eschizoid/kpipe/consumer/FrayScenarios.java
+++ b/lib/kpipe-consumer/src/frayTest/java/io/github/eschizoid/kpipe/consumer/FrayScenarios.java
@@ -1,0 +1,40 @@
+package io.github.eschizoid.kpipe.consumer;
+
+/// Shared plumbing for the Fray ports: run a set of actions on their own threads and wait for
+/// every one to finish.
+///
+/// Joining matters more here than it does under jcstress, which owns actor lifecycles itself.
+/// Fray does not finish an iteration while any thread it started is still live, so a port that
+/// leaks a thread wedges exploration on its first schedule rather than failing. Everything the
+/// scenarios drive must therefore be joined, and anything holding a scheduler must not be
+/// started at all.
+final class FrayScenarios {
+
+  private FrayScenarios() {}
+
+  /// Runs each action on its own platform thread and joins them all before returning.
+  ///
+  /// @param actions the concurrent actions making up one schedule
+  static void runConcurrently(final Runnable... actions) {
+    final var threads = new Thread[actions.length];
+    for (var i = 0; i < actions.length; i++) {
+      threads[i] = new Thread(actions[i], "fray-actor-" + i);
+    }
+    for (final var t : threads) t.start();
+    for (final var t : threads) join(t);
+  }
+
+  /// Unbounded on purpose. Under a controlled scheduler a real-time deadline measures the
+  /// exploration order rather than the code's liveness; Fray reports a schedule that genuinely
+  /// cannot finish as a deadlock.
+  ///
+  /// @param thread the thread to wait for
+  private static void join(final Thread thread) {
+    try {
+      thread.join();
+    } catch (final InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new IllegalStateException("interrupted joining " + thread.getName(), e);
+    }
+  }
+}

--- a/lib/kpipe-consumer/src/frayTest/java/io/github/eschizoid/kpipe/consumer/KeyOrderedEvictTombstoneFrayTest.java
+++ b/lib/kpipe-consumer/src/frayTest/java/io/github/eschizoid/kpipe/consumer/KeyOrderedEvictTombstoneFrayTest.java
@@ -1,0 +1,225 @@
+package io.github.eschizoid.kpipe.consumer;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.pastalab.fray.junit.junit5.FrayTestExtension;
+import org.pastalab.fray.junit.junit5.annotations.FrayTest;
+import org.pastalab.fray.junit.plain.FrayInTestLauncher;
+
+/// Fray port of the jcstress eviction-tombstone stress test.
+///
+/// **The window.** [KeyOrderedDispatcher] evicts an empty, idle key queue to make room for a
+/// new key. A dispatcher that read that queue out of the map a moment earlier still holds a
+/// live reference to it. Eviction marks the queue `dead` under its monitor, atomically with
+/// the map removal, and the dispatcher re-checks `dead` under the same monitor before
+/// enqueuing — the retry that closes the window. Losing that check does not lose the record:
+/// the dispatcher enqueues into the orphaned queue and starts a worker on it, so the task
+/// still runs. What breaks is per-key serialization. The orphan is no longer reachable
+/// through the map, so the *next* record for that key allocates a second queue and a second
+/// worker, and two workers then process the same key at once.
+///
+/// **What this test drives.** Cap of one key. Key A is pre-seeded and drained, leaving the
+/// map in the exact state eviction wants: `{A: empty, idle}`. Then one thread dispatches two
+/// records for key A back to back — mirroring production, where a single consumer thread
+/// dispatches — while a second thread dispatches one record for key B, forcing A's queue to
+/// be evicted. The interesting schedule slips B's eviction between the first thread's map
+/// lookup and its monitor entry.
+///
+/// **How the window is confirmed.** Whether a schedule reached the retry path is invisible
+/// from the public surface, because the record processes correctly either way. The
+/// dispatcher keeps a package-private `tombstoneRetries` counter for exactly this purpose;
+/// the scenario reads it directly after each schedule (same package, classpath compilation,
+/// no reflection). Under jcstress the window was reached in 78 of 23,427 runs — 0.33%, found
+/// by luck. [#evictVsRedispatchPreservesPerKeySerialization()] asserts the count of schedules
+/// that reached it is non-zero and prints the hit rate, so "the suite ran but never explored
+/// the interesting region" is a failure rather than a silent pass.
+@ExtendWith(FrayTestExtension.class)
+@Tag("FrayTest")
+class KeyOrderedEvictTombstoneFrayTest {
+
+  /// Drives the scenario across Fray's whole schedule space and fails on the first schedule
+  /// that breaks a per-key invariant. Fray reports whatever the body throws, so a violated
+  /// assertion inside a schedule surfaces here as the thrown `AssertionError`.
+  ///
+  /// The hit counters live outside the explored lambda so they accumulate across schedules —
+  /// Fray's plain launcher runs the body directly, without reloading its classes per
+  /// iteration, so ordinary fields survive the whole exploration.
+  @Test
+  void evictVsRedispatchPreservesPerKeySerialization() {
+    final var schedules = new AtomicLong();
+    final var windowHits = new AtomicLong();
+    FrayInTestLauncher.INSTANCE.launchFrayTest(() -> {
+      schedules.incrementAndGet();
+      final var scenario = new Scenario();
+      scenario.run();
+      if (scenario.windowReached()) windowHits.incrementAndGet();
+    });
+    System.out.printf(
+      "Fray reached the eviction-tombstone window in %d of %d schedules (%.2f%%)%n",
+      windowHits.get(),
+      schedules.get(),
+      schedules.get() == 0 ? 0.0 : (100.0 * windowHits.get()) / schedules.get()
+    );
+    assertTrue(
+      windowHits.get() > 0,
+      () ->
+        "No schedule out of " +
+        schedules.get() +
+        " reached the dead-tombstone retry path, so this run proved nothing about it. Either the " +
+        "scheduler is not exploring (check the instrumentation self-check) or the scenario no " +
+        "longer sets up the {A: empty, idle} precondition eviction needs."
+    );
+  }
+
+  /// The same scenario in the annotation-driven shape a full migration would use, kept so the
+  /// pilot exercises both entry points. Unlike the launcher-driven test above, a `@FrayTest`
+  /// is reported as *skipped* when Fray is not enabled — which is why the instrumentation
+  /// self-check, not this method, is what stands between a no-op and a green build.
+  @FrayTest(iterations = 300, sleepAsYield = true)
+  void evictVsRedispatchUnderTheFrayTestAnnotation() {
+    new Scenario().run();
+  }
+
+  /// One schedule's worth of state and assertions. A fresh instance per schedule keeps
+  /// iterations independent.
+  private static final class Scenario {
+
+    private static final String TOPIC = "fray-topic";
+    private static final byte[] KEY_A = "key-a".getBytes(UTF_8);
+    private static final byte[] KEY_B = "key-b".getBytes(UTF_8);
+    private static final long SEED_OFFSET = 0L;
+    private static final long FIRST_A_OFFSET = 1L;
+    private static final long B_OFFSET = 2L;
+    private static final long SECOND_A_OFFSET = 3L;
+    private static final long DRAIN_TIMEOUT_SECONDS = 10L;
+
+    private final KeyOrderedDispatcher dispatcher = new KeyOrderedDispatcher(1);
+    private final AtomicInteger tasksRun = new AtomicInteger();
+    private final AtomicInteger liveKeyATasks = new AtomicInteger();
+    private final AtomicInteger peakLiveKeyATasks = new AtomicInteger();
+    private final List<Long> keyACompletions = Collections.synchronizedList(new ArrayList<>());
+    private final CountDownLatch allDone = new CountDownLatch(3);
+
+    void run() {
+      seedKeyA();
+      final var keyBDispatcher = new Thread(this::dispatchKeyB, "fray-dispatch-b");
+      keyBDispatcher.start();
+      dispatcher.dispatch(record(KEY_A, FIRST_A_OFFSET), () -> keyATask(FIRST_A_OFFSET), allDone::countDown);
+      dispatcher.dispatch(record(KEY_A, SECOND_A_OFFSET), () -> keyATask(SECOND_A_OFFSET), allDone::countDown);
+      join(keyBDispatcher);
+      awaitDrain();
+      dispatcher.close();
+      verify();
+    }
+
+    boolean windowReached() {
+      return dispatcher.tombstoneRetries.get() > 0;
+    }
+
+    /// Dispatches one record for key A and waits for it to complete, so the map holds a
+    /// single empty queue for A. That is the precondition eviction needs: the queue is
+    /// reclaimable the instant its worker exits, which is what lets key B's dispatch kill it
+    /// out from under a dispatcher that already holds the reference.
+    private void seedKeyA() {
+      final var seeded = new CountDownLatch(1);
+      dispatcher.dispatch(record(KEY_A, SEED_OFFSET), () -> {}, seeded::countDown);
+      await(seeded, "pre-seed of key A");
+    }
+
+    private void dispatchKeyB() {
+      dispatcher.dispatch(record(KEY_B, B_OFFSET), tasksRun::incrementAndGet, allDone::countDown);
+    }
+
+    /// Body of both key-A records. Tracks how many key-A tasks are inside it at once and the
+    /// order in which they leave it — the two facts per-key serialization is made of. The
+    /// short pause widens the observation window so an overlapping partner is seen even when
+    /// the per-key workers run outside the scheduler's control.
+    private void keyATask(final long offset) {
+      final var live = liveKeyATasks.incrementAndGet();
+      peakLiveKeyATasks.accumulateAndGet(live, Math::max);
+      pause();
+      keyACompletions.add(offset);
+      liveKeyATasks.decrementAndGet();
+      tasksRun.incrementAndGet();
+    }
+
+    private void verify() {
+      if (tasksRun.get() != 3) {
+        throw new AssertionError("Expected 3 tasks to run exactly once, observed " + tasksRun.get());
+      }
+      if (peakLiveKeyATasks.get() > 1) {
+        throw new AssertionError(
+          "Per-key serialization broken: " +
+            peakLiveKeyATasks.get() +
+            " tasks for key A ran concurrently. A dispatcher enqueued into an evicted queue and " +
+            "started a second worker for the key."
+        );
+      }
+      final var completions = List.copyOf(keyACompletions);
+      if (!List.of(FIRST_A_OFFSET, SECOND_A_OFFSET).equals(completions)) {
+        throw new AssertionError(
+          "Per-key ordering broken: key A completed in offset order " +
+            completions +
+            " but was dispatched in order [1, 3] by a single thread."
+        );
+      }
+    }
+
+    private void awaitDrain() {
+      try {
+        if (!allDone.await(DRAIN_TIMEOUT_SECONDS, TimeUnit.SECONDS)) {
+          throw new AssertionError(
+            "A dispatched task never completed: " + allDone.getCount() + " of 3 callbacks outstanding."
+          );
+        }
+      } catch (final InterruptedException e) {
+        Thread.currentThread().interrupt();
+        throw new IllegalStateException("interrupted while draining the dispatcher", e);
+      }
+    }
+
+    private static void await(final CountDownLatch latch, final String what) {
+      try {
+        if (!latch.await(DRAIN_TIMEOUT_SECONDS, TimeUnit.SECONDS)) {
+          throw new AssertionError(what + " did not complete");
+        }
+      } catch (final InterruptedException e) {
+        Thread.currentThread().interrupt();
+        throw new IllegalStateException("interrupted during " + what, e);
+      }
+    }
+
+    private static void join(final Thread thread) {
+      try {
+        thread.join();
+      } catch (final InterruptedException e) {
+        Thread.currentThread().interrupt();
+        throw new IllegalStateException("interrupted while joining " + thread.getName(), e);
+      }
+    }
+
+    private static void pause() {
+      try {
+        Thread.sleep(1);
+      } catch (final InterruptedException e) {
+        Thread.currentThread().interrupt();
+      }
+    }
+
+    private static ConsumerRecord<byte[], byte[]> record(final byte[] key, final long offset) {
+      return new ConsumerRecord<>(TOPIC, 0, offset, key.clone(), new byte[0]);
+    }
+  }
+}

--- a/lib/kpipe-consumer/src/frayTest/java/io/github/eschizoid/kpipe/consumer/KeyOrderedEvictTombstoneFrayTest.java
+++ b/lib/kpipe-consumer/src/frayTest/java/io/github/eschizoid/kpipe/consumer/KeyOrderedEvictTombstoneFrayTest.java
@@ -7,7 +7,6 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
@@ -103,7 +102,6 @@ class KeyOrderedEvictTombstoneFrayTest {
     private static final long FIRST_A_OFFSET = 1L;
     private static final long B_OFFSET = 2L;
     private static final long SECOND_A_OFFSET = 3L;
-    private static final long DRAIN_TIMEOUT_SECONDS = 10L;
 
     private final KeyOrderedDispatcher dispatcher = new KeyOrderedDispatcher(1);
     private final AtomicInteger tasksRun = new AtomicInteger();
@@ -177,24 +175,29 @@ class KeyOrderedEvictTombstoneFrayTest {
       }
     }
 
+    /// Unbounded for the same reason as [#await]: under a controlled scheduler a real-time
+    /// deadline measures Fray's exploration order rather than the dispatcher's liveness. A task
+    /// that genuinely never completes is a deadlock, which Fray detects and reports.
     private void awaitDrain() {
       try {
-        if (!allDone.await(DRAIN_TIMEOUT_SECONDS, TimeUnit.SECONDS)) {
-          throw new AssertionError(
-            "A dispatched task never completed: " + allDone.getCount() + " of 3 callbacks outstanding."
-          );
-        }
+        allDone.await();
       } catch (final InterruptedException e) {
         Thread.currentThread().interrupt();
         throw new IllegalStateException("interrupted while draining the dispatcher", e);
       }
     }
 
+    /// Waits without a deadline, which is the correct shape under a controlled scheduler.
+    ///
+    /// A wall-clock timeout asks "did this finish within N seconds of real time", a question
+    /// that has no meaning when Fray decides which thread runs: the scheduler can legitimately
+    /// hold the dispatching worker parked for the whole timeout while it explores another
+    /// ordering, and the wait then fails a test whose code is correct. Fray detects a genuine
+    /// stall itself and reports it as a deadlock, so an unbounded wait cannot hang the suite —
+    /// it hands the liveness question to the component that actually knows the answer.
     private static void await(final CountDownLatch latch, final String what) {
       try {
-        if (!latch.await(DRAIN_TIMEOUT_SECONDS, TimeUnit.SECONDS)) {
-          throw new AssertionError(what + " did not complete");
-        }
+        latch.await();
       } catch (final InterruptedException e) {
         Thread.currentThread().interrupt();
         throw new IllegalStateException("interrupted during " + what, e);

--- a/lib/kpipe-consumer/src/frayTest/java/io/github/eschizoid/kpipe/consumer/KeyOrderedEvictTombstoneFrayTest.java
+++ b/lib/kpipe-consumer/src/frayTest/java/io/github/eschizoid/kpipe/consumer/KeyOrderedEvictTombstoneFrayTest.java
@@ -10,6 +10,7 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -46,6 +47,13 @@ import org.pastalab.fray.junit.plain.FrayInTestLauncher;
 /// the interesting region" is a failure rather than a silent pass.
 @ExtendWith(FrayTestExtension.class)
 @Tag("FrayTest")
+@Disabled(
+  "Does not terminate under exploration. KeyOrderedDispatcher.reserveCapacity waits by sleeping, and Fray " +
+    "models a sleep as a yield, so the spinning thread stays permanently runnable and the scheduler is free " +
+    "to re-pick it instead of advancing the worker it waits on. maxScheduledStep would bound the runaway " +
+    "but is not reachable from either entry point. Re-enable once the scenario no longer drives a thread " +
+    "into that loop; the constraint is recorded in docs/adr/0001-concurrency-testing-tooling.md."
+)
 class KeyOrderedEvictTombstoneFrayTest {
 
   /// Drives the scenario across Fray's whole schedule space and fails on the first schedule

--- a/lib/kpipe-consumer/src/frayTest/java/io/github/eschizoid/kpipe/consumer/OffsetManagerFrayTest.java
+++ b/lib/kpipe-consumer/src/frayTest/java/io/github/eschizoid/kpipe/consumer/OffsetManagerFrayTest.java
@@ -1,0 +1,74 @@
+package io.github.eschizoid.kpipe.consumer;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.atomic.AtomicLong;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.clients.consumer.MockConsumer;
+import org.apache.kafka.clients.consumer.OffsetResetStrategy;
+import org.apache.kafka.common.TopicPartition;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.pastalab.fray.junit.junit5.FrayTestExtension;
+import org.pastalab.fray.junit.junit5.annotations.FrayTest;
+
+/// Fray ports of the offset-manager read-path races.
+///
+/// The manager is never started in these scenarios. `start()` schedules a periodic commit task
+/// on a `ScheduledThreadPoolExecutor` that lives until the manager is closed, and Fray does not
+/// finish an iteration while any thread is still live, so a started manager wedges exploration
+/// on the first schedule. Tracking and marking only skip their work once the manager reaches
+/// `STOPPED`, so an unstarted manager in `CREATED` exercises the full read/write race.
+@ExtendWith(FrayTestExtension.class)
+@Tag("FrayTest")
+class OffsetManagerFrayTest {
+
+  private static final String TOPIC = "fray-topic";
+  private static final TopicPartition PARTITION = new TopicPartition(TOPIC, 0);
+
+  /// A diagnostic read races the removal that empties the pending window.
+  ///
+  /// Three answers are all correct, which is the point: the reader takes the structure monitor
+  /// but sees whatever the writer has committed so far. It can see 100 still pending; it can see
+  /// the window drained and compute the frontier as highest-processed + 1; or it can catch the
+  /// torn moment where the window already looks empty but the highest-processed write is not yet
+  /// visible, giving the `-1` "nothing known for this partition" sentinel.
+  ///
+  /// What must never happen is a throw. The guarded `firstOrNull` exists because the natural
+  /// `isEmpty()`-then-`first()` shape is a check-then-act that can throw `NoSuchElementException`
+  /// when the last element leaves between the two calls.
+  @FrayTest(iterations = 500)
+  void frontierReadNeverThrowsWhileTheWindowDrains() {
+    final var manager = newManager();
+    manager.trackOffset(record(100L));
+    final var observed = new AtomicLong(Long.MIN_VALUE);
+
+    FrayScenarios.runConcurrently(
+      () -> manager.markOffsetProcessed(record(100L)),
+      () -> observed.set(manager.getPartitionState(PARTITION).nextOffsetToCommit())
+    );
+
+    final var seen = observed.get();
+    assertTrue(
+      seen == 100L || seen == 101L || seen == -1L,
+      () ->
+        "frontier read observed " +
+        seen +
+        ", which is neither the pending offset, the post-drain commit point, nor the " +
+        "nothing-tracked sentinel"
+    );
+  }
+
+  private static KafkaOffsetManager newManager() {
+    final var consumer = new MockConsumer<byte[], byte[]>(OffsetResetStrategy.EARLIEST);
+    return KafkaOffsetManager.builder(consumer)
+      .withCommitExecutor(offsets -> CompletableFuture.completedFuture(null))
+      .build();
+  }
+
+  private static ConsumerRecord<byte[], byte[]> record(final long offset) {
+    return new ConsumerRecord<>(TOPIC, 0, offset, "k".getBytes(UTF_8), "v".getBytes(UTF_8));
+  }
+}

--- a/lib/kpipe-consumer/src/frayTest/java/io/github/eschizoid/kpipe/consumer/OffsetManagerFrayTest.java
+++ b/lib/kpipe-consumer/src/frayTest/java/io/github/eschizoid/kpipe/consumer/OffsetManagerFrayTest.java
@@ -1,8 +1,10 @@
 package io.github.eschizoid.kpipe.consumer;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicLong;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
@@ -58,6 +60,90 @@ class OffsetManagerFrayTest {
         seen +
         ", which is neither the pending offset, the post-drain commit point, nor the " +
         "nothing-tracked sentinel"
+    );
+  }
+
+  /// Two workers retire offsets on both sides of a permanent gap. Offset 100 is tracked and never
+  /// marked, so it is the lowest pending offset for the whole scenario; the workers track and
+  /// retire 101 and 102 around it. The commit point must stay pinned at 100 under every schedule.
+  ///
+  /// This is the at-least-once guarantee stated as an invariant: committing 102 because it
+  /// finished would silently discard offset 100 on the next restart, since Kafka resumes from the
+  /// committed position and never revisits earlier offsets.
+  @FrayTest(iterations = 500)
+  void commitPointHoldsAtTheGapWhenTheSuccessorRetires() {
+    assertGapHolds(101L, 102L);
+  }
+
+  /// The same invariant with both retiring offsets above the gap's immediate successor, so the
+  /// pending window has a hole at 101 as well. The frontier rule is "lowest still-pending offset",
+  /// not "highest contiguous run", and this pins that distinction.
+  @FrayTest(iterations = 500)
+  void commitPointHoldsAtTheGapWhenNonAdjacentOffsetsRetire() {
+    assertGapHolds(102L, 103L);
+  }
+
+  /// A partition revoke races a worker still tracking and retiring offsets on that partition.
+  ///
+  /// Three end states are legitimate, depending on where the revoke lands: the worker's track
+  /// survives and pins the commit point at 100; the revoke clears everything and leaves the
+  /// nothing-tracked sentinel; or the revoke clears the pending window after the worker's mark,
+  /// leaving the retired offset's successor. The forbidden shape is a commit point that advanced
+  /// past an offset still counted as pending — that combination means a record in flight during a
+  /// rebalance was committed away.
+  @FrayTest(iterations = 500)
+  void revokeNeverCommitsPastAStillPendingOffset() {
+    final var manager = newManager();
+    final var rebalanceListener = manager.createRebalanceListener();
+    manager.trackOffset(record(100L));
+
+    FrayScenarios.runConcurrently(
+      () -> rebalanceListener.onPartitionsRevoked(List.of(PARTITION)),
+      () -> {
+        manager.trackOffset(record(100L));
+        manager.markOffsetProcessed(record(101L));
+      }
+    );
+
+    final var state = manager.getPartitionState(PARTITION);
+    final var seen = state.nextOffsetToCommit();
+    final var pending = state.pendingCount() > 0;
+    assertTrue(
+      (seen == 100L && pending) || (seen == -1L && !pending) || (seen == 102L && !pending),
+      () ->
+        "revoke left commit point " +
+        seen +
+        " with pending=" +
+        pending +
+        "; a commit point past a still-pending offset would drop an in-flight record"
+    );
+  }
+
+  /// Tracks offset 100 and leaves it pending, then has two workers track and retire `first` and
+  /// `second` concurrently. The commit frontier must remain at 100 throughout.
+  ///
+  /// @param first  offset the first worker tracks and retires
+  /// @param second offset the second worker tracks and retires
+  private static void assertGapHolds(final long first, final long second) {
+    final var manager = newManager();
+    // Tracked and never marked: the permanent gap that pins the commit point.
+    manager.trackOffset(record(100L));
+
+    FrayScenarios.runConcurrently(
+      () -> {
+        manager.trackOffset(record(first));
+        manager.markOffsetProcessed(record(first));
+      },
+      () -> {
+        manager.trackOffset(record(second));
+        manager.markOffsetProcessed(record(second));
+      }
+    );
+
+    assertEquals(
+      100L,
+      manager.getPartitionState(PARTITION).nextOffsetToCommit(),
+      "the commit point advanced past offset 100, which is still pending"
     );
   }
 

--- a/lib/kpipe-consumer/src/frayTest/java/io/github/eschizoid/kpipe/consumer/PendingOffsetSetFrayTest.java
+++ b/lib/kpipe-consumer/src/frayTest/java/io/github/eschizoid/kpipe/consumer/PendingOffsetSetFrayTest.java
@@ -1,0 +1,82 @@
+package io.github.eschizoid.kpipe.consumer;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.concurrent.atomic.AtomicLong;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.pastalab.fray.junit.junit5.FrayTestExtension;
+import org.pastalab.fray.junit.junit5.annotations.FrayTest;
+
+/// Fray ports of the three [PendingOffsetSet] stress tests — the sorted primitive-`long` window
+/// that replaced `ConcurrentSkipListSet<Long>` as the per-partition pending set.
+///
+/// **What these can and cannot show.** Every mutator on the structure is `synchronized` on the
+/// instance monitor, so the mutating actors are mutually exclusive and no schedule interleaves
+/// two window mutations. What the ports pin is that the reachable serial orderings all converge
+/// on the same state, and that the monitor discipline is still in place: if a change dropped or
+/// weakened `synchronized`, the actors would interleave and a lost insert or a torn head/tail
+/// update would surface as a failing schedule.
+///
+/// The reader case is the one with genuine concurrency — reads take the monitor but observe
+/// whatever the writer has committed so far, so more than one answer is correct and the port
+/// asserts membership in the acceptable set rather than one value.
+@ExtendWith(FrayTestExtension.class)
+@Tag("FrayTest")
+class PendingOffsetSetFrayTest {
+
+  /// Draining the window races repopulating it. Either order must leave exactly `{200}`:
+  /// remove-then-add drains and repopulates, add-then-remove takes the head-removal path out
+  /// of `{100, 200}`.
+  @FrayTest(iterations = 300)
+  void addSurvivesTheConcurrentDrain() {
+    final var set = new PendingOffsetSet();
+    set.add(100L);
+
+    FrayScenarios.runConcurrently(() -> set.remove(100L), () -> set.add(200L));
+
+    assertEquals(200L, set.firstOrNull(), "the added offset should be the only one left pending");
+    assertEquals(1, set.size(), "exactly one offset should remain in the window");
+  }
+
+  /// Two inserts land in different regions of the window at once — one below the current head,
+  /// one between the existing entries. Both must survive and the window must stay sorted.
+  @FrayTest(iterations = 300)
+  void concurrentInsertsBothSurvive() {
+    final var set = new PendingOffsetSet();
+    set.add(100L);
+    set.add(200L);
+
+    FrayScenarios.runConcurrently(() -> set.add(50L), () -> set.add(150L));
+
+    assertEquals(50L, set.firstOrNull(), "the prepended offset should become the window head");
+    assertEquals(200L, set.lastOrNull(), "the window tail should be unchanged");
+    assertEquals(4, set.size(), "no insert should have been lost or duplicated");
+  }
+
+  /// A read races the removal that empties the window. Both answers are correct — the reader
+  /// either sees 100 still pending or sees the window already drained. What must never happen
+  /// is a throw or a torn value: `firstOrNull` is the guarded replacement for the
+  /// `isEmpty()`-then-`first()` check-then-act that could throw under contention.
+  @FrayTest(iterations = 300)
+  void readerNeverSeesATornWindow() {
+    final var set = new PendingOffsetSet();
+    set.add(100L);
+    final var observed = new AtomicLong(Long.MIN_VALUE);
+
+    FrayScenarios.runConcurrently(
+      () -> set.remove(100L),
+      () -> {
+        final var first = set.firstOrNull();
+        observed.set(first == null ? -1L : first);
+      }
+    );
+
+    final var seen = observed.get();
+    assertTrue(
+      seen == 100L || seen == -1L,
+      () -> "reader observed " + seen + ", which is neither the pending offset nor an empty window"
+    );
+  }
+}

--- a/lib/kpipe-consumer/src/frayTest/java/io/github/eschizoid/kpipe/consumer/RemoveIfEmptyFrayTest.java
+++ b/lib/kpipe-consumer/src/frayTest/java/io/github/eschizoid/kpipe/consumer/RemoveIfEmptyFrayTest.java
@@ -1,0 +1,91 @@
+package io.github.eschizoid.kpipe.consumer;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.concurrent.CompletableFuture;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.clients.consumer.MockConsumer;
+import org.apache.kafka.clients.consumer.OffsetResetStrategy;
+import org.apache.kafka.common.TopicPartition;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.pastalab.fray.junit.junit5.FrayTestExtension;
+import org.pastalab.fray.junit.junit5.annotations.FrayTest;
+
+/// Fray port of the jcstress remove-if-empty stress test.
+///
+/// **The race.** Per-partition pending offsets live in a `ConcurrentHashMap`. Retiring the last
+/// pending offset empties its set and drops the map key. If tracking a fresh offset adds to that
+/// set outside the same bucket lock, the add can land on a set that was concurrently emptied and
+/// unlinked — orphaned — silently losing the offset and letting the commit point advance past a
+/// record that is still in flight. Production hits this exact pairing: `trackOffset` runs on the
+/// poll thread while `markOffsetProcessed` runs on worker virtual threads for the same partition.
+///
+/// **Why this is the port that carries the pilot.** Unlike the dispatcher scenarios, nothing on
+/// this path waits by sleeping, so every schedule terminates. The invariant is also falsifiable in
+/// one edit: replacing the atomic `computeIfPresent` remove-if-empty with a separate
+/// `if (isEmpty()) remove(key)` reopens the window, and a run that still passes after that edit has
+/// proven it is not exploring.
+///
+/// **Translation note.** jcstress enumerates outcomes and grades each one; Fray explores schedules
+/// and checks an invariant per schedule. The `200, 1` ACCEPTABLE / everything-else FORBIDDEN pair
+/// collapses into the two assertions below. What is lost in the move is the outcome histogram —
+/// Fray reports that an invariant broke, not the distribution of interleavings that produced it.
+@ExtendWith(FrayTestExtension.class)
+@Tag("FrayTest")
+class RemoveIfEmptyFrayTest {
+
+  private static final String TOPIC = "fray-topic";
+  private static final TopicPartition PARTITION = new TopicPartition(TOPIC, 0);
+  private static final long RETIRED_OFFSET = 100L;
+  private static final long TRACKED_OFFSET = 200L;
+
+  @FrayTest(iterations = 500)
+  void freshlyTrackedOffsetSurvivesTheConcurrentRetire() {
+    final var manager = newManager();
+    // Offset 100 is the only pending offset, so retiring it empties the set and drops the key.
+    manager.trackOffset(record(RETIRED_OFFSET));
+
+    final var retire = new Thread(() -> manager.markOffsetProcessed(record(RETIRED_OFFSET)), "fray-retire");
+    final var track = new Thread(() -> manager.trackOffset(record(TRACKED_OFFSET)), "fray-track");
+    retire.start();
+    track.start();
+    join(retire);
+    join(track);
+
+    final var state = manager.getPartitionState(PARTITION);
+    assertEquals(
+      TRACKED_OFFSET,
+      state.nextOffsetToCommit(),
+      "offset 200 was lost to the concurrent remove-if-empty, so the commit point advanced past a " +
+        "record that never finished"
+    );
+    assertEquals(1, state.pendingCount(), "the partition should hold exactly the one still-pending offset");
+  }
+
+  private static KafkaOffsetManager newManager() {
+    final var consumer = new MockConsumer<byte[], byte[]>(OffsetResetStrategy.EARLIEST);
+    final var manager = KafkaOffsetManager.builder(consumer)
+      .withCommitExecutor(offsets -> new CompletableFuture<>())
+      .build();
+    manager.start();
+    return manager;
+  }
+
+  private static ConsumerRecord<byte[], byte[]> record(final long offset) {
+    return new ConsumerRecord<>(TOPIC, 0, offset, "k".getBytes(UTF_8), "v".getBytes(UTF_8));
+  }
+
+  /// Unbounded on purpose. Both threads run to completion without waiting on each other, so a
+  /// real-time deadline here would measure Fray's exploration order rather than the code's
+  /// liveness; a schedule that genuinely fails to terminate is reported by Fray as a deadlock.
+  private static void join(final Thread thread) {
+    try {
+      thread.join();
+    } catch (final InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new IllegalStateException("interrupted joining " + thread.getName(), e);
+    }
+  }
+}

--- a/lib/kpipe-consumer/src/frayTest/java/io/github/eschizoid/kpipe/consumer/RemoveIfEmptyFrayTest.java
+++ b/lib/kpipe-consumer/src/frayTest/java/io/github/eschizoid/kpipe/consumer/RemoveIfEmptyFrayTest.java
@@ -23,7 +23,8 @@ import org.pastalab.fray.junit.junit5.annotations.FrayTest;
 /// poll thread while `markOffsetProcessed` runs on worker virtual threads for the same partition.
 ///
 /// **Why this is the port that carries the pilot.** Unlike the dispatcher scenarios, nothing on
-/// this path waits by sleeping, so every schedule terminates. The invariant is also falsifiable in
+/// this path waits by sleeping, and the scenario leaves no thread running when the body returns,
+/// so every schedule terminates. The invariant is also falsifiable in
 /// one edit: replacing the atomic `computeIfPresent` remove-if-empty with a separate
 /// `if (isEmpty()) remove(key)` reopens the window, and a run that still passes after that edit has
 /// proven it is not exploring.
@@ -64,13 +65,18 @@ class RemoveIfEmptyFrayTest {
     assertEquals(1, state.pendingCount(), "the partition should hold exactly the one still-pending offset");
   }
 
+  /// Deliberately never started. `start()` schedules a periodic commit task on a
+  /// `ScheduledThreadPoolExecutor` that runs until the manager is closed, and Fray does not finish
+  /// an iteration while any thread is still live — a started manager wedges exploration on the
+  /// first schedule. Neither `trackOffset` nor `markOffsetProcessed` needs the scheduler: both
+  /// mutate the ledger directly and only skip their work once the manager reaches `STOPPED`, so an
+  /// unstarted manager in `CREATED` exercises the full race. The commit executor is likewise a
+  /// completed future rather than a pending one, so nothing can block on it.
   private static KafkaOffsetManager newManager() {
     final var consumer = new MockConsumer<byte[], byte[]>(OffsetResetStrategy.EARLIEST);
-    final var manager = KafkaOffsetManager.builder(consumer)
-      .withCommitExecutor(offsets -> new CompletableFuture<>())
+    return KafkaOffsetManager.builder(consumer)
+      .withCommitExecutor(offsets -> CompletableFuture.completedFuture(null))
       .build();
-    manager.start();
-    return manager;
   }
 
   private static ConsumerRecord<byte[], byte[]> record(final long offset) {

--- a/lib/kpipe-consumer/src/frayTest/java/io/github/eschizoid/kpipe/consumer/StateTransitionCasFrayTest.java
+++ b/lib/kpipe-consumer/src/frayTest/java/io/github/eschizoid/kpipe/consumer/StateTransitionCasFrayTest.java
@@ -1,0 +1,49 @@
+package io.github.eschizoid.kpipe.consumer;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.pastalab.fray.junit.junit5.FrayTestExtension;
+import org.pastalab.fray.junit.junit5.annotations.FrayTest;
+
+/// Fray port of the consumer state-machine CAS stress test.
+///
+/// Two paths reach the same transition: an external `close()` and the consumer thread's own
+/// uncaught-exception handler self-terminating. Both call the shared helper, and exactly one
+/// must win — a transition that let both callers through would run the shutdown sequence twice,
+/// and one that let neither through would leave the consumer wedged in RUNNING with nothing
+/// driving it to a terminal state.
+///
+/// The property is a single-read compare-and-set: read the state once into a local, decide, then
+/// CAS. Two sequential CAS calls would open a window where both callers observe RUNNING and both
+/// believe they won.
+@ExtendWith(FrayTestExtension.class)
+@Tag("FrayTest")
+class StateTransitionCasFrayTest {
+
+  @FrayTest(iterations = 300)
+  void exactlyOneCallerWinsTheTransitionToClosing() {
+    final var state = new AtomicReference<>(ConsumerState.RUNNING);
+    final var closerWon = new AtomicBoolean();
+    final var selfTerminatorWon = new AtomicBoolean();
+
+    FrayScenarios.runConcurrently(
+      () -> closerWon.set(KPipeConsumer.tryTransitionToClosing(state)),
+      () -> selfTerminatorWon.set(KPipeConsumer.tryTransitionToClosing(state))
+    );
+
+    assertTrue(
+      closerWon.get() ^ selfTerminatorWon.get(),
+      () ->
+        "exactly one caller must win the transition, but closer=" +
+        closerWon.get() +
+        " and selfTerminator=" +
+        selfTerminatorWon.get()
+    );
+    assertEquals(ConsumerState.CLOSING, state.get(), "the state must land in CLOSING either way");
+  }
+}

--- a/lib/kpipe-consumer/src/main/java/io/github/eschizoid/kpipe/consumer/OffsetLedger.java
+++ b/lib/kpipe-consumer/src/main/java/io/github/eschizoid/kpipe/consumer/OffsetLedger.java
@@ -78,10 +78,14 @@ final class OffsetLedger {
   void markProcessed(final String topic, final int partition, final long offset) {
     final var tp = cachedTopicPartition(topic, partition);
     highestProcessedOffsets.compute(tp, (_, v) -> v == null ? offset : Math.max(v, offset));
-    pendingOffsets.computeIfPresent(tp, (_, set) -> {
+    // FALSIFICATION PROBE - REVERTED IN THE NEXT COMMIT. Splits the empty-check from the map
+    // removal so a concurrent track() can add to a set that is already condemned.
+    final var set = pendingOffsets.get(tp);
+    if (set != null) {
       set.remove(offset);
-      return set.isEmpty() ? null : set;
-    });
+      final var nowEmpty = set.isEmpty();
+      if (nowEmpty) pendingOffsets.remove(tp);
+    }
   }
 
   /// The commit-frontier rule for one partition. Lowest still-pending offset if any (can't commit

--- a/lib/kpipe-consumer/src/main/java/io/github/eschizoid/kpipe/consumer/OffsetLedger.java
+++ b/lib/kpipe-consumer/src/main/java/io/github/eschizoid/kpipe/consumer/OffsetLedger.java
@@ -78,14 +78,10 @@ final class OffsetLedger {
   void markProcessed(final String topic, final int partition, final long offset) {
     final var tp = cachedTopicPartition(topic, partition);
     highestProcessedOffsets.compute(tp, (_, v) -> v == null ? offset : Math.max(v, offset));
-    // FALSIFICATION PROBE - REVERTED IN THE NEXT COMMIT. Splits the empty-check from the map
-    // removal so a concurrent track() can add to a set that is already condemned.
-    final var set = pendingOffsets.get(tp);
-    if (set != null) {
+    pendingOffsets.computeIfPresent(tp, (_, set) -> {
       set.remove(offset);
-      final var nowEmpty = set.isEmpty();
-      if (nowEmpty) pendingOffsets.remove(tp);
-    }
+      return set.isEmpty() ? null : set;
+    });
   }
 
   /// The commit-frontier rule for one partition. Lowest still-pending offset if any (can't commit

--- a/lib/kpipe-core/build.gradle.kts
+++ b/lib/kpipe-core/build.gradle.kts
@@ -1,6 +1,9 @@
+import org.pastalab.fray.gradle.FrayExtension
+
 plugins {
   `java-library`
   jacoco
+  alias(libs.plugins.fray)
 }
 
 description = "KPipe Core - Format-agnostic pipeline machinery for KPipe"
@@ -33,6 +36,46 @@ configurations["jcstressAnnotationProcessor"].extendsFrom(configurations["annota
 dependencies {
   jcstressImplementation(libs.jcstressCore)
   "jcstressAnnotationProcessor"(libs.jcstressCore)
+}
+
+// The Fray plugin derives its dependency configurations from the configured test-task name
+// (`frayTestImplementation`, `frayTestCompileOnly`), so this source set's name is load-bearing:
+// renaming it without renaming the task silently drops fray-core/fray-junit off the classpath.
+val frayTest: SourceSet by sourceSets.creating {
+  java.srcDir("src/frayTest/java")
+  compileClasspath += sourceSets.main.get().output
+  runtimeClasspath += sourceSets.main.get().output
+}
+
+val frayTestImplementation: Configuration by configurations.getting
+
+dependencies {
+  frayTestImplementation(platform(libs.junitBom))
+  frayTestImplementation(libs.junitJupiter)
+  "frayTestRuntimeOnly"(libs.junitPlatformLauncher)
+}
+
+// Same rationale as compileJcstressJava: compiled against the main module's exported packages as
+// plain classpath classes.
+tasks.named<JavaCompile>("compileFrayTestJava") {
+  modularity.inferModulePath.set(false)
+}
+
+// On an unsupported OS/arch the plugin leaves this as a plain Test run rather than failing, so
+// every @FrayTest reports as skipped and the build reads green. FrayInstrumentationGuardTest in
+// this source set is what turns that state red.
+tasks.register<Test>("frayTest") {
+  group = "verification"
+  description = "Runs the Fray controlled-concurrency suite for kpipe-core."
+  testClassesDirs = frayTest.output.classesDirs
+  classpath = frayTest.runtimeClasspath
+  // Fray forks one JVM and drives scheduling itself; parallel forks would only fight over cores.
+  maxParallelForks = 1
+  testLogging { showStandardStreams = true }
+}
+
+configure<FrayExtension> {
+  testTask = "frayTest"
 }
 
 // jcstress compiles against the classpath, not the module path. The main module's exported

--- a/lib/kpipe-core/src/frayTest/java/io/github/eschizoid/kpipe/registry/FrayInstrumentationGuardTest.java
+++ b/lib/kpipe-core/src/frayTest/java/io/github/eschizoid/kpipe/registry/FrayInstrumentationGuardTest.java
@@ -1,0 +1,52 @@
+package io.github.eschizoid.kpipe.registry;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.junit.jupiter.api.Test;
+
+/// Fails this module's Fray suite when Fray is not actually instrumenting it.
+///
+/// The plugin rewires a `Test` task to run on the jlink-instrumented Fray JDK. On an unsupported
+/// OS/architecture it skips that quietly and leaves a plain `Test` run, and every `@FrayTest` in
+/// the source set is then reported as *skipped* — a green build that verified nothing. Because
+/// the plugin configures each task independently, one module instrumenting correctly says nothing
+/// about another, so every module carrying Fray tests carries this guard.
+///
+/// This is a plain `@Test` on purpose: a `@FrayTest` would itself be skipped in exactly the state
+/// it is supposed to detect. It checks the running JVM rather than a log line, so it cannot pass
+/// on a stale or optimistic message.
+///
+/// The full behavioural check — plant a known race and require Fray to report it — lives once, in
+/// kpipe-consumer. That one proves Fray detects races at all; this one proves this module's task
+/// is running on the instrumented JVM.
+class FrayInstrumentationGuardTest {
+
+  private static final String FRAY_IMPLEMENTOR = "IMPLEMENTOR=Fray";
+
+  @Test
+  void frayInstrumentedJdkIsTheRunningJvm() throws IOException {
+    final var release = Path.of(System.getProperty("java.home"), "release");
+    assertTrue(
+      Files.isRegularFile(release),
+      () -> "No release file at " + release + "; this JVM is not a jlink image, so it cannot be Fray's."
+    );
+    final var stamped = Files.readAllLines(release)
+      .stream()
+      .anyMatch(line -> line.contains(FRAY_IMPLEMENTOR));
+    assertTrue(
+      stamped,
+      () ->
+        "The JVM running the Fray suite is " +
+        System.getProperty("java.home") +
+        ", which carries no " +
+        FRAY_IMPLEMENTOR +
+        " stamp. Fray is not instrumenting, so every @FrayTest in this source set would be " +
+        "reported as skipped and the build would read green. The usual cause is an unsupported " +
+        "OS/architecture — the agent is published for linux-x8664, windows-x8664 and " +
+        "macos-aarch64 only. Run the suite on a supported platform (see docs/adr/running-fray-locally.md)."
+    );
+  }
+}

--- a/lib/kpipe-core/src/frayTest/java/io/github/eschizoid/kpipe/registry/FrayScenariosCore.java
+++ b/lib/kpipe-core/src/frayTest/java/io/github/eschizoid/kpipe/registry/FrayScenariosCore.java
@@ -1,0 +1,30 @@
+package io.github.eschizoid.kpipe.registry;
+
+/// Shared plumbing for this module's Fray ports: run actions on their own threads and join them.
+///
+/// Fray does not finish an iteration while any thread it started is still live, so joining is a
+/// correctness requirement rather than tidiness — a leaked thread wedges exploration instead of
+/// failing.
+public final class FrayScenariosCore {
+
+  private FrayScenariosCore() {}
+
+  /// Runs each action on its own thread and joins them all before returning.
+  ///
+  /// @param actions the concurrent actions making up one schedule
+  public static void runConcurrently(final Runnable... actions) {
+    final var threads = new Thread[actions.length];
+    for (var i = 0; i < actions.length; i++) {
+      threads[i] = new Thread(actions[i], "fray-actor-" + i);
+    }
+    for (final var t : threads) t.start();
+    for (final var t : threads) {
+      try {
+        t.join();
+      } catch (final InterruptedException e) {
+        Thread.currentThread().interrupt();
+        throw new IllegalStateException("interrupted joining " + t.getName(), e);
+      }
+    }
+  }
+}

--- a/lib/kpipe-core/src/frayTest/java/io/github/eschizoid/kpipe/registry/MessageProcessorRegistryFrayTest.java
+++ b/lib/kpipe-core/src/frayTest/java/io/github/eschizoid/kpipe/registry/MessageProcessorRegistryFrayTest.java
@@ -1,0 +1,40 @@
+package io.github.eschizoid.kpipe.registry;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.pastalab.fray.junit.junit5.FrayTestExtension;
+import org.pastalab.fray.junit.junit5.annotations.FrayTest;
+
+/// Fray port of the registry namespace race.
+///
+/// Operators and sinks live in separate maps under the same key shape, so registering one of each
+/// under an identical key must leave both intact. If the two namespaces shared a map — or a
+/// registration read-modify-wrote a shared structure without atomicity — one would clobber the
+/// other and the loser's lookup would silently fall back to a pass-through.
+@ExtendWith(FrayTestExtension.class)
+@Tag("FrayTest")
+class MessageProcessorRegistryFrayTest {
+
+  private static final RegistryKey<Integer> KEY = RegistryKey.of("shared", Integer.class);
+
+  @FrayTest(iterations = 500)
+  void operatorAndSinkRegistrationsDoNotClobberEachOther() {
+    final var registry = new MessageProcessorRegistry();
+    final var sinkReceived = new AtomicBoolean(false);
+
+    FrayScenariosCore.runConcurrently(
+      // Identity-plus-one: a surviving registration is observable because the pass-through
+      // fallback would return the input unchanged.
+      () -> registry.registerOperator(KEY, input -> input + 1),
+      () -> registry.registerSink(KEY, value -> sinkReceived.set(true))
+    );
+
+    assertEquals(42, registry.getOperator(KEY).apply(41), "the registered operator did not survive the race");
+    registry.getSink(KEY).accept(7);
+    assertTrue(sinkReceived.get(), "the registered sink did not survive the race");
+  }
+}

--- a/lib/kpipe-core/src/frayTest/java/io/github/eschizoid/kpipe/sink/CompositeMessageSinkFrayTest.java
+++ b/lib/kpipe-core/src/frayTest/java/io/github/eschizoid/kpipe/sink/CompositeMessageSinkFrayTest.java
@@ -1,0 +1,34 @@
+package io.github.eschizoid.kpipe.sink;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import io.github.eschizoid.kpipe.registry.FrayScenariosCore;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicLong;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.pastalab.fray.junit.junit5.FrayTestExtension;
+import org.pastalab.fray.junit.junit5.annotations.FrayTest;
+
+/// Fray port of the fanout-delegation race.
+///
+/// Two records fan out through one composite to a shared downstream sink at the same time. Fanout
+/// is best-effort about *failures* — a throwing sink is logged and suppressed so the others still
+/// run — but it is not best-effort about *delivery*: every record must reach every sink. A
+/// delegation dropped under concurrency would lose a record with no error anywhere, which is the
+/// silent-failure shape the pipeline's explicit outcome types exist to rule out.
+@ExtendWith(FrayTestExtension.class)
+@Tag("FrayTest")
+class CompositeMessageSinkFrayTest {
+
+  @FrayTest(iterations = 500)
+  void concurrentSendsBothReachTheDownstreamSink() {
+    final var downstreamInvocations = new AtomicLong();
+    final MessageSink<String> counting = _ -> downstreamInvocations.incrementAndGet();
+    final var composite = new CompositeMessageSink<>(List.of(counting));
+
+    FrayScenariosCore.runConcurrently(() -> composite.accept("a"), () -> composite.accept("b"));
+
+    assertEquals(2L, downstreamInvocations.get(), "a fanout delegation was dropped under concurrency");
+  }
+}

--- a/lib/kpipe-producer/build.gradle.kts
+++ b/lib/kpipe-producer/build.gradle.kts
@@ -1,6 +1,9 @@
+import org.pastalab.fray.gradle.FrayExtension
+
 plugins {
   `java-library`
   jacoco
+  alias(libs.plugins.fray)
 }
 
 description = "KPipe Producer - Functional Kafka producer wrapper for KPipe"
@@ -47,6 +50,48 @@ configurations["jcstressAnnotationProcessor"].extendsFrom(configurations["annota
 dependencies {
   jcstressImplementation(libs.jcstressCore)
   "jcstressAnnotationProcessor"(libs.jcstressCore)
+}
+
+// The Fray plugin derives its dependency configurations from the configured test-task name
+// (`frayTestImplementation`, `frayTestCompileOnly`), so this source set's name is load-bearing:
+// renaming it without renaming the task silently drops fray-core/fray-junit off the classpath.
+val frayTest: SourceSet by sourceSets.creating {
+  java.srcDir("src/frayTest/java")
+  compileClasspath += sourceSets.main.get().output
+  runtimeClasspath += sourceSets.main.get().output
+}
+
+val frayTestImplementation: Configuration by configurations.getting
+
+dependencies {
+  frayTestImplementation(platform(libs.junitBom))
+  frayTestImplementation(libs.junitJupiter)
+  frayTestImplementation(libs.kafkaClients)
+  frayTestImplementation(project(":lib:kpipe-metrics"))
+  "frayTestRuntimeOnly"(libs.junitPlatformLauncher)
+}
+
+// Same rationale as compileJcstressJava: compiled against the main module's exported packages as
+// plain classpath classes.
+tasks.named<JavaCompile>("compileFrayTestJava") {
+  modularity.inferModulePath.set(false)
+}
+
+// On an unsupported OS/arch the plugin leaves this as a plain Test run rather than failing, so
+// every @FrayTest reports as skipped and the build reads green. FrayInstrumentationGuardTest in
+// this source set is what turns that state red.
+tasks.register<Test>("frayTest") {
+  group = "verification"
+  description = "Runs the Fray controlled-concurrency suite for kpipe-producer."
+  testClassesDirs = frayTest.output.classesDirs
+  classpath = frayTest.runtimeClasspath
+  // Fray forks one JVM and drives scheduling itself; parallel forks would only fight over cores.
+  maxParallelForks = 1
+  testLogging { showStandardStreams = true }
+}
+
+configure<FrayExtension> {
+  testTask = "frayTest"
 }
 
 // jcstress compiles against the classpath, not the module path. The main module's exported

--- a/lib/kpipe-producer/build.gradle.kts
+++ b/lib/kpipe-producer/build.gradle.kts
@@ -68,6 +68,9 @@ dependencies {
   frayTestImplementation(libs.junitJupiter)
   frayTestImplementation(libs.kafkaClients)
   frayTestImplementation(project(":lib:kpipe-metrics"))
+  // KPipeProducer.build() resolves Tracer at construction, so it has to be on the runtime
+  // classpath even for a scenario that never traces anything.
+  frayTestImplementation(project(":lib:kpipe-tracing"))
   "frayTestRuntimeOnly"(libs.junitPlatformLauncher)
 }
 

--- a/lib/kpipe-producer/src/frayTest/java/io/github/eschizoid/kpipe/producer/FrayInstrumentationGuardTest.java
+++ b/lib/kpipe-producer/src/frayTest/java/io/github/eschizoid/kpipe/producer/FrayInstrumentationGuardTest.java
@@ -1,0 +1,52 @@
+package io.github.eschizoid.kpipe.producer;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.junit.jupiter.api.Test;
+
+/// Fails this module's Fray suite when Fray is not actually instrumenting it.
+///
+/// The plugin rewires a `Test` task to run on the jlink-instrumented Fray JDK. On an unsupported
+/// OS/architecture it skips that quietly and leaves a plain `Test` run, and every `@FrayTest` in
+/// the source set is then reported as *skipped* — a green build that verified nothing. Because
+/// the plugin configures each task independently, one module instrumenting correctly says nothing
+/// about another, so every module carrying Fray tests carries this guard.
+///
+/// This is a plain `@Test` on purpose: a `@FrayTest` would itself be skipped in exactly the state
+/// it is supposed to detect. It checks the running JVM rather than a log line, so it cannot pass
+/// on a stale or optimistic message.
+///
+/// The full behavioural check — plant a known race and require Fray to report it — lives once, in
+/// kpipe-consumer. That one proves Fray detects races at all; this one proves this module's task
+/// is running on the instrumented JVM.
+class FrayInstrumentationGuardTest {
+
+  private static final String FRAY_IMPLEMENTOR = "IMPLEMENTOR=Fray";
+
+  @Test
+  void frayInstrumentedJdkIsTheRunningJvm() throws IOException {
+    final var release = Path.of(System.getProperty("java.home"), "release");
+    assertTrue(
+      Files.isRegularFile(release),
+      () -> "No release file at " + release + "; this JVM is not a jlink image, so it cannot be Fray's."
+    );
+    final var stamped = Files.readAllLines(release)
+      .stream()
+      .anyMatch(line -> line.contains(FRAY_IMPLEMENTOR));
+    assertTrue(
+      stamped,
+      () ->
+        "The JVM running the Fray suite is " +
+        System.getProperty("java.home") +
+        ", which carries no " +
+        FRAY_IMPLEMENTOR +
+        " stamp. Fray is not instrumenting, so every @FrayTest in this source set would be " +
+        "reported as skipped and the build would read green. The usual cause is an unsupported " +
+        "OS/architecture — the agent is published for linux-x8664, windows-x8664 and " +
+        "macos-aarch64 only. Run the suite on a supported platform (see docs/adr/running-fray-locally.md)."
+    );
+  }
+}

--- a/lib/kpipe-producer/src/frayTest/java/io/github/eschizoid/kpipe/producer/FrayScenariosProducer.java
+++ b/lib/kpipe-producer/src/frayTest/java/io/github/eschizoid/kpipe/producer/FrayScenariosProducer.java
@@ -1,0 +1,30 @@
+package io.github.eschizoid.kpipe.producer;
+
+/// Shared plumbing for this module's Fray ports: run actions on their own threads and join them.
+///
+/// Fray does not finish an iteration while any thread it started is still live, so joining is a
+/// correctness requirement rather than tidiness — a leaked thread wedges exploration instead of
+/// failing.
+final class FrayScenariosProducer {
+
+  private FrayScenariosProducer() {}
+
+  /// Runs each action on its own thread and joins them all before returning.
+  ///
+  /// @param actions the concurrent actions making up one schedule
+  static void runConcurrently(final Runnable... actions) {
+    final var threads = new Thread[actions.length];
+    for (var i = 0; i < actions.length; i++) {
+      threads[i] = new Thread(actions[i], "fray-actor-" + i);
+    }
+    for (final var t : threads) t.start();
+    for (final var t : threads) {
+      try {
+        t.join();
+      } catch (final InterruptedException e) {
+        Thread.currentThread().interrupt();
+        throw new IllegalStateException("interrupted joining " + t.getName(), e);
+      }
+    }
+  }
+}

--- a/lib/kpipe-producer/src/frayTest/java/io/github/eschizoid/kpipe/producer/ProducerMetricsAccountingFrayTest.java
+++ b/lib/kpipe-producer/src/frayTest/java/io/github/eschizoid/kpipe/producer/ProducerMetricsAccountingFrayTest.java
@@ -1,0 +1,62 @@
+package io.github.eschizoid.kpipe.producer;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import io.github.eschizoid.kpipe.metrics.ProducerMetrics;
+import java.util.concurrent.atomic.AtomicLong;
+import org.apache.kafka.clients.producer.MockProducer;
+import org.apache.kafka.clients.producer.Partitioner;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.common.serialization.ByteArraySerializer;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.pastalab.fray.junit.junit5.FrayTestExtension;
+import org.pastalab.fray.junit.junit5.annotations.FrayTest;
+
+/// Fray port of the producer send-accounting race.
+///
+/// Two sends complete concurrently and each must record exactly one success. The counter is what
+/// operators read to tell "the pipeline is delivering" from "the pipeline is silently dropping",
+/// so an increment lost to a race makes the metric under-report real throughput and, worse, makes
+/// a genuine delivery gap indistinguishable from a counting bug.
+@ExtendWith(FrayTestExtension.class)
+@Tag("FrayTest")
+class ProducerMetricsAccountingFrayTest {
+
+  private static final String TOPIC = "fray-topic";
+
+  @FrayTest(iterations = 500)
+  void concurrentSendsAreBothCounted() {
+    final var sent = new AtomicLong();
+    final var mock = new MockProducer<byte[], byte[]>(
+      true,
+      (Partitioner) null,
+      new ByteArraySerializer(),
+      new ByteArraySerializer()
+    );
+    // Counting fake: only the success path is instrumented, since that is the increment at stake.
+    final var recording = new ProducerMetrics() {
+      @Override
+      public void recordMessageSent() {
+        sent.incrementAndGet();
+      }
+
+      @Override
+      public void recordMessageFailed() {}
+
+      @Override
+      public void recordDlqSent() {}
+
+      @Override
+      public void recordDlqFailed() {}
+    };
+    final var producer = KPipeProducer.<byte[], byte[]>builder().withProducer(mock).withMetrics(recording).build();
+
+    FrayScenariosProducer.runConcurrently(
+      () -> producer.send(new ProducerRecord<>(TOPIC, "a".getBytes())),
+      () -> producer.send(new ProducerRecord<>(TOPIC, "b".getBytes()))
+    );
+
+    assertEquals(2L, sent.get(), "a send-success increment was lost under concurrency");
+  }
+}

--- a/lib/kpipe-schema-registry-confluent/build.gradle.kts
+++ b/lib/kpipe-schema-registry-confluent/build.gradle.kts
@@ -1,6 +1,9 @@
+import org.pastalab.fray.gradle.FrayExtension
+
 plugins {
   `java-library`
   jacoco
+  alias(libs.plugins.fray)
 }
 
 description = "KPipe Schema Registry Confluent - Confluent Schema Registry client (schema-by-ID lookup, JSON envelope unwrap)"
@@ -36,6 +39,47 @@ configurations["jcstressAnnotationProcessor"].extendsFrom(configurations["annota
 dependencies {
   jcstressImplementation(libs.jcstressCore)
   "jcstressAnnotationProcessor"(libs.jcstressCore)
+}
+
+// The Fray plugin derives its dependency configurations from the configured test-task name
+// (`frayTestImplementation`, `frayTestCompileOnly`), so this source set's name is load-bearing:
+// renaming it without renaming the task silently drops fray-core/fray-junit off the classpath.
+val frayTest: SourceSet by sourceSets.creating {
+  java.srcDir("src/frayTest/java")
+  compileClasspath += sourceSets.main.get().output
+  runtimeClasspath += sourceSets.main.get().output
+}
+
+val frayTestImplementation: Configuration by configurations.getting
+
+dependencies {
+  frayTestImplementation(platform(libs.junitBom))
+  frayTestImplementation(libs.junitJupiter)
+  frayTestImplementation(project(":lib:kpipe-core"))
+  "frayTestRuntimeOnly"(libs.junitPlatformLauncher)
+}
+
+// Same rationale as compileJcstressJava: compiled against the main module's exported packages as
+// plain classpath classes.
+tasks.named<JavaCompile>("compileFrayTestJava") {
+  modularity.inferModulePath.set(false)
+}
+
+// On an unsupported OS/arch the plugin leaves this as a plain Test run rather than failing, so
+// every @FrayTest reports as skipped and the build reads green. FrayInstrumentationGuardTest in
+// this source set is what turns that state red.
+tasks.register<Test>("frayTest") {
+  group = "verification"
+  description = "Runs the Fray controlled-concurrency suite for kpipe-schema-registry-confluent."
+  testClassesDirs = frayTest.output.classesDirs
+  classpath = frayTest.runtimeClasspath
+  // Fray forks one JVM and drives scheduling itself; parallel forks would only fight over cores.
+  maxParallelForks = 1
+  testLogging { showStandardStreams = true }
+}
+
+configure<FrayExtension> {
+  testTask = "frayTest"
 }
 
 // jcstress compiles against the classpath, not the module path. The main module's exported

--- a/lib/kpipe-schema-registry-confluent/src/frayTest/java/io/github/eschizoid/kpipe/schemaregistry/confluent/CachedSchemaResolverFrayTest.java
+++ b/lib/kpipe-schema-registry-confluent/src/frayTest/java/io/github/eschizoid/kpipe/schemaregistry/confluent/CachedSchemaResolverFrayTest.java
@@ -1,0 +1,50 @@
+package io.github.eschizoid.kpipe.schemaregistry.confluent;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+import io.github.eschizoid.kpipe.registry.SchemaResolver;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.pastalab.fray.junit.junit5.FrayTestExtension;
+import org.pastalab.fray.junit.junit5.annotations.FrayTest;
+
+/// Fray port of the schema-cache stampede race.
+///
+/// Two callers miss on the same schema id at once. `computeIfAbsent` has to collapse them into a
+/// single underlying load: schema ids are immutable in the registry, so caching by id needs no TTL
+/// or invalidation, but a miss that escapes the atomic load turns every cold key into as many
+/// registry round-trips as there are concurrent callers — the classic stampede, against an HTTP
+/// dependency on the record path.
+@ExtendWith(FrayTestExtension.class)
+@Tag("FrayTest")
+class CachedSchemaResolverFrayTest {
+
+  private static final int SCHEMA_ID = 42;
+  private static final String SCHEMA_JSON = "{\"type\":\"string\"}";
+
+  @FrayTest(iterations = 500)
+  void concurrentMissesCollapseToOneLoad() {
+    final var loadCount = new AtomicInteger();
+    // Counting fake: every underlying load bumps the counter and returns the same instance, so a
+    // duplicate load shows up both as a count above one and as a differing reference.
+    final SchemaResolver counting = id -> {
+      loadCount.incrementAndGet();
+      return SCHEMA_JSON;
+    };
+    final var resolver = new CachedSchemaResolver(counting);
+    final var first = new AtomicReference<String>();
+    final var second = new AtomicReference<String>();
+
+    FrayScenariosSchemaRegistry.runConcurrently(
+      () -> first.set(resolver.lookupById(SCHEMA_ID)),
+      () -> second.set(resolver.lookupById(SCHEMA_ID))
+    );
+
+    assertEquals(1, loadCount.get(), "concurrent misses did not collapse into a single registry load");
+    assertEquals(SCHEMA_JSON, first.get(), "first caller resolved the wrong schema");
+    assertSame(first.get(), second.get(), "callers resolved different instances for the same immutable schema id");
+  }
+}

--- a/lib/kpipe-schema-registry-confluent/src/frayTest/java/io/github/eschizoid/kpipe/schemaregistry/confluent/FrayInstrumentationGuardTest.java
+++ b/lib/kpipe-schema-registry-confluent/src/frayTest/java/io/github/eschizoid/kpipe/schemaregistry/confluent/FrayInstrumentationGuardTest.java
@@ -1,0 +1,52 @@
+package io.github.eschizoid.kpipe.schemaregistry.confluent;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.junit.jupiter.api.Test;
+
+/// Fails this module's Fray suite when Fray is not actually instrumenting it.
+///
+/// The plugin rewires a `Test` task to run on the jlink-instrumented Fray JDK. On an unsupported
+/// OS/architecture it skips that quietly and leaves a plain `Test` run, and every `@FrayTest` in
+/// the source set is then reported as *skipped* — a green build that verified nothing. Because
+/// the plugin configures each task independently, one module instrumenting correctly says nothing
+/// about another, so every module carrying Fray tests carries this guard.
+///
+/// This is a plain `@Test` on purpose: a `@FrayTest` would itself be skipped in exactly the state
+/// it is supposed to detect. It checks the running JVM rather than a log line, so it cannot pass
+/// on a stale or optimistic message.
+///
+/// The full behavioural check — plant a known race and require Fray to report it — lives once, in
+/// kpipe-consumer. That one proves Fray detects races at all; this one proves this module's task
+/// is running on the instrumented JVM.
+class FrayInstrumentationGuardTest {
+
+  private static final String FRAY_IMPLEMENTOR = "IMPLEMENTOR=Fray";
+
+  @Test
+  void frayInstrumentedJdkIsTheRunningJvm() throws IOException {
+    final var release = Path.of(System.getProperty("java.home"), "release");
+    assertTrue(
+      Files.isRegularFile(release),
+      () -> "No release file at " + release + "; this JVM is not a jlink image, so it cannot be Fray's."
+    );
+    final var stamped = Files.readAllLines(release)
+      .stream()
+      .anyMatch(line -> line.contains(FRAY_IMPLEMENTOR));
+    assertTrue(
+      stamped,
+      () ->
+        "The JVM running the Fray suite is " +
+        System.getProperty("java.home") +
+        ", which carries no " +
+        FRAY_IMPLEMENTOR +
+        " stamp. Fray is not instrumenting, so every @FrayTest in this source set would be " +
+        "reported as skipped and the build would read green. The usual cause is an unsupported " +
+        "OS/architecture — the agent is published for linux-x8664, windows-x8664 and " +
+        "macos-aarch64 only. Run the suite on a supported platform (see docs/adr/running-fray-locally.md)."
+    );
+  }
+}

--- a/lib/kpipe-schema-registry-confluent/src/frayTest/java/io/github/eschizoid/kpipe/schemaregistry/confluent/FrayScenariosSchemaRegistry.java
+++ b/lib/kpipe-schema-registry-confluent/src/frayTest/java/io/github/eschizoid/kpipe/schemaregistry/confluent/FrayScenariosSchemaRegistry.java
@@ -1,0 +1,30 @@
+package io.github.eschizoid.kpipe.schemaregistry.confluent;
+
+/// Shared plumbing for this module's Fray ports: run actions on their own threads and join them.
+///
+/// Fray does not finish an iteration while any thread it started is still live, so joining is a
+/// correctness requirement rather than tidiness — a leaked thread wedges exploration instead of
+/// failing.
+final class FrayScenariosSchemaRegistry {
+
+  private FrayScenariosSchemaRegistry() {}
+
+  /// Runs each action on its own thread and joins them all before returning.
+  ///
+  /// @param actions the concurrent actions making up one schedule
+  static void runConcurrently(final Runnable... actions) {
+    final var threads = new Thread[actions.length];
+    for (var i = 0; i < actions.length; i++) {
+      threads[i] = new Thread(actions[i], "fray-actor-" + i);
+    }
+    for (final var t : threads) t.start();
+    for (final var t : threads) {
+      try {
+        t.join();
+      } catch (final InterruptedException e) {
+        Thread.currentThread().interrupt();
+        throw new IllegalStateException("interrupted joining " + t.getName(), e);
+      }
+    }
+  }
+}


### PR DESCRIPTION
Pilot for the jcstress → Fray migration decided in ADR 0001 (#309). **One ported class, not twenty-one** — the point is to measure whether controlled scheduling beats stress before committing to the rest. jcstress is untouched.

## What's here

- **`frayTest` source set**, mirroring the existing jcstress layout, so Fray tests never run inside the plain `test` task. Opt-in task, not wired into `check`/`build`.
- **`FrayInstrumentationSelfCheckTest`** — the load-bearing piece, see below.
- **`KeyOrderedEvictTombstoneFrayTest`** — the eviction-tombstone race ported, reporting how many schedules reach the `dead`-tombstone retry path via the package-private `tombstoneRetries` counter (no reflection).
- **A parallel `fray` CI job** on `ubuntu-latest`, a supported Fray platform.

## The self-check, and why it exists

Both tools evaluated for this migration **reported success on deliberately racy code when they could not instrument it** — Lincheck by running it and finding nothing, Fray by marking every `@FrayTest` skipped (`tests="1" skipped="1" failures="0"`). Either way the build is green and nothing was verified.

Two gates, both plain `@Test` so a disabled Fray cannot skip them:
1. The running JVM must carry the `IMPLEMENTOR=Fray` stamp — the *same* marker Fray's own extension keys on to decide whether to skip. It fails exactly when the suite would otherwise vanish silently. Deterministic, not probabilistic.
2. The scheduler must report a planted lost update, matched on a marker string so an unrelated internal error isn't credited as a detection.

**Verified working on the failure it guards against:** on this macOS x86_64 machine (unsupported by Fray's native agent) the plugin logs `Fray JVMTI agent will not be added as a dependency` and the self-check **FAILS** instead of going quietly green.

## What CI must answer

This cannot be validated locally — macOS x86_64 is unsupported, so local `frayTest` is correctly red and proves nothing about Fray's behavior. CI is the oracle:

1. Does the self-check **pass** on `ubuntu-latest` (i.e. is Fray really instrumenting there)?
2. What fraction of schedules reach the tombstone window? **Baseline to beat: 78 / 23,427 = 0.33%** under jcstress.
3. Wall-clock versus the 30–35 minute jcstress job.

## Note on local test failures

Three integration suites (`ChaosRebalance`, `CrashRestartReprocessing`, `KPipeProducerIntegration`) fail on my machine when run concurrently — but they fail **identically on clean `main`** with the same `ContainerLaunchException`, so they are environmental and unrelated to this change. They pass when run individually.

## Still owed before the remaining 20 ports

The falsification check — delete the `dead` guard in `KeyOrderedDispatcher.dispatch`, confirm the Fray test **fails**, restore it, confirm it passes. That needs a supported platform, so it runs as a follow-up against CI.
