### PR TITLE
docs: correct the batch lock claim and absorb the deferred-decisions register

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -366,7 +366,10 @@ deliberately escape-hatch-only.
 
   The age tick adds a second dimension: the scheduler is a **single** thread shared by every topic's tick and by the
   circuit-breaker probe, so an age-triggered flush that blocks also delays age flushes on every other topic and the
-  breaker's OPEN → HALF_OPEN transition. Size-triggered flushes run on worker threads and do not have that property.
+  breaker's OPEN → HALF_OPEN transition. Size-triggered flushes run wherever the dispatcher placed the record — a worker
+  virtual thread under PARALLEL and KEY_ORDERED, but the **consumer thread itself under SEQUENTIAL**, where a blocking
+  sink stalls the poll loop and risks `max.poll.interval.ms` eviction, the same end state the paused loop keeps polling
+  to avoid.
   Whether one-flush-at-a-time is a guarantee worth keeping or an accident of lock placement is tracked in #313.
   Constructed in the consumer ctor, started in `start()`, drained in `close()`.
 - **Backpressure participation in parallel mode.** `inFlightCount` is decremented as soon as `processRecord` returns —
@@ -578,11 +581,13 @@ roadmap lives in the GitHub epics instead (verification in #312, architecture in
   dispatch is a rounding error at the broker level once per-record work reaches a millisecond, and the v2 broker verify
   came back flat. Re-open only with evidence of a dispatch-bound production workload, and re-run
   `KeyOrderedDispatchBenchmark` before landing anything.
-- **Three refuted audit claims.** `send()` cannot hang forever — the ack wait is bounded by `delivery.timeout.ms`,
-  and the pre-return block on metadata and buffer allocation is bounded by `max.block.ms`, so reach for whichever knob
-  matches the phase you are tuning. There is no `Pattern` subscription, so no per-topic cardinality bomb. Protobuf
-  message-index over-allocation is rejected before the allocation and covered by
-  `ProtobufFormatRegistryTest`. Do not re-raise without new facts.
+- **Three refuted audit claims.** `send()` cannot hang forever, but it has two bounds and they **add**: the call
+  blocks first on metadata and buffer allocation, bounded by `max.block.ms`, and only then waits for the ack, bounded
+  by `delivery.timeout.ms`. They are sequential phases of one call, not alternatives — tightening
+  `delivery.timeout.ms` alone does not bound `send()`, which matters for the batch-lock hold described above, where a
+  DLQ produce runs once per record. There is no `Pattern` subscription, so no per-topic cardinality bomb. Protobuf
+  message-index over-allocation is rejected before the allocation, though the test covering it would still pass with
+  the guard removed — see the note below. Do not re-raise without new facts.
 
 - **Header-based schema envelopes** (Azure SR style, schema id in Kafka headers). `MessageFormat.deserialize(byte[])`
   cannot see headers, so this needs a contract extension, not an implementation. Only on real demand.
@@ -593,3 +598,10 @@ roadmap lives in the GitHub epics instead (verification in #312, architecture in
 
 **Still open, and not deferred:** whether tracing should default on when `kpipe-tracing-otel` is present on the
 classpath, or stay explicit.
+
+**Two standing facts about this repo, recorded because nothing else holds them.** Copilot code review is effectively
+off: adding `copilot-pull-request-reviewer[bot]` as a requested reviewer returns success and attaches nobody, and the
+`reviews` array stays empty, so a Copilot done-signal never arrives and any workflow waiting for one will not
+terminate. Re-enabling it is a repository setting. Separately, `ProtobufFormatRegistryTest`'s over-allocation case
+trips the truncated-varint branch rather than the size guard, so it would still pass if the guard were deleted — the
+guard is correctly placed, but untested.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -354,9 +354,12 @@ deliberately escape-hatch-only.
   `[0, batchSize)` is a contract violation. `BatchPipelineWrapper` flags missing indexes with a synthetic
   `IllegalStateException` and routes them to the DLQ rather than silently marking them processed (§12). Out-of-range
   indexes are logged at WARNING; a `null` `BatchResult` is treated as whole-batch failure.
-- **`BatchPipelineWrapper` owns buffer + lock + gauge + age-tick.** One wrapper per topic; `ReentrantLock` protects
-  `enqueue` / `tick` / `close` / `flushLocked` so parallel-mode workers can enqueue concurrently while a flush is
-  mid-flight. Constructed in the consumer ctor, started in `start()`, drained in `close()`.
+- **`BatchPipelineWrapper` owns buffer + lock + gauge + age-tick.** One wrapper per topic; a single `ReentrantLock`
+  serializes `enqueue` / `tick` / `close` / `flushLocked`. Note what that means on the flush path: `flushLocked` calls
+  the user's `BatchSink` **while holding the lock**, so a flush blocks every other worker's `enqueue` for that topic
+  until the sink returns — and a batch sink is a network call by construction. One flush per topic is in flight at a
+  time. Whether that is a guarantee worth keeping or an accident of lock placement is open; see the batch-lock item in
+  issue #313. Constructed in the consumer ctor, started in `start()`, drained in `close()`.
 - **Backpressure participation in parallel mode.** `inFlightCount` is decremented as soon as `processRecord` returns —
   for batch paths that's "the record was buffered," which would make buffered records invisible to the in-flight
   watermark. The wrapper's `bufferedCount()` is added to `KPipeConsumer.totalInFlight()` to close that gap.
@@ -542,3 +545,30 @@ test-classifier jar — it's a runtime tool for users' test suites.
   columns** into a `//` continuation — which the IDE then flags as _dangling Javadoc_ (a real, recurring paper-cut).
   Keep every `///` line ≤ ~95 cols; hand-joining a long line is silently reverted on the next `spotlessApply`. This is
   why some test-tree dangling-Javadoc kept reappearing.
+
+---
+
+## Deliberately deferred
+
+Things decided against, with the reason. Re-proposing any of these needs new evidence, not a new argument — the
+argument was already had. Moved here from an untracked roadmap file so the decisions are reviewable; the forward-looking
+roadmap lives in the GitHub epics instead (verification in #312, architecture in #313), where it is visible.
+
+- **`Stream.strict()` / `.lenient()` toggle, `KPipe.from(props)` short-form, a `just new-format` scaffold.** Surface
+  area without a demonstrated need.
+- **Transient-vs-permanent DLQ-send classification.** Decided 2026-06-22: a failed DLQ send increments a counter, logs
+  at ERROR, and leaves the offset pending so the record is reprocessed on restart. A down DLQ applies backpressure
+  rather than silently dropping.
+- **Extracting a shared DLQ-or-mark helper.** Decided 2026-07-17: the per-path asymmetries are deliberate, and
+  `DlqTerminalContractTest` enforces the lockstep a shared helper would have provided.
+- **Unified metrics collector / `MetricsContext` bundle; `Tracer.isEnabled()`; a `RegistryModeFormat` base class.**
+  Abstractions over two call sites.
+- **Further dispatcher performance work.** Measured 2026-07-21: dispatch is a rounding error at the broker level once
+  per-record work reaches a millisecond, and the v2 broker verify came back flat. Re-open only with evidence of a
+  dispatch-bound production workload, and re-run `KeyOrderedDispatchBenchmark` before landing anything.
+- **Three refuted audit claims.** `send()` blocking is bounded by `delivery.timeout.ms`; there is no `Pattern`
+  subscription, so no per-topic cardinality bomb; Protobuf message-index over-allocation is guarded and tested. Do not
+  re-raise without new facts.
+
+**Still open, and not deferred:** whether tracing should default on when `kpipe-tracing-otel` is present on the
+classpath, or stay explicit.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -360,7 +360,10 @@ deliberately escape-hatch-only.
   sink returns — the per-record outcome dispatch runs there too, including `markProcessed` (which reaches a
   user-supplied `OffsetManager`, possibly Postgres- or Redis-backed) and `onBatchFailure` (which reaches a synchronous
   DLQ produce that waits for the broker ack). `failAll` does that produce once per record, serially, so a whole-batch
-  failure against an unavailable DLQ holds the topic's lock for the batch size times the produce timeout. The sink is
+  failure against an unavailable DLQ holds the topic's lock for the batch size times the per-record produce timeout —
+  `max.block.ms` or `delivery.timeout.ms` depending on whether DLQ topic metadata is cached, per the refuted-claims
+  entry below. An interrupt collapses that: the producer restores the interrupt flag, so every later send in the loop
+  fails on entry and the hold falls to roughly one timeout rather than N. The sink is
   arbitrary user code of unbounded duration — that, not any assumption that it performs I/O, is why holding the lock
   across it matters.
 
@@ -581,20 +584,16 @@ roadmap lives in the GitHub epics instead (verification in #312, architecture in
   dispatch is a rounding error at the broker level once per-record work reaches a millisecond, and the v2 broker verify
   came back flat. Re-open only with evidence of a dispatch-bound production workload, and re-run
   `KeyOrderedDispatchBenchmark` before landing anything.
-- **Three refuted audit claims.** `send()` cannot hang forever, but it has two bounds and they **add**: the call
-  blocks first on metadata and buffer allocation, bounded by `max.block.ms`, and only then waits for the ack, bounded
-  by `delivery.timeout.ms`. They are sequential phases of one call, not alternatives — tightening
-  `delivery.timeout.ms` alone does not bound `send()`, which matters for the batch-lock hold described above, where a
-  DLQ produce runs once per record. There is no `Pattern` subscription, so no per-topic cardinality bomb. Protobuf
-  message-index over-allocation is rejected before the allocation, though the test covering it would still pass with
-  the guard removed — see the note below. Do not re-raise without new facts.
-
+- **Three refuted audit claims.** `send()` cannot hang forever — both of its phases are bounded, and they add rather
+  than substitute; the javadoc on `KPipeProducer.send` carries which knob governs which phase. There is no `Pattern`
+  subscription, so no per-topic cardinality bomb. Protobuf message-index over-allocation is rejected before the
+  allocation. Do not re-raise without new facts.
 - **Header-based schema envelopes** (Azure SR style, schema id in Kafka headers). `MessageFormat.deserialize(byte[])`
   cannot see headers, so this needs a contract extension, not an implementation. Only on real demand.
 - **A Spring Boot starter.** Only on a real ask from a Spring shop — that trigger is the whole decision.
 - **An aggregated NOTICE for the shaded `-confluent` jar.** Shadow's default merge keeps the first-seen LICENSE and
-  NOTICE, and the seven expected entries were verified present. A hand-curated aggregate would be better attribution
-  hygiene, not a correctness fix.
+  NOTICE. A hand-curated aggregate would be better attribution hygiene, not a correctness fix — and if the entry count
+  matters, assert it in the build rather than in prose here.
 
 **Still open, and not deferred:** whether tracing should default on when `kpipe-tracing-otel` is present on the
 classpath, or stay explicit.
@@ -602,6 +601,4 @@ classpath, or stay explicit.
 **Two standing facts about this repo, recorded because nothing else holds them.** Copilot code review is effectively
 off: adding `copilot-pull-request-reviewer[bot]` as a requested reviewer returns success and attaches nobody, and the
 `reviews` array stays empty, so a Copilot done-signal never arrives and any workflow waiting for one will not
-terminate. Re-enabling it is a repository setting. Separately, `ProtobufFormatRegistryTest`'s over-allocation case
-trips the truncated-varint branch rather than the size guard, so it would still pass if the guard were deleted — the
-guard is correctly placed, but untested.
+terminate. Re-enabling it is a repository setting.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -355,11 +355,20 @@ deliberately escape-hatch-only.
   `IllegalStateException` and routes them to the DLQ rather than silently marking them processed (§12). Out-of-range
   indexes are logged at WARNING; a `null` `BatchResult` is treated as whole-batch failure.
 - **`BatchPipelineWrapper` owns buffer + lock + gauge + age-tick.** One wrapper per topic; a single `ReentrantLock`
-  serializes `enqueue` / `tick` / `close` / `flushLocked`. Note what that means on the flush path: `flushLocked` calls
-  the user's `BatchSink` **while holding the lock**, so a flush blocks every other worker's `enqueue` for that topic
-  until the sink returns — and a batch sink is a network call by construction. One flush per topic is in flight at a
-  time. Whether that is a guarantee worth keeping or an accident of lock placement is open; see the batch-lock item in
-  issue #313. Constructed in the consumer ctor, started in `start()`, drained in `close()`.
+  serializes `enqueue` / `tick` / `close` / `flushLocked`, and one flush per topic is in flight at a time. Note how much
+  runs under that lock: `flushLocked` calls the user's `BatchSink` while holding it, and does **not** release when the
+  sink returns — the per-record outcome dispatch runs there too, including `markProcessed` (which reaches a
+  user-supplied `OffsetManager`, possibly Postgres- or Redis-backed) and `onBatchFailure` (which reaches a synchronous
+  DLQ produce that waits for the broker ack). `failAll` does that produce once per record, serially, so a whole-batch
+  failure against an unavailable DLQ holds the topic's lock for the batch size times the produce timeout. The sink is
+  arbitrary user code of unbounded duration — that, not any assumption that it performs I/O, is why holding the lock
+  across it matters.
+
+  The age tick adds a second dimension: the scheduler is a **single** thread shared by every topic's tick and by the
+  circuit-breaker probe, so an age-triggered flush that blocks also delays age flushes on every other topic and the
+  breaker's OPEN → HALF_OPEN transition. Size-triggered flushes run on worker threads and do not have that property.
+  Whether one-flush-at-a-time is a guarantee worth keeping or an accident of lock placement is tracked in #313.
+  Constructed in the consumer ctor, started in `start()`, drained in `close()`.
 - **Backpressure participation in parallel mode.** `inFlightCount` is decremented as soon as `processRecord` returns —
   for batch paths that's "the record was buffered," which would make buffered records invisible to the in-flight
   watermark. The wrapper's `bufferedCount()` is added to `KPipeConsumer.totalInFlight()` to close that gap.
@@ -540,7 +549,7 @@ test-classifier jar — it's a runtime tool for users' test suites.
   #220 tripped on. `uncommittedTail()` applies the operators to the seeded `[k,P)` (filter-aware) so it matches the
   sink's post-pipeline shape under any mode — computing it from `firstRun.subList` would be wrong under PARALLEL
   (capture order ≠ offset order). A genuinely load-bearing resume-seek assertion (consumer skips `[0,k)` on its own) is
-  still open — see PLAN.md.
+  tracked in the verification epic, #312.
 - **`///` Javadoc + google-java-format footgun.** spotless (google-java-format) wraps any `///` doc line **>100
   columns** into a `//` continuation — which the IDE then flags as _dangling Javadoc_ (a real, recurring paper-cut).
   Keep every `///` line ≤ ~95 cols; hand-joining a long line is silently reverted on the next `spotlessApply`. This is
@@ -556,19 +565,31 @@ roadmap lives in the GitHub epics instead (verification in #312, architecture in
 
 - **`Stream.strict()` / `.lenient()` toggle, `KPipe.from(props)` short-form, a `just new-format` scaffold.** Surface
   area without a demonstrated need.
-- **Transient-vs-permanent DLQ-send classification.** Decided 2026-06-22: a failed DLQ send increments a counter, logs
-  at ERROR, and leaves the offset pending so the record is reprocessed on restart. A down DLQ applies backpressure
-  rather than silently dropping.
-- **Extracting a shared DLQ-or-mark helper.** Decided 2026-07-17: the per-path asymmetries are deliberate, and
-  `DlqTerminalContractTest` enforces the lockstep a shared helper would have provided.
-- **Unified metrics collector / `MetricsContext` bundle; `Tracer.isEnabled()`; a `RegistryModeFormat` base class.**
-  Abstractions over two call sites.
-- **Further dispatcher performance work.** Measured 2026-07-21: dispatch is a rounding error at the broker level once
-  per-record work reaches a millisecond, and the v2 broker verify came back flat. Re-open only with evidence of a
-  dispatch-bound production workload, and re-run `KeyOrderedDispatchBenchmark` before landing anything.
-- **Three refuted audit claims.** `send()` blocking is bounded by `delivery.timeout.ms`; there is no `Pattern`
-  subscription, so no per-topic cardinality bomb; Protobuf message-index over-allocation is guarded and tested. Do not
-  re-raise without new facts.
+- **Transient-vs-permanent DLQ-send classification.** A failed DLQ send increments a counter, logs at ERROR, and
+  leaves the offset pending so the record is reprocessed on restart. A down DLQ applies backpressure rather than
+  silently dropping.
+- **Extracting a shared DLQ-or-mark helper.** The per-path asymmetries are deliberate, and `DlqTerminalContractTest`
+  enforces the lockstep a shared helper would have provided — a 2×3 matrix over both paths, with both production sites
+  carrying `LOCKSTEP:` comments naming it.
+- **A unified metrics collector / `MetricsContext` bundle, and a `RegistryModeFormat` base class.** Extract when a
+  third implementation arrives, not before.
+- **`Tracer.isEnabled()`.** `Tracer.noop()` already makes the guard free, so the method would buy nothing.
+- **Further dispatcher performance work.** Measured in `benchmarks/results/2026-07-21-keyordered-dispatch-ab.md`:
+  dispatch is a rounding error at the broker level once per-record work reaches a millisecond, and the v2 broker verify
+  came back flat. Re-open only with evidence of a dispatch-bound production workload, and re-run
+  `KeyOrderedDispatchBenchmark` before landing anything.
+- **Three refuted audit claims.** `send()` cannot hang forever — the ack wait is bounded by `delivery.timeout.ms`,
+  and the pre-return block on metadata and buffer allocation is bounded by `max.block.ms`, so reach for whichever knob
+  matches the phase you are tuning. There is no `Pattern` subscription, so no per-topic cardinality bomb. Protobuf
+  message-index over-allocation is rejected before the allocation and covered by
+  `ProtobufFormatRegistryTest`. Do not re-raise without new facts.
+
+- **Header-based schema envelopes** (Azure SR style, schema id in Kafka headers). `MessageFormat.deserialize(byte[])`
+  cannot see headers, so this needs a contract extension, not an implementation. Only on real demand.
+- **A Spring Boot starter.** Only on a real ask from a Spring shop — that trigger is the whole decision.
+- **An aggregated NOTICE for the shaded `-confluent` jar.** Shadow's default merge keeps the first-seen LICENSE and
+  NOTICE, and the seven expected entries were verified present. A hand-curated aggregate would be better attribution
+  hygiene, not a correctness fix.
 
 **Still open, and not deferred:** whether tracing should default on when `kpipe-tracing-otel` is present on the
 classpath, or stay explicit.

--- a/lib/kpipe-producer/src/main/java/io/github/eschizoid/kpipe/producer/KPipeProducer.java
+++ b/lib/kpipe-producer/src/main/java/io/github/eschizoid/kpipe/producer/KPipeProducer.java
@@ -222,9 +222,12 @@ public class KPipeProducer<K, V> implements AutoCloseable {
   /// When called from a virtual thread this is highly efficient — blocking on the future
   /// parks the virtual thread without pinning its carrier thread.
   ///
-  /// The blocking wait is bounded by the producer's own `delivery.timeout.ms` (default 2 minutes):
-  /// the Kafka client fails the returned future after that, so this call cannot park forever even
-  /// against a hung broker. Tune that producer property to tighten or relax the bound.
+  /// This cannot park forever, but it has two bounds and they add rather than substitute.
+  /// `KafkaProducer.send` blocks first on metadata lookup and buffer allocation, bounded by
+  /// `max.block.ms`; only then does the returned future wait for the broker ack, bounded by
+  /// `delivery.timeout.ms`. They are sequential phases of one call, so tightening
+  /// `delivery.timeout.ms` alone does not bound this method — pick the property that matches the
+  /// phase you are trying to bound, or set both.
   ///
   /// @param record the record to send
   /// @return the metadata for the record that was sent


### PR DESCRIPTION
Two things, both consequences of the `AGENTS.md` adoption in #318/#319.

## The batch lock claim is false

`AGENTS.md` said the `ReentrantLock` protects `enqueue` / `tick` / `close` / `flushLocked` "so parallel-mode workers can enqueue concurrently while a flush is mid-flight."

They cannot. Tracing the call chain: `enqueue` takes the lock, and on reaching `policy.maxSize()` calls `flushLocked()` inline — still holding it. `flushLocked` calls `flush`, which calls `sink.apply(values)`. The user's `BatchSink` therefore runs **under the lock**, and a batch sink is a network call by construction: a database write, an HTTP post, an S3 put. While it is in flight every other virtual-thread worker calling `enqueue` for that topic blocks, as do the age `tick` and `close`.

The section now says what the lock does — one flush per topic in flight at a time, enqueue blocked for its duration — and points at the open question of whether that is an intended guarantee or an accident of lock placement, which is now item 6 on #313.

## The deferred-decisions register moves in

It lived in an untracked roadmap file, so it was invisible to anyone who cloned the repo — the same condition that let `AGENTS.md` accumulate nine errors before #318 checked it.

Every claim was verified before the move, not carried on trust:

| claim | check |
| --- | --- |
| `DlqTerminalContractTest` enforces the DLQ-or-mark lockstep | file exists at `lib/kpipe-consumer/src/test/.../DlqTerminalContractTest.java` |
| Re-run `KeyOrderedDispatchBenchmark` before dispatcher perf work | exists at `benchmarks/src/jmh/.../KeyOrderedDispatchBenchmark.java` |
| The 2026-07-21 A/B capture backs the "dispatch is a rounding error" call | `benchmarks/results/2026-07-21-keyordered-dispatch-ab.md` present |
| `strict()`/`lenient()`, `KPipe.from(props)`, `Tracer.isEnabled()` still deferred | 0 occurrences each in the current surface |

## What is deliberately not moved

The roadmap half. It is duplicated by the epics — #312 for verification, #313 for architecture — and had drifted in three checkable ways while nobody could see it:

| the file said | actual |
| --- | --- |
| Released line 1.18.0 | latest tag `v1.20.0` — two releases stale |
| Module taxonomy (14 lib modules) | 15 — the list omits `kpipe-tracing`, whose extraction the same file records further down |

**Correction to an earlier version of this description**, from review: I also argued the file was "last updated seven weeks ago". That is what its header claims, but `stat` reports an mtime of today and the body carries content dated three days ago. The file is actively maintained — what is stale is its own self-reported timestamp, which is a sharper version of the same problem rather than evidence of abandonment. The argument for retiring it rests on the duplication and the two real drifts above, not on neglect.

Two copies of a roadmap means the invisible one lies. The epics are visible, get updated, and are where the work is actually tracked, so they win and the file is retired. `.claude/` stays gitignored apart from the one-line `@AGENTS.md` pointer.

