### PR TITLE
ci: absorb coverage measurement drift in the codecov project gate

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,17 @@
+coverage:
+  status:
+    # Total coverage across the repo. Codecov's default threshold is 0%, which fails a pull
+    # request on any decrease at all, including one it did not cause: the total is not stable
+    # between runs, and identical production code re-measures within a couple of tenths of a
+    # percent. At that default, a diff containing no .java file can still fail this gate. The
+    # threshold is set above the drift so a failure here means a real regression.
+    project:
+      default:
+        threshold: 0.5%
+
+    # Coverage of the lines the pull request actually changed. Held at zero tolerance: it is
+    # computed from the diff rather than from the repo total, so it carries none of the drift
+    # above, and it reports "not affected" when a pull request touches no code.
+    patch:
+      default:
+        threshold: 0%


### PR DESCRIPTION
The repo has no `codecov.yml`, so both coverage checks run at codecov's default `threshold: 0%` — the project check fails on *any* decrease in total coverage, whether or not the pull request caused it.

## The problem

Total coverage is not stable between runs. Four runs of the docs-only branch behind #315, all against the same base `5816179`, with **zero `.java` files in the diff**:

| commit | codecov/project |
| --- | --- |
| 1337a71 | 80.34% (-0.09%) |
| 1bcd69f | 80.37% (-0.06%) |
| 19a7693 | **80.53% (+0.11%)** — passed |
| 51ed665 | 80.37% (-0.06%) |

Identical production code, a span of ~0.19%, and the gate flipped green on one of the four. Across the last several merged PRs the project delta ranges from -0.09% to +0.14%, including `+0.00%` twice.

At a 0% threshold this reports a regression where no code changed. A gate that fires on noise trains readers to wave it through, which is the failure mode a coverage gate exists to prevent.

## The change

`project` threshold set to **0.5%** — roughly 2x the largest observed excursion, and well below any regression worth attention.

`patch` held at zero tolerance. It is computed from the diff rather than the repo total, so it carries none of the drift, and it already reported "Coverage not affected" for the docs-only case above. That check is the one doing real work and it stays strict.

Validated against codecov's own endpoint (`POST https://codecov.io/validate`): `Valid!`, both thresholds parsed as intended.

## What this does not do

It does not explain *why* the measurement drifts. That the total moves on unchanged code is established by the table above; the mechanism is not, and I did not want to assert one I had not verified. If the cause is timing-dependent tests leaving lines covered or uncovered run to run, that is worth finding separately — this change stops the gate lying in the meantime, it does not make the measurement deterministic.
