### PR TITLE
feat(schema-registry): warn once when the schema cache outgrows its assumption

### DIFF
--- a/lib/kpipe-schema-registry-confluent/src/main/java/io/github/eschizoid/kpipe/schemaregistry/confluent/CachedSchemaResolver.java
+++ b/lib/kpipe-schema-registry-confluent/src/main/java/io/github/eschizoid/kpipe/schemaregistry/confluent/CachedSchemaResolver.java
@@ -5,6 +5,7 @@ import java.lang.System.Logger;
 import java.lang.System.Logger.Level;
 import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
 
 /// In-process LRU-free cache wrapping any [SchemaResolver].
@@ -19,7 +20,15 @@ import java.util.concurrent.atomic.AtomicLong;
 /// Cardinality grows on the order of schema-version registrations — typically tens per topic
 /// over the lifetime of a production system, even with active evolution. Unbounded cache size
 /// is not a real concern at that rate. If a user does need a bound, they can wrap this
-/// resolver themselves; we'll add LRU here if a real workload demonstrates the need.
+/// resolver themselves.
+///
+/// That bound is an assumption about producer behaviour, not something this class enforces, and
+/// a producer registering a schema per deploy — or a consumer spanning many topics with
+/// independent lineages — breaks it. The failure mode is a slow leak in a long-running consumer,
+/// which is among the hardest to attribute, so [#lookupById] logs once at WARNING when the cache
+/// passes [#UNEXPECTED_SIZE]. Bounding is deliberately not attempted: eviction would mean a
+/// synchronous registry round-trip on the record path for a schema about to be used again, and
+/// the warning is what would tell us the assumption had failed.
 ///
 /// **Thread-safety.** Backed by a [ConcurrentHashMap] so the hot read path is lock-free per
 /// bucket. `computeIfAbsent` makes the load+store atomic — if two threads miss on the same ID
@@ -38,10 +47,16 @@ public final class CachedSchemaResolver implements SchemaResolver, AutoCloseable
 
   private static final Logger LOGGER = System.getLogger(CachedSchemaResolver.class.getName());
 
+  /// Distinct schema IDs beyond which the cardinality assumption looks wrong. Set well above the
+  /// tens a healthy topic reaches over its lifetime, so crossing it means producer behaviour has
+  /// changed rather than that the cache is merely warm.
+  private static final int UNEXPECTED_SIZE = 1_000;
+
   private final SchemaResolver delegate;
   private final ConcurrentHashMap<Integer, String> cache = new ConcurrentHashMap<>();
   private final AtomicLong hits = new AtomicLong();
   private final AtomicLong misses = new AtomicLong();
+  private final AtomicBoolean sizeWarningEmitted = new AtomicBoolean();
 
   /// Wraps `delegate` with an unbounded by-ID cache.
   ///
@@ -57,10 +72,31 @@ public final class CachedSchemaResolver implements SchemaResolver, AutoCloseable
       hits.incrementAndGet();
       return hit;
     }
-    return cache.computeIfAbsent(schemaId, id -> {
+    final var resolved = cache.computeIfAbsent(schemaId, id -> {
       misses.incrementAndGet();
       return delegate.lookupById(id);
     });
+    warnOnceIfCacheLooksUnbounded();
+    return resolved;
+  }
+
+  /// Logs once when the cache exceeds the size its no-eviction design assumes.
+  ///
+  /// Guarded by a compare-and-set so sustained growth produces one line rather than one per
+  /// record. Schema IDs are immutable, so nothing here is a correctness problem — the entries
+  /// stay valid — but the memory is held for the life of the process.
+  private void warnOnceIfCacheLooksUnbounded() {
+    if (cache.size() <= UNEXPECTED_SIZE || !sizeWarningEmitted.compareAndSet(false, true)) {
+      return;
+    }
+    LOGGER.log(
+      Level.WARNING,
+      "Schema cache holds more than {0} distinct IDs. This cache never evicts, which assumes a "
+        + "topic registers tens of schemas over its lifetime; a producer registering per deploy "
+        + "breaks that and the entries are held for the life of the process. Wrap this resolver "
+        + "with your own bounded cache if the count keeps climbing. Logged once.",
+      UNEXPECTED_SIZE
+    );
   }
 
   /// Returns the number of cache hits since this resolver was constructed.

--- a/lib/kpipe-schema-registry-confluent/src/main/java/io/github/eschizoid/kpipe/schemaregistry/confluent/CachedSchemaResolver.java
+++ b/lib/kpipe-schema-registry-confluent/src/main/java/io/github/eschizoid/kpipe/schemaregistry/confluent/CachedSchemaResolver.java
@@ -26,7 +26,7 @@ import java.util.concurrent.atomic.AtomicLong;
 /// a producer registering a schema per deploy — or a consumer spanning many topics with
 /// independent lineages — breaks it. The failure mode is a slow leak in a long-running consumer,
 /// which is among the hardest to attribute, so [#lookupById] logs once at WARNING when the cache
-/// passes [#UNEXPECTED_SIZE]. Bounding is deliberately not attempted: eviction would mean a
+/// passes a thousand distinct ids. Bounding is deliberately not attempted: eviction would mean a
 /// synchronous registry round-trip on the record path for a schema about to be used again, and
 /// the warning is what would tell us the assumption had failed.
 ///
@@ -86,7 +86,13 @@ public final class CachedSchemaResolver implements SchemaResolver, AutoCloseable
   /// record. Schema IDs are immutable, so nothing here is a correctness problem — the entries
   /// stay valid — but the memory is held for the life of the process.
   private void warnOnceIfCacheLooksUnbounded() {
-    if (cache.size() <= UNEXPECTED_SIZE || !sizeWarningEmitted.compareAndSet(false, true)) {
+    // Flag first: after this has fired, size() would be recomputed on every miss for the life
+    // of the process — and the unbounded growth it flags is exactly when misses are endless
+    // and the map is largest.
+    if (sizeWarningEmitted.get() || cache.size() <= UNEXPECTED_SIZE) {
+      return;
+    }
+    if (!sizeWarningEmitted.compareAndSet(false, true)) {
       return;
     }
     LOGGER.log(
@@ -94,7 +100,7 @@ public final class CachedSchemaResolver implements SchemaResolver, AutoCloseable
       "Schema cache holds more than {0} distinct IDs. This cache never evicts, which assumes a "
         + "topic registers tens of schemas over its lifetime; a producer registering per deploy "
         + "breaks that and the entries are held for the life of the process. Wrap this resolver "
-        + "with your own bounded cache if the count keeps climbing. Logged once.",
+        + "with your own bounded cache if the count keeps climbing. Logged once per resolver.",
       UNEXPECTED_SIZE
     );
   }

--- a/lib/kpipe-schema-registry-confluent/src/test/java/io/github/eschizoid/kpipe/schemaregistry/confluent/CachedSchemaResolverSizeWarningTest.java
+++ b/lib/kpipe-schema-registry-confluent/src/test/java/io/github/eschizoid/kpipe/schemaregistry/confluent/CachedSchemaResolverSizeWarningTest.java
@@ -72,9 +72,11 @@ class CachedSchemaResolverSizeWarningTest {
       "sustained growth must log once, not once per record — a stuck producer would otherwise "
         + "flood the log at poll rate"
     );
+    final var message = warnings.getFirst().getMessage();
+    assertTrue(message.contains("never evicts"), "the warning should name the design property that was outgrown");
     assertTrue(
-      warnings.getFirst().getMessage().contains("never evicts"),
-      "the warning should name the design property that has been outgrown"
+      message.contains("bounded cache"),
+      "the warning should name the remedy; a diagnosis an operator cannot act on is half a warning"
     );
   }
 
@@ -146,5 +148,31 @@ class CachedSchemaResolverSizeWarningTest {
       assertEquals(1_200, resolver.hitCount(), "the second pass should be served entirely from cache");
       assertEquals(1_200, resolver.missCount(), "the first pass should account for every miss");
     }
+  }
+
+  /// Pins the threshold and the comparison exactly, rather than bracketing it loosely.
+  ///
+  /// The other tests only establish that 500 is silent and 5,000 warns, which leaves the constant
+  /// free to drift anywhere between and the boundary untested. The javadoc states a thousand in
+  /// prose, and prose does not hold a number still.
+  @Test
+  void theThresholdIsExactlyOneThousand() {
+    final var atThreshold = captureWarnings(() -> {
+      try (final var resolver = new CachedSchemaResolver(id -> "s" + id)) {
+        for (var id = 0; id < 1_000; id++) {
+          resolver.lookupById(id);
+        }
+      }
+    });
+    assertEquals(0, atThreshold.size(), "exactly a thousand distinct ids is within the assumption, not past it");
+
+    final var pastThreshold = captureWarnings(() -> {
+      try (final var resolver = new CachedSchemaResolver(id -> "s" + id)) {
+        for (var id = 0; id < 1_001; id++) {
+          resolver.lookupById(id);
+        }
+      }
+    });
+    assertEquals(1, pastThreshold.size(), "one id past the threshold must warn");
   }
 }

--- a/lib/kpipe-schema-registry-confluent/src/test/java/io/github/eschizoid/kpipe/schemaregistry/confluent/CachedSchemaResolverSizeWarningTest.java
+++ b/lib/kpipe-schema-registry-confluent/src/test/java/io/github/eschizoid/kpipe/schemaregistry/confluent/CachedSchemaResolverSizeWarningTest.java
@@ -4,20 +4,129 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import io.github.eschizoid.kpipe.registry.SchemaResolver;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.logging.Handler;
+import java.util.logging.Level;
+import java.util.logging.LogRecord;
+import java.util.logging.Logger;
 import org.junit.jupiter.api.Test;
 
-/// Pins caching behaviour past the cardinality the no-eviction design assumes.
+/// Pins the cache's behaviour past the cardinality its no-eviction design assumes.
 ///
-/// The warning emitted at that point goes through `System.Logger` and is not asserted here —
-/// intercepting it would need a custom `LoggerFinder` installed process-wide. What these tests
-/// do pin is that crossing the threshold changes nothing else: entries are still retained, the
-/// delegate is still called exactly once per distinct id, and the hit and miss counters still
-/// add up. A warning path that quietly broke caching would fail here.
+/// The warning is the whole point of the change, so it is asserted rather than merely executed:
+/// exactly one line however far past the threshold the cache grows, and none below it. A
+/// sustained miss stream must not log at record rate. `System.Logger` output is captured through
+/// the JUL handler it bridges to, the same way `KeyOrderedDispatcherTest` pins the KEY_ORDERED
+/// saturation warning.
 class CachedSchemaResolverSizeWarningTest {
 
+  /// Captures WARNING records from the resolver's logger for the duration of `body`.
+  ///
+  /// @param body what to run while capturing
+  /// @return the warnings emitted
+  private static java.util.List<LogRecord> captureWarnings(final Runnable body) {
+    final var julLogger = Logger.getLogger(CachedSchemaResolver.class.getName());
+    final var captured = new CopyOnWriteArrayList<LogRecord>();
+    final var handler = new Handler() {
+      @Override
+      public void publish(final LogRecord record) {
+        if (record.getLevel().intValue() >= Level.WARNING.intValue()) captured.add(record);
+      }
+
+      @Override
+      public void flush() {}
+
+      @Override
+      public void close() {}
+    };
+    final var originalLevel = julLogger.getLevel();
+    final var originalUseParent = julLogger.getUseParentHandlers();
+    julLogger.addHandler(handler);
+    julLogger.setLevel(Level.ALL);
+    julLogger.setUseParentHandlers(false);
+    try {
+      body.run();
+    } finally {
+      julLogger.removeHandler(handler);
+      julLogger.setLevel(originalLevel);
+      julLogger.setUseParentHandlers(originalUseParent);
+    }
+    return captured;
+  }
+
   @Test
-  void everyDistinctIdIsCachedAndLoadedExactlyOnce() {
+  void sustainedGrowthPastTheThresholdLogsExactlyOnce() {
+    final var warnings = captureWarnings(() -> {
+      try (final var resolver = new CachedSchemaResolver(id -> "s" + id)) {
+        for (var id = 0; id < 5_000; id++) {
+          resolver.lookupById(id);
+        }
+      }
+    });
+
+    assertEquals(
+      1,
+      warnings.size(),
+      "sustained growth must log once, not once per record — a stuck producer would otherwise "
+        + "flood the log at poll rate"
+    );
+    assertTrue(
+      warnings.getFirst().getMessage().contains("never evicts"),
+      "the warning should name the design property that has been outgrown"
+    );
+  }
+
+  @Test
+  void stayingBelowTheThresholdLogsNothing() {
+    final var warnings = captureWarnings(() -> {
+      try (final var resolver = new CachedSchemaResolver(id -> "s" + id)) {
+        for (var id = 0; id < 500; id++) {
+          resolver.lookupById(id);
+        }
+      }
+    });
+
+    assertEquals(0, warnings.size(), "a cache within its assumed cardinality must stay silent");
+  }
+
+  @Test
+  void concurrentCrossingsStillLogOnce() throws InterruptedException {
+    final var start = new CountDownLatch(1);
+    final var done = new CountDownLatch(16);
+    final var resolver = new CachedSchemaResolver(id -> "s" + id);
+
+    final var warnings = captureWarnings(() -> {
+      for (var t = 0; t < 16; t++) {
+        final var offset = t * 1_000;
+        Thread.ofPlatform().daemon().start(() -> {
+          try {
+            start.await();
+            for (var i = 0; i < 1_000; i++) {
+              resolver.lookupById(offset + i);
+            }
+          } catch (final InterruptedException e) {
+            Thread.currentThread().interrupt();
+          } finally {
+            done.countDown();
+          }
+        });
+      }
+      start.countDown();
+      try {
+        done.await();
+      } catch (final InterruptedException e) {
+        Thread.currentThread().interrupt();
+      }
+    });
+    resolver.close();
+
+    assertEquals(1, warnings.size(), "sixteen threads crossing the threshold together must still log once");
+  }
+
+  @Test
+  void crossingTheThresholdDoesNotDisturbCaching() {
     final var loads = new AtomicInteger();
     final SchemaResolver counting = id -> {
       loads.incrementAndGet();
@@ -28,7 +137,6 @@ class CachedSchemaResolverSizeWarningTest {
       for (var id = 0; id < 1_200; id++) {
         resolver.lookupById(id);
       }
-      // A second pass must not reach the delegate: the warning path must not disturb caching.
       for (var id = 0; id < 1_200; id++) {
         resolver.lookupById(id);
       }
@@ -36,22 +144,7 @@ class CachedSchemaResolverSizeWarningTest {
       assertEquals(1_200, loads.get(), "each distinct id should load exactly once");
       assertEquals(1_200, resolver.size(), "every entry should be retained; this cache does not evict");
       assertEquals(1_200, resolver.hitCount(), "the second pass should be served entirely from cache");
-      assertTrue(resolver.missCount() == 1_200, "the first pass should account for every miss");
-    }
-  }
-
-  @Test
-  void stayingBelowTheThresholdChangesNothing() {
-    final var loads = new AtomicInteger();
-    try (final var resolver = new CachedSchemaResolver(id -> {
-      loads.incrementAndGet();
-      return "s" + id;
-    })) {
-      for (var id = 0; id < 50; id++) {
-        resolver.lookupById(id);
-      }
-      assertEquals(50, resolver.size());
-      assertEquals(50, loads.get());
+      assertEquals(1_200, resolver.missCount(), "the first pass should account for every miss");
     }
   }
 }

--- a/lib/kpipe-schema-registry-confluent/src/test/java/io/github/eschizoid/kpipe/schemaregistry/confluent/CachedSchemaResolverSizeWarningTest.java
+++ b/lib/kpipe-schema-registry-confluent/src/test/java/io/github/eschizoid/kpipe/schemaregistry/confluent/CachedSchemaResolverSizeWarningTest.java
@@ -1,0 +1,57 @@
+package io.github.eschizoid.kpipe.schemaregistry.confluent;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.github.eschizoid.kpipe.registry.SchemaResolver;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.jupiter.api.Test;
+
+/// Pins caching behaviour past the cardinality the no-eviction design assumes.
+///
+/// The warning emitted at that point goes through `System.Logger` and is not asserted here —
+/// intercepting it would need a custom `LoggerFinder` installed process-wide. What these tests
+/// do pin is that crossing the threshold changes nothing else: entries are still retained, the
+/// delegate is still called exactly once per distinct id, and the hit and miss counters still
+/// add up. A warning path that quietly broke caching would fail here.
+class CachedSchemaResolverSizeWarningTest {
+
+  @Test
+  void everyDistinctIdIsCachedAndLoadedExactlyOnce() {
+    final var loads = new AtomicInteger();
+    final SchemaResolver counting = id -> {
+      loads.incrementAndGet();
+      return "{\"type\":\"string\",\"id\":" + id + "}";
+    };
+
+    try (final var resolver = new CachedSchemaResolver(counting)) {
+      for (var id = 0; id < 1_200; id++) {
+        resolver.lookupById(id);
+      }
+      // A second pass must not reach the delegate: the warning path must not disturb caching.
+      for (var id = 0; id < 1_200; id++) {
+        resolver.lookupById(id);
+      }
+
+      assertEquals(1_200, loads.get(), "each distinct id should load exactly once");
+      assertEquals(1_200, resolver.size(), "every entry should be retained; this cache does not evict");
+      assertEquals(1_200, resolver.hitCount(), "the second pass should be served entirely from cache");
+      assertTrue(resolver.missCount() == 1_200, "the first pass should account for every miss");
+    }
+  }
+
+  @Test
+  void stayingBelowTheThresholdChangesNothing() {
+    final var loads = new AtomicInteger();
+    try (final var resolver = new CachedSchemaResolver(id -> {
+      loads.incrementAndGet();
+      return "s" + id;
+    })) {
+      for (var id = 0; id < 50; id++) {
+        resolver.lookupById(id);
+      }
+      assertEquals(50, resolver.size());
+      assertEquals(50, loads.get());
+    }
+  }
+}


### PR DESCRIPTION
Closes the third item of #313.

`CachedSchemaResolver` never evicts, and that is correct: Confluent schema IDs are immutable, so a cached entry stays valid forever and no TTL or invalidation protocol is needed. The class documents that reasoning well.

What it also documents, less visibly, is an assumption: cardinality stays in the tens because a topic registers few schemas over its lifetime. That half is not a property of the system — it is a claim about producer behaviour, and nothing enforces it. A producer registering a schema per deploy breaks it, as does a consumer subscribed across many topics with independent schema lineages. The entries are `String` schema text, and the format layers cache parsed `Schema` and `Descriptor` objects keyed by the same IDs on top, so the real footprint is larger than the map suggests.

The failure mode is a slow leak in a long-running consumer: no error, no incorrect behaviour, just memory held for the life of the process. That is among the hardest classes of problem to attribute after the fact.

## What this does

`lookupById` logs once at WARNING when the cache passes a thousand distinct IDs. The threshold sits well above what a healthy topic reaches, so crossing it means producer behaviour has changed rather than that the cache is merely warm. An `AtomicBoolean` compare-and-set makes it one line per process rather than one per record — the same shape as the KEY_ORDERED stall warning.

## What this deliberately does not do

It does not bound the cache. Eviction would mean a synchronous registry round-trip on the record path for a schema that is about to be used again, and it would replace a design whose whole appeal is needing no policy with one that needs a size knob and an eviction strategy. If the warning ever fires in a real deployment, that is the evidence that would justify the trade — and it is the thing that is currently missing.

## Tests

The tests pin that crossing the threshold changes nothing else: every entry retained, the delegate called exactly once per distinct ID, and the hit and miss counters adding up across a second pass served entirely from cache.

They do **not** assert the log line. `System.Logger` would need a process-wide `LoggerFinder` to intercept, which is a heavier fixture than this warrants. The tests are falsifiable for what they do claim: a warning path that evicted instead of logging fails them, which is the way this change could plausibly break something.

https://claude.ai/code/session_01HhhuubMxcupaGLPuotZQNb
