### PR TITLE
docs: track the CLAUDE.md pointer and drop the stale section refs

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/.gitignore
+++ b/.gitignore
@@ -235,7 +235,12 @@ gradle-app.setting
 .junie
 
 ### Claude ###
-.claude
+# Contents ignored, except the agent-instructions pointer: it is a single @AGENTS.md line,
+# so the instructions themselves live in one reviewable file at the repo root. Written as
+# `.claude/*` rather than `.claude` because git will not descend into an excluded directory,
+# and an un-ignore rule for a file inside one never matches.
+.claude/*
+!.claude/CLAUDE.md
 
 ### Toke Savior ###
 .token-savior-cache.json

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -121,11 +121,12 @@ a consumer only pulls the format it actually uses (§19).
 
 ## §10 OpenTelemetry metrics
 
-`kpipe-metrics` has no telemetry dependency at all — its `build.gradle.kts` declares none and its `module-info`
-has no `requires` clause, so it is interfaces plus a no-op default and nothing else. `opentelemetry-api` enters only
-via `kpipe-metrics-otel`, which users add alongside their own SDK (Prometheus, OTLP, Jaeger). `ConsumerMetrics` /
-`ProducerMetrics` default to `ConsumerMetrics.noop()` / `ProducerMetrics.noop()` (zero cost when not configured) and
-wire via `.withMetrics(...)`.
+`kpipe-metrics` carries no telemetry dependency — `build.gradle.kts` declares nothing beyond test libraries and
+`module-info` has no `requires` clause at all, so it is interfaces plus a no-op default and nothing else. On the
+metrics side `opentelemetry-api` arrives only with `kpipe-metrics-otel`, which declares it `api` and `requires
+transitive` it — so adding that module brings the API along and the user supplies just an SDK (Prometheus, OTLP,
+Jaeger). Tracing has its own at `kpipe-tracing-otel`. `ConsumerMetrics` / `ProducerMetrics` default to
+`ConsumerMetrics.noop()` / `ProducerMetrics.noop()` (zero cost when not configured) and wire via `.withMetrics(...)`.
 
 | Component         | Instrument                                     | Type      |
 | ----------------- | ---------------------------------------------- | --------- |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -121,9 +121,11 @@ a consumer only pulls the format it actually uses (§19).
 
 ## §10 OpenTelemetry metrics
 
-`kpipe-metrics` ships interfaces against `opentelemetry-api` only — no SDK. Users bring their own SDK (Prometheus, OTLP,
-Jaeger). Both `ConsumerMetrics` / `ProducerMetrics` default to `OpenTelemetry.noop()` (zero cost when not configured)
-and wire via `.withMetrics(...)`.
+`kpipe-metrics` has no telemetry dependency at all — its `build.gradle.kts` declares none and its `module-info`
+has no `requires` clause, so it is interfaces plus a no-op default and nothing else. `opentelemetry-api` enters only
+via `kpipe-metrics-otel`, which users add alongside their own SDK (Prometheus, OTLP, Jaeger). `ConsumerMetrics` /
+`ProducerMetrics` default to `ConsumerMetrics.noop()` / `ProducerMetrics.noop()` (zero cost when not configured) and
+wire via `.withMetrics(...)`.
 
 | Component         | Instrument                                     | Type      |
 | ----------------- | ---------------------------------------------- | --------- |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -123,9 +123,9 @@ a consumer only pulls the format it actually uses (§19).
 
 `kpipe-metrics` carries no telemetry dependency — `build.gradle.kts` declares nothing beyond test libraries and
 `module-info` has no `requires` clause at all, so it is interfaces plus a no-op default and nothing else. On the
-metrics side `opentelemetry-api` arrives only with `kpipe-metrics-otel`, which declares it `api` and `requires
-transitive` it — so adding that module brings the API along and the user supplies just an SDK (Prometheus, OTLP,
-Jaeger). Tracing has its own at `kpipe-tracing-otel`. `ConsumerMetrics` / `ProducerMetrics` default to
+metrics side `opentelemetry-api` arrives only with `kpipe-metrics-otel`, which brings the API along, so the user
+adds just an SDK (`opentelemetry-sdk`) and an exporter (Prometheus, OTLP, Jaeger). Tracing has its own at
+`kpipe-tracing-otel`. `ConsumerMetrics` / `ProducerMetrics` default to
 `ConsumerMetrics.noop()` / `ProducerMetrics.noop()` (zero cost when not configured) and wire via `.withMetrics(...)`.
 
 | Component         | Instrument                                     | Type      |

--- a/lib/kpipe-consumer/src/main/java/io/github/eschizoid/kpipe/consumer/KeyOrderedDispatcher.java
+++ b/lib/kpipe-consumer/src/main/java/io/github/eschizoid/kpipe/consumer/KeyOrderedDispatcher.java
@@ -274,10 +274,11 @@ final class KeyOrderedDispatcher implements Dispatcher {
       try {
         // A 1ms sleep, not Thread.yield, so sustained saturation doesn't peg a CPU core on the
         // consumer thread. Worst-case latency is one sleep tick after a queue drains. Whatever
-        // this becomes it must stay bounded: an indefinite wait here strands the consumer with
-        // its group membership, which is what keeping the paused loop polling exists to prevent.
-        // Making it event-driven — a draining worker unparking this thread instead of a 1ms
-        // poll — is a legitimate optimization, but it needs a park, and the dispatcher tests
+        // this becomes it must stay bounded: an indefinite wait here stops the consumer returning
+        // to poll(), so the broker evicts it from the group after max.poll.interval.ms — the same
+        // failure that keeping the paused loop polling exists to prevent. Making it event-driven
+        // — a draining worker unparking this thread instead of a 1ms sleep tick — is a
+        // legitimate optimization, but it needs a park, and the dispatcher tests
         // assert that drainInFlightBeforeTeardown is the only wait a record-completion unpark
         // can shorten. Update that claim in the same change.
         //noinspection BusyWait — intentional bounded backpressure sleep, not a spin

--- a/lib/kpipe-consumer/src/main/java/io/github/eschizoid/kpipe/consumer/KeyOrderedDispatcher.java
+++ b/lib/kpipe-consumer/src/main/java/io/github/eschizoid/kpipe/consumer/KeyOrderedDispatcher.java
@@ -272,9 +272,12 @@ final class KeyOrderedDispatcher implements Dispatcher {
         );
       }
       try {
-        // 1ms park, not Thread.yield, so sustained saturation doesn't peg a CPU core on
-        // the consumer thread. Worst-case latency is one sleep tick after a queue drains.
-        //noinspection BusyWait — intentional bounded backpressure park, not a spin
+        // A 1ms sleep, not Thread.yield, so sustained saturation doesn't peg a CPU core on the
+        // consumer thread. Worst-case latency is one sleep tick after a queue drains. Sleep
+        // rather than LockSupport.parkNanos deliberately: this runs on the consumer thread, and
+        // a sleeping thread ignores the unpark that record completions deliver, so it cannot
+        // absorb one meant for the teardown drain.
+        //noinspection BusyWait — intentional bounded backpressure sleep, not a spin
         Thread.sleep(1);
       } catch (final InterruptedException e) {
         Thread.currentThread().interrupt();
@@ -331,14 +334,14 @@ final class KeyOrderedDispatcher implements Dispatcher {
     }
     if (probe.getState() != Thread.State.NEW) {
       throw new IllegalArgumentException(
-        "workerFactory must return unstarted threads; the daemon probe would otherwise run work and the "
-          + "dispatcher would not own the thread's lifecycle"
+        "workerFactory must return unstarted threads; the daemon probe would otherwise run work and the " +
+          "dispatcher would not own the thread's lifecycle"
       );
     }
     if (!probe.isDaemon()) {
       throw new IllegalArgumentException(
-        "workerFactory must produce daemon threads: close() interrupts workers that outlast the drain wait, "
-          + "and a task that ignores interruption would keep the JVM alive"
+        "workerFactory must produce daemon threads: close() interrupts workers that outlast the drain wait, " +
+          "and a task that ignores interruption would keep the JVM alive"
       );
     }
     return r -> {
@@ -348,8 +351,8 @@ final class KeyOrderedDispatcher implements Dispatcher {
       }
       if (t.getState() != Thread.State.NEW || !t.isDaemon()) {
         throw new IllegalStateException(
-          "workerFactory returned a thread that is already started or not a daemon; the dispatcher owns "
-            + "the thread's lifecycle and relies on daemon status to let the JVM exit"
+          "workerFactory returned a thread that is already started or not a daemon; the dispatcher owns " +
+            "the thread's lifecycle and relies on daemon status to let the JVM exit"
         );
       }
       return t;
@@ -379,13 +382,15 @@ final class KeyOrderedDispatcher implements Dispatcher {
   }
 
   private void startWorker(final Object key, final KeyQueue queue) {
-    final var worker = requireThread(workerFactory.newThread(() -> {
+    final var worker = requireThread(
+      workerFactory.newThread(() -> {
         try {
           drain(queue);
         } finally {
           activeWorkers.remove(Thread.currentThread());
         }
-      }));
+      })
+    );
     worker.setName("kpipe-key-worker-" + System.identityHashCode(key));
     activeWorkers.add(worker);
     try {

--- a/lib/kpipe-consumer/src/main/java/io/github/eschizoid/kpipe/consumer/KeyOrderedDispatcher.java
+++ b/lib/kpipe-consumer/src/main/java/io/github/eschizoid/kpipe/consumer/KeyOrderedDispatcher.java
@@ -273,10 +273,13 @@ final class KeyOrderedDispatcher implements Dispatcher {
       }
       try {
         // A 1ms sleep, not Thread.yield, so sustained saturation doesn't peg a CPU core on the
-        // consumer thread. Worst-case latency is one sleep tick after a queue drains. Sleep
-        // rather than LockSupport.parkNanos deliberately: this runs on the consumer thread, and
-        // a sleeping thread ignores the unpark that record completions deliver, so it cannot
-        // absorb one meant for the teardown drain.
+        // consumer thread. Worst-case latency is one sleep tick after a queue drains. Whatever
+        // this becomes it must stay bounded: an indefinite wait here strands the consumer with
+        // its group membership, which is what keeping the paused loop polling exists to prevent.
+        // Making it event-driven — a draining worker unparking this thread instead of a 1ms
+        // poll — is a legitimate optimization, but it needs a park, and the dispatcher tests
+        // assert that drainInFlightBeforeTeardown is the only wait a record-completion unpark
+        // can shorten. Update that claim in the same change.
         //noinspection BusyWait — intentional bounded backpressure sleep, not a spin
         Thread.sleep(1);
       } catch (final InterruptedException e) {

--- a/lib/kpipe-consumer/src/test/java/io/github/eschizoid/kpipe/consumer/ConsumerHealthControllerTest.java
+++ b/lib/kpipe-consumer/src/test/java/io/github/eschizoid/kpipe/consumer/ConsumerHealthControllerTest.java
@@ -294,8 +294,8 @@ class ConsumerHealthControllerTest {
     // guard's outcome — it does not itself park a thread); in a real consumer the paused loop
     // keeps polling and re-ticks, so without the guard the miss costs fetch-nothing poll cycles
     // rather than stranding the consumer. With the guard the Pause and Resume commands are
-    // queued inside the same tick and cancel when flushed, so the Kafka-level pause never takes
-    // effect and no cycle is lost at all.
+    // queued inside the same tick and flush back-to-back in one processCommands() drain, so no
+    // poll ever runs while paused and no cycle is lost.
     hook.backpressurePauseAction = () -> inflight.set(0);
 
     health.tickBackpressure(consumer);

--- a/lib/kpipe-consumer/src/test/java/io/github/eschizoid/kpipe/consumer/ConsumerHealthControllerTest.java
+++ b/lib/kpipe-consumer/src/test/java/io/github/eschizoid/kpipe/consumer/ConsumerHealthControllerTest.java
@@ -292,8 +292,10 @@ class ConsumerHealthControllerTest {
     // was set, so none of them unparks the consumer thread. Without the post-pause re-check the
     // controller stays paused and the isPaused assertion below fails fast (this test asserts the
     // guard's outcome — it does not itself park a thread); in a real consumer the paused loop
-    // keeps polling and re-ticks, so without the guard the miss costs a poll cycle rather than
-    // stranding the consumer. The guard removes even that.
+    // keeps polling and re-ticks, so without the guard the miss costs fetch-nothing poll cycles
+    // rather than stranding the consumer. With the guard the Pause and Resume commands are
+    // queued inside the same tick and cancel when flushed, so the Kafka-level pause never takes
+    // effect and no cycle is lost at all.
     hook.backpressurePauseAction = () -> inflight.set(0);
 
     health.tickBackpressure(consumer);

--- a/lib/kpipe-consumer/src/test/java/io/github/eschizoid/kpipe/consumer/ConsumerHealthControllerTest.java
+++ b/lib/kpipe-consumer/src/test/java/io/github/eschizoid/kpipe/consumer/ConsumerHealthControllerTest.java
@@ -82,18 +82,12 @@ class ConsumerHealthControllerTest {
 
   @Test
   void pauseHookRejectedAsNull() {
-    assertThrows(
-      IllegalArgumentException.class,
-      () -> new ConsumerHealthController(null, null, scheduler, null, hook)
-    );
+    assertThrows(IllegalArgumentException.class, () -> new ConsumerHealthController(null, null, scheduler, null, hook));
   }
 
   @Test
   void metricsObserverRejectedAsNull() {
-    assertThrows(
-      IllegalArgumentException.class,
-      () -> new ConsumerHealthController(null, null, scheduler, hook, null)
-    );
+    assertThrows(IllegalArgumentException.class, () -> new ConsumerHealthController(null, null, scheduler, hook, null));
   }
 
   // ─────────────────────────── Circuit breaker ──────────────────────────────
@@ -214,7 +208,8 @@ class ConsumerHealthControllerTest {
 
   @Test
   void pauseArbitrationIsTestableWithoutAMetricsFake() {
-    // The payoff of splitting the old 7-method Hook into PauseLifecycleHook + HealthMetricsObserver:
+    // The payoff of splitting the old 7-method Hook into PauseLifecycleHook +
+    // HealthMetricsObserver:
     // a test that cares only about pause arbitration supplies a focused 2-method PauseLifecycleHook
     // recorder and the shared no-op HealthMetricsObserver — two DISTINCT adapters, wired
     // independently, with no obligation to stub the five metric callbacks.
@@ -234,8 +229,13 @@ class ConsumerHealthControllerTest {
 
     final var inflight = new AtomicInteger(0);
     final var bp = new BackpressureController(10, 3, BackpressureController.inFlightStrategy(inflight::get));
-    final var health =
-      new ConsumerHealthController(bp, null, scheduler, pauseOnly, ConsumerHealthController.HealthMetricsObserver.NOOP);
+    final var health = new ConsumerHealthController(
+      bp,
+      null,
+      scheduler,
+      pauseOnly,
+      ConsumerHealthController.HealthMetricsObserver.NOOP
+    );
     final var consumer = new MockConsumer<byte[], byte[]>("earliest");
 
     inflight.set(15);
@@ -291,8 +291,9 @@ class ConsumerHealthControllerTest {
     // becoming visible: those completions all read the pause mask before the BACKPRESSURE bit
     // was set, so none of them unparks the consumer thread. Without the post-pause re-check the
     // controller stays paused and the isPaused assertion below fails fast (this test asserts the
-    // guard's outcome — it does not itself park a thread); in a real consumer that state is a
-    // parked consumer thread with no remaining wake-up source.
+    // guard's outcome — it does not itself park a thread); in a real consumer the paused loop
+    // keeps polling and re-ticks, so without the guard the miss costs a poll cycle rather than
+    // stranding the consumer. The guard removes even that.
     hook.backpressurePauseAction = () -> inflight.set(0);
 
     health.tickBackpressure(consumer);
@@ -361,7 +362,8 @@ class ConsumerHealthControllerTest {
   }
 
   private static final class RecordingHook
-    implements ConsumerHealthController.PauseLifecycleHook, ConsumerHealthController.HealthMetricsObserver {
+    implements ConsumerHealthController.PauseLifecycleHook, ConsumerHealthController.HealthMetricsObserver
+  {
 
     int pauseCalls;
     int resumeCalls;

--- a/lib/kpipe-consumer/src/test/java/io/github/eschizoid/kpipe/consumer/ParallelDispatcherRaceTest.java
+++ b/lib/kpipe-consumer/src/test/java/io/github/eschizoid/kpipe/consumer/ParallelDispatcherRaceTest.java
@@ -19,13 +19,16 @@ import org.junit.jupiter.api.Test;
 /// strategy reads through `KPipeConsumer.backpressureLoad()`. The counter is the single source
 /// of truth for the high/low watermark, so a leaked or double-counted in-flight on the throw
 /// path translates directly into either pause-forever (the watermark latches high and the
-/// consumer parks indefinitely) or pause-never (the count underflows and backpressure stops
-/// engaging).
+/// consumer stays paused, fetching nothing) or pause-never (the count underflows and
+/// backpressure stops engaging).
 ///
-/// The consumer also relies on the `onComplete` callback firing after every record — that
-/// callback is what unparks the consumer thread when it parked under backpressure. If a
-/// throwing record swallowed its `onComplete`, a parked consumer thread would never be woken
-/// and the pipeline would stall on the first failure.
+/// The consumer also relies on the `onComplete` callback firing after every record. In the real
+/// consumer that callback only unparks the consumer thread while backpressure holds it, which
+/// shortens the bounded wait in `drainInFlightBeforeTeardown` and nothing else — a paused
+/// consumer keeps polling and re-evaluates backpressure every iteration, so a missed callback
+/// costs no resume latency. Exactly-once is still the dispatcher's contract, and
+/// `onCompleteOnThrowReleasesAParkedWaiter` parks a stand-in thread to make a missed callback
+/// observable at all, which it is not from the consumer's own behaviour.
 ///
 /// These tests drive [ParallelDispatcher] directly (it is package-private) so the throw paths
 /// are deterministic and don't depend on a running Kafka consumer loop. They focus on what
@@ -48,10 +51,11 @@ class ParallelDispatcherRaceTest {
 
   @Test
   void onCompleteOnThrowReleasesAParkedWaiter() throws InterruptedException {
-    // Mirrors the consumer-thread interaction: the consumer parks under backpressure and the
-    // dispatcher's onComplete callback is the unpark source. Here a real thread parks and the
-    // throw-path onComplete must unpark it. If onComplete were skipped when the task threw,
-    // the waiter would stay parked until the test's 3s join timeout and fail.
+    // The dispatcher's onComplete callback is the consumer's unpark source. The real consumer is
+    // not parked while running, so a missed callback is invisible from its behaviour; this parks
+    // a stand-in thread instead, which makes the throw-path callback observable. If onComplete
+    // were skipped when the task threw, the waiter would stay parked until the test's 3s join
+    // timeout and fail.
     final var rejectCount = new AtomicInteger(0);
     final var dispatcher = newDispatcher(rejectCount);
     final var waiterParked = new CountDownLatch(1);

--- a/lib/kpipe-consumer/src/test/java/io/github/eschizoid/kpipe/consumer/ParallelDispatcherTest.java
+++ b/lib/kpipe-consumer/src/test/java/io/github/eschizoid/kpipe/consumer/ParallelDispatcherTest.java
@@ -165,13 +165,13 @@ class ParallelDispatcherTest {
 
   @Test
   void drainableCountDecrementedWhenTaskThrows() throws InterruptedException {
-    // Guards the criticality-9 race in §20: ParallelDispatcher owns the in-flight counter that
-    // drives PARALLEL-mode backpressure (§5). If the task body throws and the finally block did
-    // NOT decrement, drainableCount() would climb monotonically per failed record — the watermark
-    // would latch at HIGH and the consumer would pause forever (deadlock). Conversely, double
-    // decrement would underflow toward negative and the consumer would never pause (false-
-    // negative backpressure). The production code wraps processTask.run() in try/finally so
-    // interrupt-style and exception-style exits both decrement exactly once; this test pins it.
+    // ParallelDispatcher owns the in-flight counter that drives PARALLEL-mode backpressure. If
+    // the task body throws and the finally block did NOT decrement, drainableCount() would climb
+    // monotonically per failed record — the watermark would latch at HIGH and the consumer would
+    // pause forever. Conversely, double decrement would underflow toward negative and the
+    // consumer would never pause (false-negative backpressure). The production code wraps
+    // processTask.run() in try/finally so interrupt-style and exception-style exits both
+    // decrement exactly once; this test pins it.
     final var rejectCount = new AtomicInteger(0);
     final var dispatcher = newDispatcher(rejectCount);
     final var completed = new CountDownLatch(1);
@@ -220,11 +220,13 @@ class ParallelDispatcherTest {
   @Test
   void onCompleteFiresExactlyOnceWhenTaskThrows() throws InterruptedException {
     // Pair test for drainableCountDecrementedWhenTaskThrows: the consumer's afterRecordComplete()
-    // unparks the consumer thread when backpressure is held (§11 LockSupport park/unpark). If
-    // onComplete fired twice on the throw path (e.g. once in a catch and once in finally), the
-    // consumer would re-evaluate twice per failed record — wasteful but tolerable. If it fired
-    // ZERO times, the consumer would never wake and the pipeline would stall on the first
-    // exception. Exactly-once is the contract.
+    // unparks the consumer thread while backpressure is holding it. That unpark is a latency
+    // nudge, not a liveness requirement — a paused consumer keeps polling on its pollTimeout
+    // cadence and re-evaluates backpressure at the top of every iteration, so a missed call costs
+    // at most one poll interval of resume delay and a doubled call costs one redundant
+    // re-evaluation. Exactly-once is still the dispatcher's contract, and it is worth pinning
+    // precisely because both failure shapes are silent: neither changes an observable outcome,
+    // only timing.
     final var rejectCount = new AtomicInteger(0);
     final var dispatcher = newDispatcher(rejectCount);
     final var completeCount = new AtomicInteger(0);

--- a/lib/kpipe-consumer/src/test/java/io/github/eschizoid/kpipe/consumer/ParallelDispatcherTest.java
+++ b/lib/kpipe-consumer/src/test/java/io/github/eschizoid/kpipe/consumer/ParallelDispatcherTest.java
@@ -219,14 +219,14 @@ class ParallelDispatcherTest {
 
   @Test
   void onCompleteFiresExactlyOnceWhenTaskThrows() throws InterruptedException {
-    // Pair test for drainableCountDecrementedWhenTaskThrows: the consumer's afterRecordComplete()
-    // unparks the consumer thread while backpressure is holding it. That unpark is a latency
-    // nudge, not a liveness requirement — a paused consumer keeps polling on its pollTimeout
-    // cadence and re-evaluates backpressure at the top of every iteration, so a missed call costs
-    // at most one poll interval of resume delay and a doubled call costs one redundant
-    // re-evaluation. Exactly-once is still the dispatcher's contract, and it is worth pinning
-    // precisely because both failure shapes are silent: neither changes an observable outcome,
-    // only timing.
+    // Pair test for drainableCountDecrementedWhenTaskThrows: the dispatcher decrements the
+    // in-flight counter and only then runs onComplete, inside its own try/catch, so the counter
+    // that drives backpressure is unaffected by this callback going missing, doubling, or
+    // throwing. What onComplete does is unpark the consumer thread while backpressure holds it,
+    // and that shortens nothing on the resume path — the consumer is inside poll(), which unpark
+    // does not interrupt. The only wait it can shorten is the bounded park in
+    // drainInFlightBeforeTeardown. Exactly-once is still the dispatcher's contract, and it is
+    // worth pinning precisely because neither failure shape would change an observable outcome.
     final var rejectCount = new AtomicInteger(0);
     final var dispatcher = newDispatcher(rejectCount);
     final var completeCount = new AtomicInteger(0);

--- a/lib/kpipe-consumer/src/test/java/io/github/eschizoid/kpipe/consumer/ParallelDispatcherTest.java
+++ b/lib/kpipe-consumer/src/test/java/io/github/eschizoid/kpipe/consumer/ParallelDispatcherTest.java
@@ -223,9 +223,10 @@ class ParallelDispatcherTest {
     // in-flight counter and only then runs onComplete, inside its own try/catch, so the counter
     // that drives backpressure is unaffected by this callback going missing, doubling, or
     // throwing. What onComplete does is unpark the consumer thread while backpressure holds it,
-    // and that shortens nothing on the resume path: the consumer thread is never parked there —
-    // it is inside poll(), running, or in a Thread.sleep, none of which unpark shortens. The only
-    // wait it can shorten is the bounded park in drainInFlightBeforeTeardown. Exactly-once is the
+    // and that shortens nothing on the resume path: the consumer thread is never parked there in
+    // a wait an unpark could shorten — it is inside Kafka I/O, running, sleeping, or in an AQS
+    // wait that re-checks and re-parks. The only wait the unpark can shorten is the bounded park
+    // in drainInFlightBeforeTeardown. Exactly-once is the
     // dispatcher's contract, and it is worth pinning precisely because neither failure shape
     // changes anything production-observable: no counter, log, or delivered record differs.
     // ParallelDispatcherRaceTest parks a stand-in thread to make the callback observable at all.

--- a/lib/kpipe-consumer/src/test/java/io/github/eschizoid/kpipe/consumer/ParallelDispatcherTest.java
+++ b/lib/kpipe-consumer/src/test/java/io/github/eschizoid/kpipe/consumer/ParallelDispatcherTest.java
@@ -223,10 +223,12 @@ class ParallelDispatcherTest {
     // in-flight counter and only then runs onComplete, inside its own try/catch, so the counter
     // that drives backpressure is unaffected by this callback going missing, doubling, or
     // throwing. What onComplete does is unpark the consumer thread while backpressure holds it,
-    // and that shortens nothing on the resume path — the consumer is inside poll(), which unpark
-    // does not interrupt. The only wait it can shorten is the bounded park in
-    // drainInFlightBeforeTeardown. Exactly-once is still the dispatcher's contract, and it is
-    // worth pinning precisely because neither failure shape would change an observable outcome.
+    // and that shortens nothing on the resume path: the consumer thread is never parked there —
+    // it is inside poll(), running, or in a Thread.sleep, none of which unpark shortens. The only
+    // wait it can shorten is the bounded park in drainInFlightBeforeTeardown. Exactly-once is the
+    // dispatcher's contract, and it is worth pinning precisely because neither failure shape
+    // changes anything production-observable: no counter, log, or delivered record differs.
+    // ParallelDispatcherRaceTest parks a stand-in thread to make the callback observable at all.
     final var rejectCount = new AtomicInteger(0);
     final var dispatcher = newDispatcher(rejectCount);
     final var completeCount = new AtomicInteger(0);

--- a/lib/kpipe-producer/src/main/java/io/github/eschizoid/kpipe/producer/KPipeProducer.java
+++ b/lib/kpipe-producer/src/main/java/io/github/eschizoid/kpipe/producer/KPipeProducer.java
@@ -98,11 +98,12 @@ public class KPipeProducer<K, V> implements AutoCloseable {
       return this;
     }
 
-    /// Sets the [ProducerMetrics] for this producer. The SPI carries no telemetry dependency at
-    /// all — `kpipe-metrics` is interfaces plus a no-op default — so a caller wanting
-    /// OpenTelemetry supplies both the API and an SDK: use
-    /// `io.github.eschizoid.kpipe.metrics.otel.OtelProducerMetrics` from `kpipe-metrics-otel`,
-    /// or [ProducerMetrics#noop()] for the no-op default.
+    /// Sets the [ProducerMetrics] for this producer. The SPI carries no telemetry
+    /// dependency — `kpipe-metrics` is interfaces plus a no-op default — so OpenTelemetry
+    /// is opt-in: add `kpipe-metrics-otel`, which brings `opentelemetry-api` with it, and
+    /// supply your own SDK. Then pass
+    /// `io.github.eschizoid.kpipe.metrics.otel.OtelProducerMetrics`, or
+    /// [ProducerMetrics#noop()] for the no-op default.
     ///
     /// @param metrics the producer metrics
     /// @return this builder instance for method chaining

--- a/lib/kpipe-producer/src/main/java/io/github/eschizoid/kpipe/producer/KPipeProducer.java
+++ b/lib/kpipe-producer/src/main/java/io/github/eschizoid/kpipe/producer/KPipeProducer.java
@@ -98,11 +98,11 @@ public class KPipeProducer<K, V> implements AutoCloseable {
       return this;
     }
 
-    /// Sets the [ProducerMetrics] for this producer. The SPI is vendor-neutral — it builds against
-    /// the OpenTelemetry API with no SDK, so callers supply their own: use
-    /// `io.github.eschizoid.kpipe.metrics.otel.OtelProducerMetrics` from
-    /// `kpipe-metrics-otel` for an OpenTelemetry-backed instance, or [ProducerMetrics#noop()] for a
-    /// no-op default.
+    /// Sets the [ProducerMetrics] for this producer. The SPI carries no telemetry dependency at
+    /// all — `kpipe-metrics` is interfaces plus a no-op default — so a caller wanting
+    /// OpenTelemetry supplies both the API and an SDK: use
+    /// `io.github.eschizoid.kpipe.metrics.otel.OtelProducerMetrics` from `kpipe-metrics-otel`,
+    /// or [ProducerMetrics#noop()] for the no-op default.
     ///
     /// @param metrics the producer metrics
     /// @return this builder instance for method chaining

--- a/lib/kpipe-producer/src/main/java/io/github/eschizoid/kpipe/producer/KPipeProducer.java
+++ b/lib/kpipe-producer/src/main/java/io/github/eschizoid/kpipe/producer/KPipeProducer.java
@@ -98,8 +98,9 @@ public class KPipeProducer<K, V> implements AutoCloseable {
       return this;
     }
 
-    /// Sets the [ProducerMetrics] for this producer. The SPI is vendor-neutral (§10 "bring your own
-    /// SDK"): use `io.github.eschizoid.kpipe.metrics.otel.OtelProducerMetrics` from
+    /// Sets the [ProducerMetrics] for this producer. The SPI is vendor-neutral — it builds against
+    /// the OpenTelemetry API with no SDK, so callers supply their own: use
+    /// `io.github.eschizoid.kpipe.metrics.otel.OtelProducerMetrics` from
     /// `kpipe-metrics-otel` for an OpenTelemetry-backed instance, or [ProducerMetrics#noop()] for a
     /// no-op default.
     ///

--- a/lib/kpipe-producer/src/main/java/io/github/eschizoid/kpipe/producer/sink/KafkaMessageSink.java
+++ b/lib/kpipe-producer/src/main/java/io/github/eschizoid/kpipe/producer/sink/KafkaMessageSink.java
@@ -76,9 +76,8 @@ public class KafkaMessageSink<T> implements MessageSink<T> {
         LOGGER.log(Level.WARNING, () -> "Failed to send record to topic " + topic, exception);
       }
       // Count after logging, and guard the user-supplied metrics impl the same way the tracer
-      // is
-      // guarded above: a throwing ProducerMetrics must never crash the producer callback thread
-      // or swallow the failure log.
+      // is guarded above: a throwing ProducerMetrics must never crash the producer callback
+      // thread or swallow the failure log.
       try {
         if (exception == null) metrics.recordMessageSent();
         else metrics.recordMessageFailed();

--- a/lib/kpipe-producer/src/main/java/io/github/eschizoid/kpipe/producer/sink/KafkaMessageSink.java
+++ b/lib/kpipe-producer/src/main/java/io/github/eschizoid/kpipe/producer/sink/KafkaMessageSink.java
@@ -75,10 +75,10 @@ public class KafkaMessageSink<T> implements MessageSink<T> {
       if (exception != null) {
         LOGGER.log(Level.WARNING, () -> "Failed to send record to topic " + topic, exception);
       }
-      // Count after logging, and guard the user-supplied metrics impl the same way tracer is
+      // Count after logging, and guard the user-supplied metrics impl the same way the tracer
+      // is
       // guarded above: a throwing ProducerMetrics must never crash the producer callback thread
-      // or
-      // swallow the failure log (§11 error-handler safety).
+      // or swallow the failure log.
       try {
         if (exception == null) metrics.recordMessageSent();
         else metrics.recordMessageFailed();


### PR DESCRIPTION
Follow-up to #318, which moved the architecture notes to `AGENTS.md` but left two loose ends.

## The pointer never shipped

`.gitignore` excluded the whole `.claude/` directory, so the `@AGENTS.md` pointer existed only on one machine. A fresh clone got `AGENTS.md` and nothing directing an agent to it.

The ignore is now `.claude/*` with an exception for `CLAUDE.md`. It has to be written that way — git does not descend into an excluded directory, so an un-ignore rule for a file inside one never matches. Verified both directions: `PLAN.md` and `bench/` are still ignored, `CLAUDE.md` is not.

## Five stale section references

`§N` citations pointed into numbering with gaps at §1, §2, §4 and §6 where sections had been deleted. Each comment states a property that reads better without the pointer, so the reference is gone and the property stays. The two `W3C §3.2` references cite an external spec and are untouched.

## One of them was also wrong

`ParallelDispatcherTest.onCompleteFiresExactlyOnceWhenTaskThrows` justified itself with:

> If it fired ZERO times, the consumer would never wake and the pipeline would stall on the first exception.

That stopped being true with #233. `afterRecordComplete`'s own javadoc says the unpark is "a best-effort latency nudge, not a liveness requirement: the paused loop no longer parks indefinitely (it keeps polling paused partitions on a `pollTimeout` cadence and re-evaluates backpressure at the top of every iteration), so the unpark only shortens the bounded `parkNanos` waits on the teardown drain path".

So a missed `onComplete` costs at most one poll interval of resume delay. The test is still worth keeping, and the honest reason is better than the old one: both failure shapes — missed call and doubled call — are invisible in observable behaviour and surface only as timing, which is exactly why an assertion has to hold the contract.

## Verification

`ParallelDispatcherTest` 10/10, `KPipeProducerTest` 24/24, `KafkaMessageSinkTest` 8/8, plus the rest of `kpipe-producer`, all green. Comment-only changes to the Java files; no behaviour touched.

## Noticed, not fixed here

`./gradlew spotlessApply` reformats **15 markdown files that are already on `main`**, including `README.md`, `docs/VERSIONING.md` and the ADR. CI runs `spotlessApply` rather than `spotlessCheck`, so it rewrites them in the workspace and never fails — the drift is invisible and permanent, and it lands in the diff of whoever next runs spotless locally. I reverted that churn out of this PR. Switching CI to `spotlessCheck` would surface it, but it needs one formatting commit first and belongs on its own.
