### PR TITLE
docs: write the versioning and compatibility policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,9 @@ implementation("io.github.eschizoid:kpipe-api")
 implementation("io.github.eschizoid:kpipe-format-json")   // or -avro / -protobuf — formats are opt-in
 ```
 
+Minor releases may remove public API through 1.x — see [docs/VERSIONING.md](docs/VERSIONING.md) for what is
+covered, how a break reaches you, and when that rule changes.
+
 `kpipe-api` brings the consumer, producer, core, metrics, and tracing modules transitively; its only external runtime dependency is
 `kafka-clients`. Maven snippets, the full module catalog, `platform` vs `enforcedPlatform`, and JPMS
 (`module-info.java`) guidance: [docs/MODULES.md](docs/MODULES.md).
@@ -244,6 +247,7 @@ without a broker involved. Add `testImplementation("io.github.eschizoid:kpipe-te
 | [docs/MODULES.md](docs/MODULES.md) | Module catalog, BOM usage, JPMS |
 | [docs/ESCAPE-HATCHES.md](docs/ESCAPE-HATCHES.md) | The explicit builder API: custom offset managers, reporters, seams |
 | [docs/OFFSET-INVARIANTS.md](docs/OFFSET-INVARIANTS.md) | The machine-checked offset invariants |
+| [docs/VERSIONING.md](docs/VERSIONING.md) | What breaks in a minor, what counts as public API, and when the rule changes |
 | [docs/adr/](docs/adr/) | Architecture decision records — why the concurrency tooling is what it is |
 | [benchmarks/](benchmarks/) | Methodology, raw results, dated capture snapshots |
 | [examples/](examples/) | Runnable apps per format + a full demo with observability stack (`./scripts/run-demo.sh`) |

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ installed unless you opt in.
 ## Installation
 
 ```kotlin
-implementation(platform("io.github.eschizoid:kpipe-bom:1.18.0"))
+implementation(platform("io.github.eschizoid:kpipe-bom:1.20.0"))
 implementation("io.github.eschizoid:kpipe-api")
 implementation("io.github.eschizoid:kpipe-format-json")   // or -avro / -protobuf — formats are opt-in
 ```

--- a/docs/MODULES.md
+++ b/docs/MODULES.md
@@ -8,7 +8,7 @@ Gradle/Maven view.
 Most applications need exactly three lines: the BOM, the fluent API, and one format module.
 
 ```kotlin
-implementation(platform("io.github.eschizoid:kpipe-bom:1.18.0"))
+implementation(platform("io.github.eschizoid:kpipe-bom:1.20.0"))
 implementation("io.github.eschizoid:kpipe-api")
 implementation("io.github.eschizoid:kpipe-format-json")   // or -avro / -protobuf
 ```
@@ -26,7 +26,7 @@ Maven equivalent:
     <dependency>
       <groupId>io.github.eschizoid</groupId>
       <artifactId>kpipe-bom</artifactId>
-      <version>1.18.0</version>
+      <version>1.20.0</version>
       <type>pom</type>
       <scope>import</scope>
     </dependency>

--- a/docs/VERSIONING.md
+++ b/docs/VERSIONING.md
@@ -67,10 +67,11 @@ API despite the suffix, because `Stream` methods take them as parameters.
   ordinary line in a `## Changes` group rather than as a migration guide. Some releases add a
   hand-written breaking-change section above the generated changelog — v1.17.0 did — but that is
   not automatic and should not be relied on. Follow the commit.
-- **No compiler warning, and no marker to grep for.** Commit subjects do not currently use the
-  conventional-commit `!` breaking marker, so a break is not mechanically distinguishable from any
-  other change in the notes. That is the cost of having no deprecation cycle, and it is the reason
-  to read the release diff for a minor upgrade rather than assuming a minor is safe.
+- **No compiler warning.** That is the cost of having no deprecation cycle, and it is the reason to
+  read the release diff for a minor upgrade rather than assuming a minor is safe. Where a commit
+  subject carries the conventional-commit `!` marker (`refactor(consumer)!:`), that is reliable
+  evidence of a break; its absence is not evidence of safety, because the marker is not applied
+  consistently.
 
 ## Support window
 

--- a/docs/VERSIONING.md
+++ b/docs/VERSIONING.md
@@ -35,29 +35,42 @@ as are `BatchPolicy`, `BatchResult` and `ProcessingMode`. The published `kpipe-t
 user test code compiles against it.
 
 **SPI** — a public interface users are expected to *implement*: `MessageFormat`, `MessageSink`, `BatchSink`,
-`SchemaResolver`, `Tracer`, `ProtobufDescriptorCompiler`, `OffsetManager`, `ConsumerMetrics`, `ProducerMetrics`.
+`SchemaResolver`, `Tracer`, `ProtobufDescriptorCompiler`, `OffsetManager`, `ConsumerMetrics`,
+`ProducerMetrics`, `KPipeMetricsReporter`.
 Same stability rules, with one asymmetry worth knowing: adding a method to one of these is a breaking change for
 an implementer and invisible to a caller.
 
-**Internal** — anything **package-private**, whatever package it lives in. That is the boundary that actually
-operates here: every package in every module is exported, with no qualified exports anywhere, so JPMS is not
-hiding anything. `KeyOrderedDispatcher`, `ParallelDispatcher`, `SequentialDispatcher`, `OffsetLedger`,
-`RecordProcessor`, `ConsumerHealthController`, `BatchPipelineWrapper` and `PendingOffsetSet` are all
-package-private and carry no guarantees. Note the shape of the names is not the rule — `CircuitBreakerController`
-and `BackpressureController` are public API despite the suffix.
+**Internal** — anything **package-private**, plus a small set of types that are public only because
+Java has no friend-module visibility. Within a single module, package-private is the boundary that
+operates: every package in every JPMS module here is exported, with no qualified exports anywhere,
+so nothing is hidden that way. `KeyOrderedDispatcher`, `ParallelDispatcher`, `SequentialDispatcher`,
+`OffsetLedger`, `RecordProcessor`, `ConsumerHealthController`, `BatchPipelineWrapper` and
+`PendingOffsetSet` are all package-private and carry no guarantees.
 
-One exception exists and is called out rather than papered over: `RegistryFunctions` in `kpipe-core` is public and
-exported but is not intended as user surface. Treat it as internal.
+A helper shared *between* KPipe modules cannot be package-private, so it is forced public and
+exported while remaining internal. `RegistryFunctions`, `ConsoleSinkSupport`, `ConfluentEnvelope`
+and `WireDiagnostics` are those, and `KafkaOffsetManager.getPartitionState` is a test observation
+point with no production caller. None of them are user surface. The shape does not identify them —
+`Operators` and `ConsumerMetricKeys` look identical and are genuine API — so this list is the
+answer, not a pattern to apply.
+
+Note the name is never the rule: `CircuitBreakerController` and `BackpressureController` are public
+API despite the suffix, because `Stream` methods take them as parameters.
 
 ## How a break reaches you
 
-- **The PR that removes it** carries the migration detail — the removed form, the replacement, and the mechanical
-  edit — and updates every caller in the repository, so there is always a worked example. The same table is in the
-  commit message.
-- **Release notes are generated from commit subjects**, so a break appears there as a `feat!:` or `refactor(x)!:`
-  line pointing at that commit rather than as a prose migration guide. Follow the commit for the table.
-- **No compiler warning.** That is the cost of having no deprecation cycle, and it is the reason to read the
-  release diff for a minor upgrade rather than assuming a minor is safe.
+- **The PR that removes it** carries the migration detail — the removed form, the replacement, and
+  the mechanical edit — and updates every caller in the repository, so there is always a worked
+  example. The same detail is in the commit message, sometimes as a table and otherwise as a bullet
+  list.
+- **Release notes are generated from commit subjects**, so a break usually appears there as an
+  ordinary line in a `## Changes` group rather than as a migration guide. Some releases add a
+  hand-written breaking-change section above the generated changelog — v1.17.0 did — but that is
+  not automatic and should not be relied on. Follow the commit.
+- **No compiler warning, and no marker to grep for.** Commit subjects do not currently use the
+  conventional-commit `!` breaking marker, so a break is not mechanically distinguishable from any
+  other change in the notes. That is the cost of having no deprecation cycle, and it is the reason
+  to read the release diff for a minor upgrade rather than assuming a minor is safe.
 
 ## Support window
 

--- a/docs/VERSIONING.md
+++ b/docs/VERSIONING.md
@@ -1,0 +1,54 @@
+# Versioning and compatibility
+
+What breaks, when, and how you find out. This page exists so you can decide whether to depend on KPipe without
+reading its commit history.
+
+## The short version
+
+**Through 1.x, a minor release may remove or rename public API.** There is no deprecation cycle: an API that goes
+is deleted in the same change that migrates its callers, and the release notes carry a migration table for every
+break. Patch releases never break anything.
+
+**From 2.0 onward, KPipe follows strict semantic versioning.** Breaking changes land only in majors, and anything
+removed is deprecated for at least one minor first.
+
+If that first rule is unacceptable for your project, pin an exact version and upgrade deliberately. The BOM makes
+that a one-line change.
+
+## Why it works this way today
+
+Deprecation cycles have real costs: they enlarge the surface every future reader has to understand, they train
+people to ignore warnings, and the promised removal is often never made, so the deprecated form outlives the thing
+that replaced it. Deleting in one step keeps the API the size of the idea.
+
+That trade favours the codebase over its users, which is the right way round while the API is still finding its
+shape and wrong once people depend on it. 2.0 is where it flips.
+
+## What counts as public API
+
+| Tier | What it covers | Stability |
+| --- | --- | --- |
+| **Public API** | `KPipe`, `Stream`, `Sink`, `Handle`, `MessageFormat`, `MessageSink`, `BatchSink`, `Result`, the `RegistryKey` / `MessageProcessorRegistry` pair, and the builders reachable from them | Covered by the rules above |
+| **SPI** | `SchemaResolver`, `Tracer`, `ProtobufDescriptorCompiler`, `OffsetManager`, `ConsumerMetrics`, `ProducerMetrics` | Same rules, but implementing one means a new abstract method is a break for you and not for a caller |
+| **Internal** | Anything package-private, anything under a package a module does not export, and every `*Dispatcher`, `*Controller` and `*Ledger` type | No guarantees. May change in any release |
+
+A type being `public` for JPMS reasons does not make it public API — the module's `exports` clauses are the
+boundary that counts.
+
+## How a break reaches you
+
+- **Release notes** carry a migration table: the removed form, the replacement, and the mechanical edit.
+- **The PR that removes it** names the removal in its description and updates every caller in the repository,
+  so there is always a worked example.
+- **No compiler warning.** That is the cost of having no deprecation cycle, and it is the reason to read the notes
+  for a minor upgrade rather than assuming a minor is safe.
+
+## Support window
+
+The newest minor on the current major receives fixes. Older minors do not get backports; upgrading forward is the
+supported path. When 2.0 arrives, 1.x gets security fixes for six months.
+
+## Java baseline
+
+KPipe targets Java 25 and uses virtual threads throughout. A Java baseline increase is treated as a breaking change
+and follows the same rules as an API removal.

--- a/docs/VERSIONING.md
+++ b/docs/VERSIONING.md
@@ -11,8 +11,10 @@ is deleted in the same change that migrates its callers. Patch releases never br
 **From 2.0 onward, KPipe follows strict semantic versioning.** Breaking changes land only in majors, and anything
 removed is deprecated for at least one minor first.
 
-If that first rule is unacceptable for your project, pin an exact version and upgrade deliberately. The BOM makes
-that a one-line change.
+If that first rule is unacceptable for your project, set the version deliberately rather than
+tracking latest. The BOM keeps that to one place — though note `platform(...)` contributes a
+constraint to conflict resolution rather than forcing a version, so a hard pin means
+`enforcedPlatform(...)` or explicit versions. See [MODULES.md](MODULES.md).
 
 ## Why it works this way today
 
@@ -36,7 +38,7 @@ user test code compiles against it.
 
 **SPI** — a public interface users are expected to *implement*: `MessageFormat`, `MessageSink`, `BatchSink`,
 `SchemaResolver`, `Tracer`, `ProtobufDescriptorCompiler`, `OffsetManager`, `ConsumerMetrics`,
-`ProducerMetrics`, `KPipeMetricsReporter`.
+`ProducerMetrics`, `KPipeMetricsReporter`, `KPipeConsumer.ErrorHandler`.
 Same stability rules, with one asymmetry worth knowing: adding a method to one of these is a breaking change for
 an implementer and invisible to a caller.
 
@@ -47,12 +49,18 @@ so nothing is hidden that way. `KeyOrderedDispatcher`, `ParallelDispatcher`, `Se
 `OffsetLedger`, `RecordProcessor`, `ConsumerHealthController`, `BatchPipelineWrapper` and
 `PendingOffsetSet` are all package-private and carry no guarantees.
 
-A helper shared *between* KPipe modules cannot be package-private, so it is forced public and
-exported while remaining internal. `RegistryFunctions`, `ConsoleSinkSupport`, `ConfluentEnvelope`
-and `WireDiagnostics` are those, and `KafkaOffsetManager.getPartitionState` is a test observation
-point with no production caller. None of them are user surface. The shape does not identify them —
-`Operators` and `ConsumerMetricKeys` look identical and are genuine API — so this list is the
-answer, not a pattern to apply.
+Some types are public without being surface. `ConsoleSinkSupport`, `ConfluentEnvelope` and
+`WireDiagnostics` are shared between KPipe modules and Java has no friend-module visibility, so
+they cannot be package-private. `RegistryFunctions` has no such excuse — it is used only inside
+`kpipe-core`, in the same package as its only caller, and is public for historical reasons alone.
+None of the four are user surface. The shape does not identify them — `Operators` and
+`ConsumerMetricKeys` look identical and are genuine API — so this list is the answer, not a
+pattern to apply.
+
+`KafkaOffsetManager.getPartitionState` and the `PartitionState` it returns sit outside these
+tiers: a diagnostic surface, documented in [OFFSET-INVARIANTS.md](OFFSET-INVARIANTS.md) for
+observing the commit frontier, with no production caller inside the library. Treat it as
+observability rather than API — useful for assertions and dashboards, not something to build on.
 
 Note the name is never the rule: `CircuitBreakerController` and `BackpressureController` are public
 API despite the suffix, because `Stream` methods take them as parameters.
@@ -64,14 +72,17 @@ API despite the suffix, because `Stream` methods take them as parameters.
   example. The same detail is in the commit message, sometimes as a table and otherwise as a bullet
   list.
 - **Release notes are generated from commit subjects**, so a break usually appears there as an
-  ordinary line in a `## Changes` group rather than as a migration guide. Some releases add a
+  ordinary line in a `## 🔄️ Changes` group rather than as a migration guide — or, when the subject
+  carries no conventional-commit type at all, in an unlabelled list after the grouped sections,
+  which is where the 1.19.0 registry rename landed. Some releases add a
   hand-written breaking-change section above the generated changelog — v1.17.0 did — but that is
   not automatic and should not be relied on. Follow the commit.
 - **No compiler warning.** That is the cost of having no deprecation cycle, and it is the reason to
-  read the release diff for a minor upgrade rather than assuming a minor is safe. Where a commit
-  subject carries the conventional-commit `!` marker (`refactor(consumer)!:`), that is reliable
-  evidence of a break; its absence is not evidence of safety, because the marker is not applied
-  consistently.
+  read the release diff for a minor upgrade rather than assuming a minor is safe. The conventional-commit `!`
+  marker (`refactor(consumer)!:`) is intended to mark a break, but has not been used to date and
+  nothing enforces it — there is no commit template and no message lint. Its presence would be a
+  signal; its absence is not one. Note also that this repository squash-merges, so the subject
+  reaching the release notes is the PR title rather than any commit message.
 
 ## Support window
 
@@ -80,5 +91,7 @@ exist and none have ever been cut, so upgrading forward is the only supported pa
 
 ## Java baseline
 
-KPipe targets Java 25 and uses virtual threads throughout. A Java baseline increase is treated as a breaking change
-and follows the same rules as an API removal.
+KPipe targets Java 25 and uses virtual threads throughout. The policy is that a baseline increase
+counts as a breaking change and follows the same rules as an API removal. That is intent, not
+precedent: the baseline has been 25 since before 1.0, and the only increase in project history
+shipped in a patch, pre-1.0.

--- a/docs/VERSIONING.md
+++ b/docs/VERSIONING.md
@@ -6,8 +6,7 @@ reading its commit history.
 ## The short version
 
 **Through 1.x, a minor release may remove or rename public API.** There is no deprecation cycle: an API that goes
-is deleted in the same change that migrates its callers, and the release notes carry a migration table for every
-break. Patch releases never break anything.
+is deleted in the same change that migrates its callers. Patch releases never break anything.
 
 **From 2.0 onward, KPipe follows strict semantic versioning.** Breaking changes land only in majors, and anything
 removed is deprecated for at least one minor first.
@@ -26,27 +25,44 @@ shape and wrong once people depend on it. 2.0 is where it flips.
 
 ## What counts as public API
 
-| Tier | What it covers | Stability |
-| --- | --- | --- |
-| **Public API** | `KPipe`, `Stream`, `Sink`, `Handle`, `MessageFormat`, `MessageSink`, `BatchSink`, `Result`, the `RegistryKey` / `MessageProcessorRegistry` pair, and the builders reachable from them | Covered by the rules above |
-| **SPI** | `SchemaResolver`, `Tracer`, `ProtobufDescriptorCompiler`, `OffsetManager`, `ConsumerMetrics`, `ProducerMetrics` | Same rules, but implementing one means a new abstract method is a break for you and not for a caller |
-| **Internal** | Anything package-private, anything under a package a module does not export, and every `*Dispatcher`, `*Controller` and `*Ledger` type | No guarantees. May change in any release |
+The tiers are defined by a rule rather than a list, because an enumeration goes stale the moment a type is added.
 
-A type being `public` for JPMS reasons does not make it public API — the module's `exports` clauses are the
-boundary that counts.
+**Public API** — any `public` type in an exported package that is not covered by the two rules below. Reaching it
+from the documented paths (`KPipe` → `Stream` → `Sink` → `Handle`, `KPipeConsumer.builder()`, the format and sink
+types they accept) is what makes it public, and that includes the types those signatures mention:
+`CircuitBreakerController` and `BackpressureController` are parameters to `Stream` methods, so they are public API,
+as are `BatchPolicy`, `BatchResult` and `ProcessingMode`. The published `kpipe-test` module is public API too —
+user test code compiles against it.
+
+**SPI** — a public interface users are expected to *implement*: `MessageFormat`, `MessageSink`, `BatchSink`,
+`SchemaResolver`, `Tracer`, `ProtobufDescriptorCompiler`, `OffsetManager`, `ConsumerMetrics`, `ProducerMetrics`.
+Same stability rules, with one asymmetry worth knowing: adding a method to one of these is a breaking change for
+an implementer and invisible to a caller.
+
+**Internal** — anything **package-private**, whatever package it lives in. That is the boundary that actually
+operates here: every package in every module is exported, with no qualified exports anywhere, so JPMS is not
+hiding anything. `KeyOrderedDispatcher`, `ParallelDispatcher`, `SequentialDispatcher`, `OffsetLedger`,
+`RecordProcessor`, `ConsumerHealthController`, `BatchPipelineWrapper` and `PendingOffsetSet` are all
+package-private and carry no guarantees. Note the shape of the names is not the rule — `CircuitBreakerController`
+and `BackpressureController` are public API despite the suffix.
+
+One exception exists and is called out rather than papered over: `RegistryFunctions` in `kpipe-core` is public and
+exported but is not intended as user surface. Treat it as internal.
 
 ## How a break reaches you
 
-- **Release notes** carry a migration table: the removed form, the replacement, and the mechanical edit.
-- **The PR that removes it** names the removal in its description and updates every caller in the repository,
-  so there is always a worked example.
-- **No compiler warning.** That is the cost of having no deprecation cycle, and it is the reason to read the notes
-  for a minor upgrade rather than assuming a minor is safe.
+- **The PR that removes it** carries the migration detail — the removed form, the replacement, and the mechanical
+  edit — and updates every caller in the repository, so there is always a worked example. The same table is in the
+  commit message.
+- **Release notes are generated from commit subjects**, so a break appears there as a `feat!:` or `refactor(x)!:`
+  line pointing at that commit rather than as a prose migration guide. Follow the commit for the table.
+- **No compiler warning.** That is the cost of having no deprecation cycle, and it is the reason to read the
+  release diff for a minor upgrade rather than assuming a minor is safe.
 
 ## Support window
 
-The newest minor on the current major receives fixes. Older minors do not get backports; upgrading forward is the
-supported path. When 2.0 arrives, 1.x gets security fixes for six months.
+The newest minor on the current major receives fixes. Older minors do not get backports — no maintenance branches
+exist and none have ever been cut, so upgrading forward is the only supported path.
 
 ## Java baseline
 


### PR DESCRIPTION
Closes the second item of #313, and #312's item 2 with it.

The repository had no statement of what a minor release may break. The rule existed — delete public API and migrate its callers in the same change, no deprecation cycle — but only in the project's own memory file, so an adopter could learn it from a compile error and not before. 1.19.0 alone renames the registry API, moves a package, and changes an `OffsetManager` SPI method, all in a minor.

## The decision

**Not a change of policy.** Delete-and-migrate is the right trade while the API is still finding its shape: deprecation cycles enlarge the surface every future reader has to understand, train people to ignore warnings, and the promised removal often never happens, so the deprecated form outlives its replacement.

What was missing is the *promise*. An adopter can live with "minors may break" if they are told in advance and every break ships a migration table. What they cannot plan around is not knowing.

So the document states both halves:

- **Through 1.x** — a minor may remove or rename public API, with a migration table in the release notes for every break. Patches never break.
- **From 2.0** — strict semver, breaking changes in majors only, one minor of deprecation before removal.

That keeps every freedom currently in use and turns the largest unknown for someone evaluating KPipe into a date.

## The other half: what "public API" means

Previously inferable only from `module-info`. The document fixes three tiers — public API, SPI, internal — and states the rule that matters: **a type being `public` for JPMS reasons is not an API promise; the module's `exports` clauses are the boundary.** Every `*Dispatcher`, `*Controller` and `*Ledger` is explicitly internal.

It also records what the no-deprecation policy costs users — no compiler warning — and says plainly that this is the reason to read the notes on a minor upgrade rather than assuming a minor is safe.

## Where it is linked

The README install block, where someone evaluating the library is already looking, and the documentation index. The install snippets also move from a pinned 1.18.0 to the current 1.20.0, which review caught while checking the document's claims.

The project's memory file records the same expiry, but `.claude/` is gitignored so that edit is local and not part of this diff.

## What review changed

The first draft defined the tiers by enumeration and got them wrong. `CircuitBreakerController` and `BackpressureController` are public records taken as parameters by `Stream` methods, and a name glob had filed them under "no guarantees". The boundary claim was also wrong for this repository: every package in all fourteen modules is exported with no qualified exports, so JPMS hides nothing and package-private visibility is the boundary that actually operates.

The release-notes promise was false — notes are generated from commit subjects, and one of the three most recent breaking releases carried a hand-written migration table. The document now points at the channel that exists, which is the commit message and PR description. The six-month security window is gone: no maintenance branch has ever been cut.

https://claude.ai/code/session_01HhhuubMxcupaGLPuotZQNb
