### PR TITLE
docs: say what the batch tick rethrow actually trades

### DIFF
--- a/lib/kpipe-consumer/src/main/java/io/github/eschizoid/kpipe/consumer/BatchPipelineWrapper.java
+++ b/lib/kpipe-consumer/src/main/java/io/github/eschizoid/kpipe/consumer/BatchPipelineWrapper.java
@@ -128,18 +128,25 @@ final class BatchPipelineWrapper<T> implements AutoCloseable {
       final var ageNanos = System.nanoTime() - oldestEnqueueNanos;
       if (ageNanos >= policy.maxAge().toNanos()) flushLocked();
     } catch (final Throwable t) {
-      // Only an Error reaches here. Every RuntimeException path through flushLocked is already
+      // In practice only an Error reaches here. The RuntimeException paths through flushLocked are
       // closed: the sink call and both callback loops catch Exception, a null BatchResult is
-      // handled explicitly, BatchResult's canonical constructor rejects null collections and
-      // null elements while still inside the user's sink call, and BatchPolicy validates maxAge
-      // at construction so the age comparison above cannot throw.
+      // handled explicitly, and BatchResult's canonical constructor rejects null collections and
+      // null elements while still inside the user's sink call. "In practice" because System.Logger
+      // is pluggable through the LoggerFinder SPI, so a throwing implementation would arrive here
+      // from the log calls themselves — not defensible, and not worth defending against.
       //
-      // The log is what an operator sees. The rethrow is a separate decision:
-      // scheduleWithFixedDelay
-      // cancels a task that throws, so this permanently stops the age trigger for this topic —
-      // records then flush only on the size threshold and on shutdown drain. That is the intended
-      // trade. The JVM has thrown an Error, and continuing to schedule flushes on it is worse than
-      // letting a low-volume topic miss its age deadline.
+      // The age comparison above is a subtler case. BatchPolicy does not bound maxAge, and
+      // Duration.toNanos() overflows past roughly 292 years, so a large enough policy would throw
+      // ArithmeticException on that line. What prevents it is that start() derives the tick period
+      // from the same maxAge via toMillis(), which overflows three orders of magnitude later: any
+      // value big enough to break toNanos() schedules the first tick centuries out, so this code
+      // never runs. That coupling is load-bearing — a fixed tick period would open the path.
+      //
+      // The log is what an operator sees. The rethrow is a separate decision: a periodic task that
+      // throws is cancelled and never rescheduled, so this permanently stops the age trigger for
+      // this topic, and records then flush only on the size threshold and on shutdown drain. That
+      // is the intended trade: the JVM has thrown an Error, and continuing to schedule flushes on
+      // it is worse than letting a low-volume topic miss its age deadline.
       LOGGER.log(Level.ERROR, "Batch tick failed for topic {0}: {1}", topic, t.getMessage(), t);
       throw t;
     } finally {

--- a/lib/kpipe-consumer/src/main/java/io/github/eschizoid/kpipe/consumer/BatchPipelineWrapper.java
+++ b/lib/kpipe-consumer/src/main/java/io/github/eschizoid/kpipe/consumer/BatchPipelineWrapper.java
@@ -128,8 +128,18 @@ final class BatchPipelineWrapper<T> implements AutoCloseable {
       final var ageNanos = System.nanoTime() - oldestEnqueueNanos;
       if (ageNanos >= policy.maxAge().toNanos()) flushLocked();
     } catch (final Throwable t) {
-      // Scheduler swallows uncaught exceptions and silently cancels the task — log and rethrow
-      // so an operator sees the failure if a flush ever throws non-Exception.
+      // Only an Error reaches here. Every RuntimeException path through flushLocked is already
+      // closed: the sink call and both callback loops catch Exception, a null BatchResult is
+      // handled explicitly, BatchResult's canonical constructor rejects null collections and
+      // null elements while still inside the user's sink call, and BatchPolicy validates maxAge
+      // at construction so the age comparison above cannot throw.
+      //
+      // The log is what an operator sees. The rethrow is a separate decision:
+      // scheduleWithFixedDelay
+      // cancels a task that throws, so this permanently stops the age trigger for this topic —
+      // records then flush only on the size threshold and on shutdown drain. That is the intended
+      // trade. The JVM has thrown an Error, and continuing to schedule flushes on it is worse than
+      // letting a low-volume topic miss its age deadline.
       LOGGER.log(Level.ERROR, "Batch tick failed for topic {0}: {1}", topic, t.getMessage(), t);
       throw t;
     } finally {
@@ -246,7 +256,10 @@ final class BatchPipelineWrapper<T> implements AutoCloseable {
         if (callbackEx instanceof InterruptedException) Thread.currentThread().interrupt();
         LOGGER.log(
           Level.ERROR,
-          "Batch outcome callback threw for offset " + record.offset() + " on topic " + topic +
+          "Batch outcome callback threw for offset " +
+            record.offset() +
+            " on topic " +
+            topic +
             "; continuing with the remaining records (offset stays unmarked, record will be reprocessed)",
           callbackEx
         );
@@ -262,7 +275,10 @@ final class BatchPipelineWrapper<T> implements AutoCloseable {
         if (callbackEx instanceof InterruptedException) Thread.currentThread().interrupt();
         LOGGER.log(
           Level.ERROR,
-          "Batch failure callback threw for offset " + entry.record().offset() + " on topic " + topic +
+          "Batch failure callback threw for offset " +
+            entry.record().offset() +
+            " on topic " +
+            topic +
             "; continuing with the remaining records",
           callbackEx
         );


### PR DESCRIPTION
Answers item 7 on #313: *"Determine whether a RuntimeException can reach `tick`, or only an Error; make the comment match the answer."*

## The answer: only an Error

Every `RuntimeException` path into `tick` is closed, and I traced each one rather than reasoning from the shape:

| path | why it cannot reach `tick` |
| --- | --- |
| `sink.apply(values)` throws | caught in `flush`, routed to `failAll` |
| sink returns `null` | handled explicitly, whole-batch failure |
| `BatchResult` with null collections | canonical constructor null-checks both — and it runs **inside the user's `sink.apply`**, so its own NPE is caught by the handler above |
| `BatchResult` with a null element or key | `List.copyOf` / `Map.copyOf` reject them, same place, same catch |
| `markProcessed` / `onBatchFailure` throw | per-iteration `catch (Exception)` in both the success loop and `failAll` |
| `policy.maxAge().toNanos()` | `BatchPolicy`'s canonical constructor requires non-null and strictly positive |
| `succeeded.set(i)` | guarded by an explicit `i >= 0 && i < size` bounds check |

So the handler only ever fires on an `Error`.

## Which makes the current behaviour right, and the comment wrong about why

The comment said the rethrow is "so an operator sees the failure". It is not — the `LOGGER.log` line directly above it does that, and would do it with or without the rethrow.

What the rethrow actually does is stop the schedule. `ScheduledExecutorService` cancels a periodic task that throws and never runs it again, so this **permanently disables the age trigger for that topic**. Records still flush on the size threshold and on shutdown drain, so nothing is lost — but a low-volume topic silently stops flushing on time, with one ERROR line as the only trace.

That trade is defensible once you know only an `Error` gets here: the JVM has thrown `OutOfMemoryError` or `StackOverflowError`, and continuing to schedule flush work on it is worse than a missed age deadline. It was not defensible as written, because the comment implied the rethrow was for visibility and said nothing about the age trigger dying.

The comment now carries both halves — what the log is for, what the rethrow costs, and why the cost is accepted.

## Verification

No behaviour touched; 23 batch tests green with `--rerun-tasks`, `spotlessJavaCheck` clean.

## Why `codecov/patch` is red, and why it is not a defect

The diff is not purely comments, and not by choice. Spotless is configured with `ratchetFrom("origin/main")` (`build.gradle.kts:115`), so it skips files unchanged against main — which is why `main` reports clean — and formats the **whole file** as soon as anything in it changes. Touching a comment therefore drags in every pre-existing formatting violation elsewhere in that file.

Here that is eight lines: two `LOGGER.log` string concatenations in `flush`'s per-record `catch` and in `failAll`'s `catch`, rewrapped across four lines each. I tried reverting them to main's formatting to keep the diff honest-to-its-title; `spotlessJavaCheck` then fails, so the rewrap is mandatory once the file is touched at all.

Those eight lines sit in callback-threw error paths that no test exercises, so codecov reports `0.00% of diff hit`. They were uncovered before this PR and are equally uncovered after — the ratchet just moved them into the diff. `codecov/patch` is not a required check on this repository (there is no branch protection configured).

The underlying issue — CI runs `spotlessApply` rather than `spotlessCheck`, so this churn is absorbed silently and reaches whoever next edits the file — is the same root cause as the fifteen markdown files noted in #321, and belongs in its own change.

