### PR TITLE
perf(schema-registry): pin the cardinality check to the cache-miss path

### DIFF
--- a/lib/kpipe-schema-registry-confluent/src/main/java/io/github/eschizoid/kpipe/schemaregistry/confluent/CachedSchemaResolver.java
+++ b/lib/kpipe-schema-registry-confluent/src/main/java/io/github/eschizoid/kpipe/schemaregistry/confluent/CachedSchemaResolver.java
@@ -57,6 +57,7 @@ public final class CachedSchemaResolver implements SchemaResolver, AutoCloseable
   private final AtomicLong hits = new AtomicLong();
   private final AtomicLong misses = new AtomicLong();
   private final AtomicBoolean sizeWarningEmitted = new AtomicBoolean();
+  private final AtomicLong unboundedChecks = new AtomicLong();
 
   /// Wraps `delegate` with an unbounded by-ID cache.
   ///
@@ -86,6 +87,7 @@ public final class CachedSchemaResolver implements SchemaResolver, AutoCloseable
   /// record. Schema IDs are immutable, so nothing here is a correctness problem — the entries
   /// stay valid — but the memory is held for the life of the process.
   private void warnOnceIfCacheLooksUnbounded() {
+    unboundedChecks.incrementAndGet();
     // Flag first: after this has fired, size() would be recomputed on every miss for the life
     // of the process — and the unbounded growth it flags is exactly when misses are endless
     // and the map is largest.
@@ -97,12 +99,31 @@ public final class CachedSchemaResolver implements SchemaResolver, AutoCloseable
     }
     LOGGER.log(
       Level.WARNING,
-      "Schema cache holds more than {0} distinct IDs. This cache never evicts, which assumes a "
-        + "topic registers tens of schemas over its lifetime; a producer registering per deploy "
-        + "breaks that and the entries are held for the life of the process. Wrap this resolver "
-        + "with your own bounded cache if the count keeps climbing. Logged once per resolver.",
+      "Schema cache holds more than {0} distinct IDs. This cache never evicts, which assumes a " +
+        "topic registers tens of schemas over its lifetime; a producer registering per deploy " +
+        "breaks that and the entries are held for the life of the process. Wrap this resolver " +
+        "with your own bounded cache if the count keeps climbing. Logged once per resolver.",
       UNEXPECTED_SIZE
     );
+  }
+
+  /// Returns how many times the cardinality check has been evaluated, for tests that pin it to
+  /// the miss path.
+  ///
+  /// [ConcurrentHashMap#size] sums the map's counter cells rather than reading a field, so
+  /// evaluating it per lookup costs real time on a warm cache — the steady state this resolver
+  /// exists to produce, where nearly every lookup is a hit. Keeping the check behind the hit-path
+  /// early return is therefore a performance property with no behavioural shadow: evaluating it
+  /// on hits as well leaves the warning firing once, at the same point, with every other
+  /// assertion about this class still passing. This counter is the only thing that tells those
+  /// two arrangements apart.
+  ///
+  /// It counts calls to the check, so it catches the check being added to the hit path. It would
+  /// not catch a bare `cache.size()` inlined there instead.
+  ///
+  /// @return cumulative count of cardinality-check evaluations
+  long unboundedCheckCount() {
+    return unboundedChecks.get();
   }
 
   /// Returns the number of cache hits since this resolver was constructed.

--- a/lib/kpipe-schema-registry-confluent/src/test/java/io/github/eschizoid/kpipe/schemaregistry/confluent/CachedSchemaResolverSizeWarningTest.java
+++ b/lib/kpipe-schema-registry-confluent/src/test/java/io/github/eschizoid/kpipe/schemaregistry/confluent/CachedSchemaResolverSizeWarningTest.java
@@ -4,6 +4,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import io.github.eschizoid.kpipe.registry.SchemaResolver;
+import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -26,7 +27,7 @@ class CachedSchemaResolverSizeWarningTest {
   ///
   /// @param body what to run while capturing
   /// @return the warnings emitted
-  private static java.util.List<LogRecord> captureWarnings(final Runnable body) {
+  private static List<LogRecord> captureWarnings(final Runnable body) {
     final var julLogger = Logger.getLogger(CachedSchemaResolver.class.getName());
     final var captured = new CopyOnWriteArrayList<LogRecord>();
     final var handler = new Handler() {
@@ -69,8 +70,8 @@ class CachedSchemaResolverSizeWarningTest {
     assertEquals(
       1,
       warnings.size(),
-      "sustained growth must log once, not once per record — a stuck producer would otherwise "
-        + "flood the log at poll rate"
+      "sustained growth must log once, not once per record — a stuck producer would otherwise " +
+        "flood the log at poll rate"
     );
     final var message = warnings.getFirst().getMessage();
     assertTrue(message.contains("never evicts"), "the warning should name the design property that was outgrown");
@@ -102,18 +103,20 @@ class CachedSchemaResolverSizeWarningTest {
     final var warnings = captureWarnings(() -> {
       for (var t = 0; t < 16; t++) {
         final var offset = t * 1_000;
-        Thread.ofPlatform().daemon().start(() -> {
-          try {
-            start.await();
-            for (var i = 0; i < 1_000; i++) {
-              resolver.lookupById(offset + i);
+        Thread.ofPlatform()
+          .daemon()
+          .start(() -> {
+            try {
+              start.await();
+              for (var i = 0; i < 1_000; i++) {
+                resolver.lookupById(offset + i);
+              }
+            } catch (final InterruptedException e) {
+              Thread.currentThread().interrupt();
+            } finally {
+              done.countDown();
             }
-          } catch (final InterruptedException e) {
-            Thread.currentThread().interrupt();
-          } finally {
-            done.countDown();
-          }
-        });
+          });
       }
       start.countDown();
       try {
@@ -174,5 +177,36 @@ class CachedSchemaResolverSizeWarningTest {
       }
     });
     assertEquals(1, pastThreshold.size(), "one id past the threshold must warn");
+  }
+
+  /// Pins the cardinality check to the miss path.
+  ///
+  /// [ConcurrentHashMap#size] sums the map's counter cells rather than reading a field, so
+  /// evaluating it per lookup costs real time on a warm cache — which is the steady state this
+  /// resolver exists to produce.
+  ///
+  /// Adding the check to the hit path while leaving the miss path untouched changes nothing else
+  /// observable: the warning still fires exactly once, at the same cardinality, and every other
+  /// test in this class still passes. This assertion is the only one that fails. Moving the call
+  /// to the top of `lookupById` instead also trips `theThresholdIsExactlyOneThousand`, because
+  /// the check then runs before the entry is inserted and the boundary shifts by one.
+  @Test
+  void theCardinalityCheckStaysOffTheCacheHitPath() {
+    try (final var resolver = new CachedSchemaResolver(id -> "s" + id)) {
+      resolver.lookupById(7);
+      assertEquals(1, resolver.unboundedCheckCount(), "the miss that populated the entry evaluates the check once");
+
+      for (var i = 0; i < 10_000; i++) {
+        resolver.lookupById(7);
+      }
+
+      assertEquals(10_000, resolver.hitCount(), "every lookup after the first should be served from cache");
+      assertEquals(
+        1,
+        resolver.unboundedCheckCount(),
+        "ten thousand cache hits must not evaluate the cardinality check — it belongs behind the " +
+          "hit-path early return, where a warm cache never pays for it"
+      );
+    }
   }
 }


### PR DESCRIPTION
Follow-up to #314. That PR added a one-shot WARNING when the schema cache outgrows its no-eviction assumption. This one stops the check drifting onto the hot path.

## The gap

`warnOnceIfCacheLooksUnbounded()` calls `ConcurrentHashMap.size()`, which sums the map's counter cells rather than reading a field. It sits *after* the cache-hit early return, so a warm cache — the steady state this resolver exists to produce, where nearly every lookup is a hit — never pays for it.

Nothing enforced that placement. The regression has no behavioural shadow, so the suite could not see it.

## Verified by mutation

| mutant | result |
| --- | --- |
| Check **added** to the hit path, miss path untouched | Warning still fires exactly once at the same cardinality; hit/miss counters still agree; **all five existing tests pass**. Only the new assertion fails. |
| Check **moved** to the top of `lookupById` | New assertion fails, and so does `theThresholdIsExactlyOneThousand` — the check then runs before insertion, so the boundary shifts by one. |

The first row is the one that matters: it is a pure cost with zero observable change, and before this PR nothing in the repo could tell it from the correct arrangement.

## The change

A package-private `unboundedCheckCount()` on the resolver, and `theCardinalityCheckStaysOffTheCacheHitPath` asserting that ten thousand hits after one miss evaluate the check exactly once. Package-private rather than public because every package in this repo is exported, so package-private is the real internal boundary — this is a test seam, not API.

The counter is an `AtomicLong` incremented only where the check already runs, which is the miss path, behind an HTTP call. It costs nothing a miss was not already paying.

## Scope

It counts calls to the check, so it catches the check being added to the hit path. It would not catch someone inlining a bare `cache.size()` there instead — stated in the accessor's javadoc rather than left for a reader to discover.

Also removes a fully-qualified `java.util.List` from the test file, which the project's coding standards disallow and which I introduced in #314.
