### PR TITLE
test: make the protobuf index-size guard test actually cover the guard

### DIFF
--- a/lib/kpipe-format-protobuf/src/test/java/io/github/eschizoid/kpipe/format/protobuf/ProtobufFormatRegistryTest.java
+++ b/lib/kpipe-format-protobuf/src/test/java/io/github/eschizoid/kpipe/format/protobuf/ProtobufFormatRegistryTest.java
@@ -239,12 +239,40 @@ class ProtobufFormatRegistryTest {
   }
 
   @Test
-  void skipBytesLikeDoubleStripIsNotOurConcernButBadIndexSizeThrows() {
-    // A malformed (huge) message-index size must fail loudly, not silently mis-slice the payload.
+  void indexSizeExceedingTheEnvelopeIsRejectedBeforeAllocating() {
+    // The size guard runs before `new int[size]`, so a corrupt varint cannot turn into a huge
+    // allocation. Both cases below assert the guard's own message rather than just the exception
+    // type: without that, deleting the guard still throws IllegalStateException from the truncated
+    // varint the loop would hit next, and the test passes while covering nothing.
     final var format = ProtobufFormat.withRegistry(new FakeResolver().put(1, "x"), new FakeCompiler());
-    // magic + id=1 + zig-zag size 0x04 (=2) but truncated before the two index elements.
+
+    // magic + id=1 + zig-zag size 0x04 (=2), with zero bytes left for the two index elements.
     final var truncated = new byte[] { 0x00, 0x00, 0x00, 0x00, 0x01, 0x04 };
-    assertThrows(IllegalStateException.class, () -> format.deserialize(truncated));
+    final var small = assertThrows(IllegalStateException.class, () -> format.deserialize(truncated));
+    assertTrue(
+      small.getMessage().contains("exceeds remaining"),
+      "must trip the size guard, not the truncated-varint branch; was: " + small.getMessage()
+    );
+
+    // magic + id=1 + a varint of 8<<28, which zig-zag decodes to 1,073,741,824. Unguarded that is
+    // a 4 GiB int[] request from ten bytes of input.
+    final var huge = new byte[] {
+      0x00,
+      0x00,
+      0x00,
+      0x00,
+      0x01,
+      (byte) 0x80,
+      (byte) 0x80,
+      (byte) 0x80,
+      (byte) 0x80,
+      0x08,
+    };
+    final var big = assertThrows(IllegalStateException.class, () -> format.deserialize(huge));
+    assertTrue(
+      big.getMessage().contains("exceeds remaining"),
+      "a billion-element index must be rejected by the guard; was: " + big.getMessage()
+    );
   }
 
   @Test


### PR DESCRIPTION
Found while reviewing #321, which cited this test as evidence that Protobuf message-index over-allocation is "guarded and tested." The guard is real and correctly placed. The test was not covering it.

## The problem

`ProtobufFormat.readMessageIndex` rejects a size larger than the remaining envelope bytes **before** `new int[size]`. The test asserted only the exception type:

```java
assertThrows(IllegalStateException.class, () -> format.deserialize(truncated));
```

Both branches throw `IllegalStateException` — the size guard, and the truncated-varint error the read loop hits on its very next statement. The assertion cannot distinguish them, so deleting the guard leaves the test green.

The test's own comment said it covered "a malformed (huge) message-index size", but its input encodes size 2.

## The change

Both cases now assert the guard's own message, and a second case is added that cannot pass without the guard: a five-byte varint of `8<<28` zig-zag decodes to **1,073,741,824**, so ten bytes of input would request a 4 GiB `int[]`.

Asserting the message rather than relying on the allocation to blow up is deliberate — a machine with enough heap would satisfy the request and then throw the truncated-varint error, passing for the wrong reason. That ambiguity is what this PR removes; reintroducing it via OOM would be the same bug.

## Verified by mutation

| state | result |
| --- | --- |
| size guard deleted | **1 failure** — `indexSizeExceedingTheEnvelopeIsRejectedBeforeAllocating` |
| guard restored | 16 / 16 green |
