### PR TITLE
docs: the containment rule was backwards, and the gate's advice is the weapon

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -561,25 +561,26 @@ test-classifier jar — it's a runtime tool for users' test suites.
   google-java-format about lambda parameters, writing `(order) ->` where the Java formatter writes `order ->`, which
   silently rewrote the README quickstart out of step with the compiled `ReadmeQuickstart.java` that
   `scripts/check-docs.sh` compares line by line.
-- **The prose formatter swallows text between underscores, and one `spotlessApply` does it.** The mechanism is a single
-  rule: a `_` opens if it is not followed by whitespace, the next `_` that is followed by a non-word character closes,
-  and everything between is eaten. `KEY_ORDERED and *behind*` becomes `KEY*ORDERED and \_behind*` — rendering as
-  `KEYORDERED _behind` — because pass one rewrites `*behind*` to `_behind_` and its closing underscore then pairs with
-  the identifier's. A word-final underscore does the same job with no emphasis anywhere: `A_B and C_D_` becomes
-  `A*B and C_D*`. Note who the victim is — `A_B` has no trailing underscore and is destroyed from four words away, and
-  an ordinary English word with a stray underscore (`and_`) is a perfectly good closer. `a_b_c` is safe because no `_`
-  in it is followed by a non-word character. Spotless iterates to a fixed point inside one invocation, so this lands in
-  a single apply and is stable after — **do not check by applying twice and diffing**, the second apply is a no-op and
-  reports clean on the file the first one destroyed.
-- **Enclose the identifier; what follows it is irrelevant.** The scan runs from the opening `_` to the end of the
-  **innermost** thing enclosing it, so a container that merely opens later is no help — `KEY_ORDERED and **a *b* c**`
-  corrupts and takes the bold with it, as does `KEY_ORDERED and [*behind*](url)`. Wrapping the identifier is what
-  protects: `` `KEY_ORDERED` ``, `**KEY_ORDERED**`, `*KEY_ORDERED*` and `[KEY_ORDERED](url)` all survive anything after
-  them. Scope is the **block**, not the line — a bare identifier reaches a closer across a soft wrap — and one shielded
-  identifier does not protect a second bare one later in the same block. `<!-- prettier-ignore -->` and code blocks
-  (fenced or indented) are equally absolute and work where backticks cannot, such as a table row, but each covers
-  exactly one block (`-start` / `-end` for a run), does nothing written as a list item, and freezes that block's
-  wrapping and alignment too.
+- **The prose formatter swallows text between underscores, and one `spotlessApply` does it.** One bounded rule covers
+  every case: the scan runs from an opening `_` to the end of the **innermost** thing enclosing it — code span,
+  emphasis, link text, table cell, list item, otherwise the block — and within that range the first `_` that is followed
+  by a non-word character, **or that ends the block**, closes it. Everything between is eaten. So
+  `KEY_ORDERED and *behind*` becomes `KEY*ORDERED and \_behind*`, rendering as `KEYORDERED _behind`, because pass one
+  rewrites `*behind*` to `_behind_` and supplies the closer. A word-final underscore does the same job with no emphasis
+  present: `A_B and C_D_` becomes `A*B and C_D*` — note that the victim is `A_B`, several words earlier, carrying no
+  trailing underscore of its own, and that an ordinary English word (`and_`) is a perfectly good closer. `a_b_c` is safe
+  because no `_` in it qualifies. Two traps in reading the rule: **assume any `_` can open** — a space after it is no
+  defence, `A_ B_` still corrupts — and "non-word" means ASCII, so a digit does not close (`max_keys_1` is safe) while
+  an accented letter or an em dash does, which matters in a file this full of `—`.
+- **The bound is the shield: enclose the identifier and nothing after it can reach.** `` `KEY_ORDERED` ``,
+  `**KEY_ORDERED**`, `*KEY_ORDERED*` and `[KEY_ORDERED](url)` all survive anything that follows, because the scan stops
+  at the enclosure's end. A container that merely opens _later_ is no help — `KEY_ORDERED and **a *b* c**` corrupts and
+  takes the bold with it, as does `KEY_ORDERED and [*behind*](url)`. Enclosing bounds one scan only: in
+  `**KEY_ORDERED** and max_keys_` the shielded identifier is fine and the bare one still corrupts. With no enclosure the
+  bound is the **block**, not the line, so a bare identifier reaches a closer across a soft wrap.
+  `<!-- prettier-ignore -->` and code blocks (fenced or indented) are equally absolute and work where backticks cannot,
+  such as a table row — but each covers exactly one block (`-start` / `-end` for a run), does nothing written as a list
+  item, and freezes that block's wrapping and alignment too.
 - **`spotlessCheck` catches this, and its own advice is the weapon.** The gate passes only when `apply(f) == f`, so a
   hazardous file fails it — which is why CI runs `spotlessCheck` rather than `spotlessApply`. The failure ends with
   `Run './gradlew spotlessApply' to fix all violations`, and following that is what destroys the file. **Never apply to

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -561,26 +561,30 @@ test-classifier jar — it's a runtime tool for users' test suites.
   google-java-format about lambda parameters, writing `(order) ->` where the Java formatter writes `order ->`, which
   silently rewrote the README quickstart out of step with the compiled `ReadmeQuickstart.java` that
   `scripts/check-docs.sh` compares line by line.
-- **The prose formatter silently corrupts one pattern, and a single `spotlessApply` is enough to do it.** Where a bare
-  underscore-bearing word and a later single-delimiter emphasis span sit in the same inline container,
-  `KEY_ORDERED *behind*` becomes `KEY*ORDERED \_behind*`, which renders as `KEYORDERED _behind` — the identifier loses a
-  character and the emphasis moves. Spotless iterates the formatter to a fixed point inside one invocation, so this
-  lands in a single `./gradlew spotlessApply` and is stable afterwards. **Do not check for it by applying twice and
-  diffing** — the second apply is always a no-op, so that reports clean on a file the first one just destroyed.
-- **`spotlessCheck` is the defense, which is why CI runs it rather than `spotlessApply`.** The gate passes only when
-  `apply(f) == f`, and any file carrying the hazard is not at its fixed point, so the gate fails it and prints the
-  corrupting hunk. What it cannot see is text that arrives **already** corrupted from outside it — which is how these
-  notes rotted: they lived untracked in `.claude/`, spotless rewrote them on disk across many local runs, and #318
-  copied the result into a tracked file. Under the old `spotlessApply` step CI silently converted such files and
-  discarded the evidence, leaving the damage in the repo.
-- **Backtick identifiers in prose — it is the only unconditional shield.** A code span is never parsed for emphasis, so
-  `` `KEY_ORDERED` `` is inert anywhere. Nothing else is reliable: a backslash escape is stripped in the same run, so
-  `KEY\_ORDERED *behind*` ends up exactly as corrupted as the unescaped form. Nesting is not protection either — what
-  matters is whether the underscore and the emphasis span share an inline container. `**KEY_ORDERED** and *behind*` is
-  safe because they do not; `**KEY_ORDERED *behind* together**` and `[KEY_ORDERED *behind*](url)` both corrupt because
-  they do, and that first shape is exactly what the original benchmark line looked like. A strong target is harmless —
-  `KEY_ORDERED and **bold**` needs a single-delimiter span to fire — and a `__dunder__` in prose is a separate same-run
-  effect that turns it bold.
+- **The prose formatter silently corrupts underscore-bearing identifiers, and one `spotlessApply` does it.** Two
+  triggers, both verified against this repo's build. First, a bare identifier followed later by a single-delimiter
+  emphasis span: `KEY_ORDERED and *behind*` becomes `KEY*ORDERED and \_behind*`, rendering as `KEYORDERED _behind` — the
+  identifier loses a character and the emphasis moves. Second, and needing no emphasis at all, a **trailing** underscore
+  before a non-word character: `Set max_keys_ to 10` becomes `Set max*keys* to 10`, which renders the middle word in
+  italics. Spotless iterates to a fixed point inside one invocation, so both land in a single `./gradlew spotlessApply`
+  and are stable after. **Do not check by applying twice and diffing** — the second apply is a no-op, so it reports
+  clean on a file the first one just destroyed.
+- **Enclose the identifier; what follows it does not matter.** The corrupting scan starts at the identifier's underscore
+  and runs to the end of whatever **encloses** it, so a container that merely opens later is no help:
+  `KEY_ORDERED and **a *b* c**` corrupts and takes the bold with it, as does `KEY_ORDERED and [*behind*](url)`. Wrapping
+  the identifier is what protects — `` `KEY_ORDERED` ``, `**KEY_ORDERED**`, `*KEY_ORDERED*` and `[KEY_ORDERED](url)` all
+  survive whatever follows them. A code span is the strongest shield because its contents are never parsed at all;
+  `<!-- prettier-ignore -->` above a block and fenced code blocks are equally absolute. Order matters too:
+  `*behind* and KEY_ORDERED` is safe, since nothing follows the identifier. A backslash escape is not a remedy — it is
+  stripped in the same run and ends up exactly as corrupted.
+- **`spotlessCheck` catches this, and its own advice is the weapon.** The gate passes only when `apply(f) == f`, so a
+  hazardous file fails it and the failure prints the corrupting hunk — which is why CI runs `spotlessCheck` rather than
+  `spotlessApply`. But the failure ends with `Run './gradlew spotlessApply' to fix all violations`, and following that
+  instruction is what destroys the file. **When a violation shows an identifier changing shape, backtick it and re-run
+  the check — never apply.** The gate is blind only to text that arrives already corrupted from outside it, which is how
+  these notes rotted: they lived untracked in `.claude/`, spotless rewrote them across many local runs, and #318 copied
+  the result into a tracked file. Unrelated: `__dunder__` in prose becomes `**dunder**`, which renders identically — GFM
+  already bolds both — but the source loses the underscores.
 - **`///` Javadoc + google-java-format footgun.** spotless (google-java-format) wraps any `///` doc line **>100
   columns** into a `//` continuation — which the IDE then flags as _dangling Javadoc_ (a real, recurring paper-cut).
   Keep every `///` line ≤ ~95 cols; hand-joining a long line is silently reverted on the next `spotlessApply`. This is

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -561,30 +561,36 @@ test-classifier jar — it's a runtime tool for users' test suites.
   google-java-format about lambda parameters, writing `(order) ->` where the Java formatter writes `order ->`, which
   silently rewrote the README quickstart out of step with the compiled `ReadmeQuickstart.java` that
   `scripts/check-docs.sh` compares line by line.
-- **The prose formatter silently corrupts underscore-bearing identifiers, and one `spotlessApply` does it.** Two
-  triggers, both verified against this repo's build. First, a bare identifier followed later by a single-delimiter
-  emphasis span: `KEY_ORDERED and *behind*` becomes `KEY*ORDERED and \_behind*`, rendering as `KEYORDERED _behind` — the
-  identifier loses a character and the emphasis moves. Second, and needing no emphasis at all, a **trailing** underscore
-  before a non-word character: `Set max_keys_ to 10` becomes `Set max*keys* to 10`, which renders the middle word in
-  italics. Spotless iterates to a fixed point inside one invocation, so both land in a single `./gradlew spotlessApply`
-  and are stable after. **Do not check by applying twice and diffing** — the second apply is a no-op, so it reports
-  clean on a file the first one just destroyed.
-- **Enclose the identifier; what follows it does not matter.** The corrupting scan starts at the identifier's underscore
-  and runs to the end of whatever **encloses** it, so a container that merely opens later is no help:
-  `KEY_ORDERED and **a *b* c**` corrupts and takes the bold with it, as does `KEY_ORDERED and [*behind*](url)`. Wrapping
-  the identifier is what protects — `` `KEY_ORDERED` ``, `**KEY_ORDERED**`, `*KEY_ORDERED*` and `[KEY_ORDERED](url)` all
-  survive whatever follows them. A code span is the strongest shield because its contents are never parsed at all;
-  `<!-- prettier-ignore -->` above a block and fenced code blocks are equally absolute. Order matters too:
-  `*behind* and KEY_ORDERED` is safe, since nothing follows the identifier. A backslash escape is not a remedy — it is
-  stripped in the same run and ends up exactly as corrupted.
+- **The prose formatter swallows text between underscores, and one `spotlessApply` does it.** The mechanism is a single
+  rule: a `_` opens if it is not followed by whitespace, the next `_` that is followed by a non-word character closes,
+  and everything between is eaten. `KEY_ORDERED and *behind*` becomes `KEY*ORDERED and \_behind*` — rendering as
+  `KEYORDERED _behind` — because pass one rewrites `*behind*` to `_behind_` and its closing underscore then pairs with
+  the identifier's. A word-final underscore does the same job with no emphasis anywhere: `A_B and C_D_` becomes
+  `A*B and C_D*`. Note who the victim is — `A_B` has no trailing underscore and is destroyed from four words away, and
+  an ordinary English word with a stray underscore (`and_`) is a perfectly good closer. `a_b_c` is safe because no `_`
+  in it is followed by a non-word character. Spotless iterates to a fixed point inside one invocation, so this lands in
+  a single apply and is stable after — **do not check by applying twice and diffing**, the second apply is a no-op and
+  reports clean on the file the first one destroyed.
+- **Enclose the identifier; what follows it is irrelevant.** The scan runs from the opening `_` to the end of the
+  **innermost** thing enclosing it, so a container that merely opens later is no help — `KEY_ORDERED and **a *b* c**`
+  corrupts and takes the bold with it, as does `KEY_ORDERED and [*behind*](url)`. Wrapping the identifier is what
+  protects: `` `KEY_ORDERED` ``, `**KEY_ORDERED**`, `*KEY_ORDERED*` and `[KEY_ORDERED](url)` all survive anything after
+  them. Scope is the **block**, not the line — a bare identifier reaches a closer across a soft wrap — and one shielded
+  identifier does not protect a second bare one later in the same block. `<!-- prettier-ignore -->` and code blocks
+  (fenced or indented) are equally absolute and work where backticks cannot, such as a table row, but each covers
+  exactly one block (`-start` / `-end` for a run), does nothing written as a list item, and freezes that block's
+  wrapping and alignment too.
 - **`spotlessCheck` catches this, and its own advice is the weapon.** The gate passes only when `apply(f) == f`, so a
-  hazardous file fails it and the failure prints the corrupting hunk — which is why CI runs `spotlessCheck` rather than
-  `spotlessApply`. But the failure ends with `Run './gradlew spotlessApply' to fix all violations`, and following that
-  instruction is what destroys the file. **When a violation shows an identifier changing shape, backtick it and re-run
-  the check — never apply.** The gate is blind only to text that arrives already corrupted from outside it, which is how
-  these notes rotted: they lived untracked in `.claude/`, spotless rewrote them across many local runs, and #318 copied
-  the result into a tracked file. Unrelated: `__dunder__` in prose becomes `**dunder**`, which renders identically — GFM
-  already bolds both — but the source loses the underscores.
+  hazardous file fails it — which is why CI runs `spotlessCheck` rather than `spotlessApply`. The failure ends with
+  `Run './gradlew spotlessApply' to fix all violations`, and following that is what destroys the file. **Never apply to
+  clear this class; backtick the identifier and re-run the check.** Do not rely on spotting the damage in the printed
+  hunk either: spotless caps its diff output at fifty lines with a non-tunable constant, so one verbose violation
+  elsewhere reduces later hazardous files to a bare filename with no hunk at all, a re-wrapped line buries the change
+  among reflowed text, and harmless violations look identical. If an apply has already happened, find it in the result
+  instead — `grep -nE '\\_|[A-Za-z0-9]\*[A-Za-z0-9]'` over the tracked `.md` files. The gate is blind only to text
+  arriving already corrupted from outside it, which is how these notes rotted: untracked in `.claude/`, rewritten across
+  many local runs, then copied into a tracked file by #318. Unrelated: `__dunder__` becomes `**dunder**`, which renders
+  identically since GFM bolds both, but the source loses its underscores.
 - **`///` Javadoc + google-java-format footgun.** spotless (google-java-format) wraps any `///` doc line **>100
   columns** into a `//` continuation — which the IDE then flags as _dangling Javadoc_ (a real, recurring paper-cut).
   Keep every `///` line ≤ ~95 cols; hand-joining a long line is silently reverted on the next `spotlessApply`. This is

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -562,9 +562,10 @@ test-classifier jar — it's a runtime tool for users' test suites.
   silently rewrote the README quickstart out of step with the compiled `ReadmeQuickstart.java` that
   `scripts/check-docs.sh` compares line by line.
 - **The prose formatter swallows text between underscores, and one `spotlessApply` does it.** One bounded rule covers
-  every case: the scan runs from an opening `_` to the end of the **innermost** thing enclosing it — code span,
-  emphasis, link text, table cell, list item, otherwise the block — and within that range the first `_` that is followed
-  by a non-word character, **or that ends the block**, closes it. Everything between is eaten. So
+  every case: the scan runs from an opening `_` to the end of the **innermost** thing enclosing it — emphasis, link
+  text, table cell, list item, otherwise the block — and within that range the first `_` that is followed by a non-word
+  character, **or that ends the block**, closes it. Everything between is eaten. A code span is the exception rather
+  than another bound: its contents are never parsed at all, so nothing inside one ever fires. So
   `KEY_ORDERED and *behind*` becomes `KEY*ORDERED and \_behind*`, rendering as `KEYORDERED _behind`, because pass one
   rewrites `*behind*` to `_behind_` and supplies the closer. A word-final underscore does the same job with no emphasis
   present: `A_B and C_D_` becomes `A*B and C_D*` — note that the victim is `A_B`, several words earlier, carrying no
@@ -574,13 +575,14 @@ test-classifier jar — it's a runtime tool for users' test suites.
   an accented letter or an em dash does, which matters in a file this full of `—`.
 - **The bound is the shield: enclose the identifier and nothing after it can reach.** `` `KEY_ORDERED` ``,
   `**KEY_ORDERED**`, `*KEY_ORDERED*` and `[KEY_ORDERED](url)` all survive anything that follows, because the scan stops
-  at the enclosure's end. A container that merely opens _later_ is no help — `KEY_ORDERED and **a *b* c**` corrupts and
-  takes the bold with it, as does `KEY_ORDERED and [*behind*](url)`. Enclosing bounds one scan only: in
-  `**KEY_ORDERED** and max_keys_` the shielded identifier is fine and the bare one still corrupts. With no enclosure the
-  bound is the **block**, not the line, so a bare identifier reaches a closer across a soft wrap.
-  `<!-- prettier-ignore -->` and code blocks (fenced or indented) are equally absolute and work where backticks cannot,
-  such as a table row — but each covers exactly one block (`-start` / `-end` for a run), does nothing written as a list
-  item, and freezes that block's wrapping and alignment too.
+  at the enclosure's end — and a code span is stronger still, since nothing inside one is parsed either. A container
+  that merely opens _later_ is no help — `KEY_ORDERED and **a *b* c**` corrupts and takes the bold with it, as does
+  `KEY_ORDERED and [*behind*](url)`. Enclosing bounds one scan only: in `**KEY_ORDERED** and max_keys_` the shielded
+  identifier is fine and the bare one still corrupts. With no enclosure the bound is the **block**, not the line, so a
+  bare identifier reaches a closer across a soft wrap. `<!-- prettier-ignore -->` and code blocks (fenced or indented)
+  are equally absolute and work where backticks cannot, such as a table row — but each covers exactly one block
+  (`-start` / `-end` for a run), does nothing written as a list item, and freezes that block's wrapping and alignment
+  too.
 - **`spotlessCheck` catches this, and its own advice is the weapon.** The gate passes only when `apply(f) == f`, so a
   hazardous file fails it — which is why CI runs `spotlessCheck` rather than `spotlessApply`. The failure ends with
   `Run './gradlew spotlessApply' to fix all violations`, and following that is what destroys the file. **Never apply to


### PR DESCRIPTION
Fourth pass on one `AGENTS.md` bullet. #324 introduced it, #325 corrected its central claim, #326 fixed a unit error, and an independent reviewer — briefed to derive the formatter's behaviour from scratch rather than check my text — found three more.

## The containment rule was backwards

I wrote that the hazard fires when the underscore and the emphasis span share an inline container, implying a later container protects. Measured, nine probes, one `spotlessApply`:

| probe | after one apply | |
| --- | --- | --- |
| `KEY_ORDERED and **a *b* c**` | `KEY*ORDERED and \*\*a \_b* c\*\*` | **corrupts — and destroys the bold** |
| `KEY_ORDERED and [*behind*](url)` | `KEY*ORDERED and [\_behind*](url)` | **corrupts** |
| `**KEY_ORDERED** and *behind*` | unchanged | safe |
| `*KEY_ORDERED* and **a *b* c**` | unchanged | safe |
| `[KEY_ORDERED](url) and *behind*` | unchanged | safe |
| `*behind* and KEY_ORDERED` | unchanged | safe — nothing follows |

The first two are shapes the old text called safe, and `**a *b* c**` is an ordinary sentence. The rule that matches every observation: **the scan runs from the identifier's underscore to the end of whatever encloses it**; a container that merely opens later is no help. Enclosing the *identifier* is what protects.

## A second trigger, with no emphasis at all

```
Set max_keys_ to 10.   ->   Set max*keys* to 10.
```

A trailing underscore before a non-word character corrupts on its own, rendering the middle word in italics. The documented trigger required a later emphasis span, so anyone auditing for it would have missed this entirely.

## The finding that matters most, which no round had

The gate fails a hazardous file and prints the corrupting hunk — then ends with:

```
Run './gradlew spotlessApply' to fix all violations.
```

**Following that instruction is what destroys the file.** The entry called `spotlessCheck` the defense without ever saying its own remediation advice is the weapon. It now says: when a violation shows an identifier changing shape, backtick it and re-run the check — never apply.

## Smaller corrections

- A code span is not the *only* unconditional shield; `<!-- prettier-ignore -->` and fenced blocks are too.
- "A strong target is harmless" holds only when the strong contains no single-delimiter emphasis — `**bold**` is safe, `**a *b* c**` is not.
- The `__dunder__` case is renormalization, not a rendering change: GFM already bolds `__x__`, so `__init__` → `**init**` renders identically and only the source loses its underscores.

## Verification

Every claim is from the nine-probe run above, in this repo's own build. The entry is a fixed point across two applies — it quotes the hazard repeatedly, so that was not free — and `spotlessCheck` and `check-docs` both exit 0.
